### PR TITLE
Fix bug which prevents address fields displaying 

### DIFF
--- a/packages/layout/src/components/cards/common/views/address/Postcode.tsx
+++ b/packages/layout/src/components/cards/common/views/address/Postcode.tsx
@@ -50,8 +50,8 @@ const Postcode: React.FC<PostcodeProps> = ({
 									return {
 										value: addressToOurFormat,
 										label: Object.keys(addressToOurFormat)
-											.filter((key) => addressObject[key])
-											.map((key) => addressObject[key])
+											.filter((key) => addressToOurFormat[key])
+											.map((key) => addressToOurFormat[key])
 											.join(', '),
 									};
 								});


### PR DESCRIPTION
Fix bug which prevents address fields displaying unless the field name is the same before and after it's transformed to our format. Instead, concatenate fields from our format alone. 

#### Fixes one of the issues in #58909

#### Checklist

- [ ] Includes tests
- [ ] Update documentation


