### PR TITLE
Bug 58918

### DIFF
--- a/packages/core/src/components/globals/globals.module.scss
+++ b/packages/core/src/components/globals/globals.module.scss
@@ -678,6 +678,33 @@
 	line-height: $line-height-3 !important;
 }
 
+/* word breaks */
+
+.wordBreak-all {
+	word-break: break-all !important;
+}
+
+.wordBreak-word {
+	word-break: break-word !important;
+}
+
+.wordBreak-normal {
+	word-break: normal !important;
+}
+
+.wordBreak-keep {
+	word-break: keep-all !important;
+}
+
+.wordBreak-initial {
+	word-break: initial !important;
+}
+
+.wordBreak-inherit {
+	word-break: inherit !important;
+}
+
+
 /* BACKGROUND */
 
 /* background color */

--- a/packages/core/src/components/globals/globals.tsx
+++ b/packages/core/src/components/globals/globals.tsx
@@ -86,7 +86,7 @@ export type TypographyProps = Partial<{
 	textAlign: 'left' | 'center' | 'right';
 	fontWeight: 1 | 2 | 3;
 	lineHeight: 1 | 2 | 3;
-	wordBreak?: WordBreak;
+	wordBreak: WordBreak;
 }>;
 
 export type SpaceProps = Partial<{

--- a/packages/core/src/components/globals/globals.tsx
+++ b/packages/core/src/components/globals/globals.tsx
@@ -73,7 +73,13 @@ export type ColorProps = Partial<{
 	fill: ColorsFullRange;
 }>;
 
-export type WordBreak = 'all' | 'word' | 'normal' | 'keep' | 'initial' | 'inherit';
+export type WordBreak =
+	| 'all'
+	| 'word'
+	| 'normal'
+	| 'keep'
+	| 'initial'
+	| 'inherit';
 
 export type TypographyProps = Partial<{
 	fontSize: ValuesFullRange;

--- a/packages/core/src/components/globals/globals.tsx
+++ b/packages/core/src/components/globals/globals.tsx
@@ -73,11 +73,14 @@ export type ColorProps = Partial<{
 	fill: ColorsFullRange;
 }>;
 
+export type WordBreak = 'all' | 'word' | 'normal' | 'keep' | 'initial' | 'inherit';
+
 export type TypographyProps = Partial<{
 	fontSize: ValuesFullRange;
 	textAlign: 'left' | 'center' | 'right';
 	fontWeight: 1 | 2 | 3;
 	lineHeight: 1 | 2 | 3;
+	wordBreak?: WordBreak;
 }>;
 
 export type SpaceProps = Partial<{

--- a/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
@@ -54,7 +54,7 @@ export const Preview: React.FC<any> = () => {
 						{actuary.emailAddress && (
 							<>
 								<H4 cfg={{ lineHeight: 3 }}>Email</H4>
-								<P>{actuary.emailAddress}</P>
+								<P cfg={{ wordBreak: 'all' }}>{actuary.emailAddress}</P>
 							</>
 						)}
 					</Flex>

--- a/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
@@ -74,7 +74,7 @@ export const Preview: React.FC<any> = () => {
 						{corporateGroup.emailAddress && (
 							<>
 								<H4 cfg={{ lineHeight: 3 }}>Email</H4>
-								<P>{corporateGroup.emailAddress}</P>
+								<P cfg={{ wordBreak: 'all' }}>{corporateGroup.emailAddress}</P>
 							</>
 						)}
 					</Flex>

--- a/packages/layout/src/components/cards/inHouse/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/preview/preview.tsx
@@ -57,7 +57,7 @@ export const Preview: React.FC<any> = () => {
 						{inHouseAdmin.emailAddress && (
 							<>
 								<H4 cfg={{ lineHeight: 3 }}>Email</H4>
-								<P>{inHouseAdmin.emailAddress}</P>
+								<P cfg={{ wordBreak: 'all' }}>{inHouseAdmin.emailAddress}</P>
 							</>
 						)}
 					</Flex>

--- a/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
@@ -49,7 +49,7 @@ export const Preview: React.FC<any> = () => {
 						{insurer.emailAddress && (
 							<>
 								<H4 cfg={{ lineHeight: 3 }}>Email</H4>
-								<P>{insurer.emailAddress}</P>
+								<P cfg={{ wordBreak: 'all' }}>{insurer.emailAddress}</P>
 							</>
 						)}
 					</Flex>

--- a/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
@@ -48,7 +48,7 @@ export const Preview: React.FC = () => {
 						<H4 cfg={{ lineHeight: 3 }}>Phone</H4>
 						<P>{trustee.telephoneNumber}</P>
 						<H4 cfg={{ lineHeight: 3 }}>Email</H4>
-						<P>{trustee.emailAddress}</P>
+						<P cfg={{ wordBreak: 'all' }}>{trustee.emailAddress}</P>
 					</Flex>
 				</Flex>
 			</Flex>


### PR DESCRIPTION
…ards updated.

#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fixing bug 58918, about long email addresses not displaying well on cards

#### Reviewers should focus on:

Adding "wordBreak" as part of the TypographyProps inside the globals module. 
Now can be specified inside the "cfg" prop of every component that accepts TypographyProps.
Accepts the following values:
- 'all' (for break-all)
- 'word' (for break-word)
- 'keep' (for keep-all)
- 'initial'
- 'normal'
- 'inherit'

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
