### PR TITLE
adding after property to FFInputNumber

### DIFF
--- a/packages/forms/src/elements/input/input.module.scss
+++ b/packages/forms/src/elements/input/input.module.scss
@@ -39,3 +39,8 @@ input::-webkit-inner-spin-button {
 input[type='number'] {
 	-moz-appearance: textfield;
 }
+
+.after {
+	line-height: 50px;
+	margin-left: 1rem;
+}

--- a/packages/forms/src/elements/input/input.tsx
+++ b/packages/forms/src/elements/input/input.tsx
@@ -8,6 +8,7 @@ export type InputProps = {
 	testId?: string;
 	label?: string;
 	touched?: boolean;
+	after?: any;
 	[key: string]: any;
 };
 export const Input: React.FC<InputProps> = ({
@@ -17,6 +18,7 @@ export const Input: React.FC<InputProps> = ({
 	label,
 	touched = false,
 	className,
+	after: After,
 	...rest
 }) => {
 	return (
@@ -34,6 +36,7 @@ export const Input: React.FC<InputProps> = ({
 				])}
 				{...rest}
 			/>
+			{After && <span className={styles.after}>{After}</span>}
 		</Flex>
 	);
 };

--- a/packages/forms/src/elements/number/number.mdx
+++ b/packages/forms/src/elements/number/number.mdx
@@ -58,6 +58,7 @@ import { FFInputNumber } from '@tpr/forms';
 					}}
 					inputWidth={5}
 					cfg={{ my: 5 }}
+					after="cm"
 				/>
 				<button type="submit" style={{ display: 'none' }} children="Submit" />
 			</form>

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -4,7 +4,10 @@ import { StyledInputLabel, InputElementHeading } from '../elements';
 import { FieldProps, FieldExtraProps } from '../../renderFields';
 import { Input } from '../input/input';
 
-type InputNumberProps = FieldRenderProps<number> & FieldExtraProps;
+interface InputNumberProps extends FieldRenderProps<number>, FieldExtraProps {
+	after?: any;
+}
+
 const InputNumber: React.FC<InputNumberProps> = ({
 	label,
 	hint,
@@ -15,6 +18,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 	placeholder,
 	inputWidth: width,
 	cfg,
+	after,
 	...props
 }) => {
 	return (
@@ -39,6 +43,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 				onChange={(evt: ChangeEvent<HTMLInputElement>) =>
 					input.onChange(evt.target.value && parseInt(evt.target.value, 10))
 				}
+				after={after}
 				{...props}
 			/>
 		</StyledInputLabel>


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Possible implementation of :after property for FFInputNumber

#### Reviewers should focus on:

The "after" property is optional, it won't cause any break if not especified.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
