### PR TITLE
Feature/add link to sidebar title

### DIFF
--- a/packages/layout/src/components/sidebar/sidebar.tsx
+++ b/packages/layout/src/components/sidebar/sidebar.tsx
@@ -143,7 +143,17 @@ export const Sidebar: React.FC<SidebarProps> = ({
 				cfg={{ flexDirection: 'column', mt: 4 }}
 				className={styles.sidebarMenu}
 			>
-				<H3 cfg={{ fontWeight: 3, color: 'primary.2' }}>{title}</H3>
+				<Link
+					cfg={{
+						fontWeight: 3,
+						color: 'primary.2',
+						textAlign: 'left',
+						fontSize: 4,
+					}}
+					onClick={() => history.push(titlePath)}
+				>
+					{title}
+				</Link>
 				<Flex cfg={{ justifyContent: 'space-between', mt: 4, mb: 2 }}>
 					<P>Section</P>
 					<P>

--- a/packages/layout/src/components/sidebar/sidebar.tsx
+++ b/packages/layout/src/components/sidebar/sidebar.tsx
@@ -113,6 +113,7 @@ export function useCalculateProgress(sections: SidebarSectionProps[]) {
 
 export type SidebarProps = {
 	title: string;
+	titlePath?: string;
 	maintenanceMode?: boolean;
 	sections: SidebarSectionProps[];
 	/** import from react-router-dom */
@@ -125,6 +126,7 @@ export type SidebarProps = {
 
 export const Sidebar: React.FC<SidebarProps> = ({
 	title,
+	titlePath,
 	sections: originalSections,
 	maintenanceMode = false,
 	matchPath,


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [X] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Added a `Link` component to the sidebar nav title. This is so the title can be used to navigate the user to the welcome page. The link can be configured using the `titlePath` prop.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
