### PR TITLE
Bug/bug 61589

### DIFF
--- a/packages/forms/src/elements/number/number.mdx
+++ b/packages/forms/src/elements/number/number.mdx
@@ -59,6 +59,7 @@ import { FFInputNumber } from '@tpr/forms';
 					inputWidth={5}
 					cfg={{ my: 5 }}
 					after="cm"
+					callback={() => console.log("callback function")}
 				/>
 				<button type="submit" style={{ display: 'none' }} children="Submit" />
 			</form>

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -6,6 +6,7 @@ import { Input } from '../input/input';
 
 interface InputNumberProps extends FieldRenderProps<number>, FieldExtraProps {
 	after?: any;
+	callback?: () => void;
 }
 
 const InputNumber: React.FC<InputNumberProps> = ({
@@ -19,6 +20,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 	inputWidth: width,
 	cfg,
 	after,
+	callback,
 	...props
 }) => {
 	return (
@@ -40,9 +42,11 @@ const InputNumber: React.FC<InputNumberProps> = ({
 				touched={meta && meta.touched && meta.error}
 				placeholder={placeholder}
 				{...input}
-				onChange={(evt: ChangeEvent<HTMLInputElement>) =>
-					input.onChange(evt.target.value && parseInt(evt.target.value, 10))
-				}
+				onKeyDown={(e) => e.key.toLowerCase() === 'e' && e.preventDefault()}
+				onChange={(evt: ChangeEvent<HTMLInputElement>) => {
+					input.onChange(evt.target.value && parseInt(evt.target.value, 10)),
+					callback();
+				}}
 				after={after}
 				{...props}
 			/>

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -44,8 +44,8 @@ const InputNumber: React.FC<InputNumberProps> = ({
 				{...input}
 				onKeyDown={(e) => e.key.toLowerCase() === 'e' && e.preventDefault()}
 				onChange={(evt: ChangeEvent<HTMLInputElement>) => {
-					input.onChange(evt.target.value && parseInt(evt.target.value, 10)),
-					callback();
+					input.onChange(evt.target.value && parseInt(evt.target.value, 10));
+					callback && callback();
 				}}
 				after={after}
 				{...props}


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

Added a callback function to FFInputNumber props, to be executed once onChange has completed, this way we avoid defining onChange for FFInputNumber which causes the inner Input onChange handler to break.

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
