### PR TITLE
Cards able to indicate "valid" status without having checkbox ticked

### DIFF
--- a/packages/layout/src/components/cards/actuary/actuary.mdx
+++ b/packages/layout/src/components/cards/actuary/actuary.mdx
@@ -57,6 +57,7 @@ import { ActuaryCard } from '@tpr/layout';
 				onRemove={callbackFn}
 				onCorrect={(value) => setComplete(value)}
 				complete={complete}
+				preValidatedData={true}
 				actuary={actuary}
 			/>
 		);

--- a/packages/layout/src/components/cards/actuary/actuary.tsx
+++ b/packages/layout/src/components/cards/actuary/actuary.tsx
@@ -99,7 +99,7 @@ export const ActuaryCard: React.FC<ActuaryProviderProps> = ({
 				return (
 					<Flex cfg={cfg} data-testid={testId} className={styles.card}>
 						<Toolbar
-							complete={context.complete}
+							complete={context.preValidatedData ? true : context.complete}
 							subtitle={() => (
 								<H4 cfg={{ lineHeight: 3 }}>
 									{[

--- a/packages/layout/src/components/cards/actuary/actuaryMachine.tsx
+++ b/packages/layout/src/components/cards/actuary/actuaryMachine.tsx
@@ -36,6 +36,7 @@ export interface ActuaryContext {
 	complete: boolean;
 	remove: { confirm: boolean; date: string } | null;
 	actuary: Partial<Actuary>;
+	preValidatedData?: boolean | null;
 }
 
 const actuaryMachine = Machine<ActuaryContext, ActuaryStates, ActuaryEvents>({

--- a/packages/layout/src/components/cards/actuary/context.tsx
+++ b/packages/layout/src/components/cards/actuary/context.tsx
@@ -49,6 +49,7 @@ export interface ActuaryProviderProps extends CardProviderProps {
 
 export const ActuaryProvider = ({
 	complete,
+	preValidatedData,
 	actuary,
 	children,
 	i18n: i18nOverrides = {},
@@ -59,6 +60,7 @@ export const ActuaryProvider = ({
 		context: {
 			complete,
 			actuary,
+			preValidatedData,
 		},
 	});
 

--- a/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
@@ -7,11 +7,15 @@ import styles from './preview.module.scss';
 
 export const Preview: React.FC<any> = () => {
 	const { current, send, onCorrect, i18n } = useActuaryContext();
-	const { actuary, complete } = current.context;
+	const { actuary, complete, preValidatedData } = current.context;
 
 	return (
 		<div
-			className={classNames([{ [styles.complete]: complete }, styles.content])}
+			className={
+				preValidatedData
+					? classNames([styles.content, styles.complete])
+					: classNames([{ [styles.complete]: complete }, styles.content])
+			}
 		>
 			{/* Actuary's Organisation name: display only	 */}
 			<P cfg={{ mb: 4 }}>{actuary.organisationName}</P>

--- a/packages/layout/src/components/cards/common/interfaces.ts
+++ b/packages/layout/src/components/cards/common/interfaces.ts
@@ -67,6 +67,7 @@ export type RecursivePartial<T> = {
 
 export interface CardProviderProps {
 	complete?: boolean;
+	preValidatedData?: boolean;
 	onCorrect?: (...args: any[]) => void;
 	onRemove?: (...args: any[]) => Promise<any>;
 	onSaveAddress?: (...args: any[]) => Promise<any>;

--- a/packages/layout/src/components/cards/common/views/nameForm/nameForm.tsx
+++ b/packages/layout/src/components/cards/common/views/nameForm/nameForm.tsx
@@ -7,7 +7,7 @@ import { cardType, cardTypeName } from '../../interfaces';
 
 interface NameFormProps {
 	type: cardType;
-	typeName: cardTypeName;
+	typeName: cardTypeName | string;
 	onSubmit: (any) => void;
 	fields: FieldProps[];
 	initialValues: {

--- a/packages/layout/src/components/cards/components/content.tsx
+++ b/packages/layout/src/components/cards/components/content.tsx
@@ -8,7 +8,7 @@ export const Loading = () => <div className={styles.loading} />;
 
 type ContentProps = {
 	type: cardType;
-	typeName?: cardTypeName;
+	typeName?: cardTypeName | string;
 	title?: string;
 	loading?: boolean;
 	breadcrumbs?: any;

--- a/packages/layout/src/components/cards/components/toolbar.tsx
+++ b/packages/layout/src/components/cards/components/toolbar.tsx
@@ -49,8 +49,6 @@ export const Toolbar: React.FC<ToolbarProps> = ({
 					pl: 4,
 				}}
 			>
-				{/* This code will be used in case that the showing the "Error" is not needed, replacing the code below */}
-				{/* {complete && <StatusMessage complete={complete} icon={CheckedCircle} />} */}
 				{complete ? (
 					<StatusMessage complete={complete} icon={CheckedCircle} />
 				) : (

--- a/packages/layout/src/components/cards/corporateGroup/context.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/context.tsx
@@ -54,6 +54,7 @@ export const CorporateGroupContext = createContext<CorporateGroupContextProps>({
 
 export const CorporateGroupProvider = ({
 	complete,
+	preValidatedData,
 	corporateGroup,
 	children,
 	i18n: i18nOverrides = {},
@@ -64,6 +65,7 @@ export const CorporateGroupProvider = ({
 		context: {
 			complete,
 			corporateGroup,
+			preValidatedData,
 		},
 	});
 

--- a/packages/layout/src/components/cards/corporateGroup/corporateGroup.mdx
+++ b/packages/layout/src/components/cards/corporateGroup/corporateGroup.mdx
@@ -61,6 +61,7 @@ import { CorporateGroupCard } from '@tpr/layout';
 				onCorrect={(value) => setComplete(value)}
 				complete={complete}
 				corporateGroup={corporateGroup}
+				preValidatedData={true}
 			/>
 		);
   }}

--- a/packages/layout/src/components/cards/corporateGroup/corporateGroup.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/corporateGroup.tsx
@@ -76,7 +76,7 @@ export const CorporateGroupCard: React.FC<CorporateGroupProviderProps> = ({
 				return (
 					<Flex cfg={cfg} data-testid={testId} className={styles.card}>
 						<Toolbar
-							complete={context.complete}
+							complete={context.preValidatedData ? true : context.complete}
 							subtitle={() => (
 								<>
 									<H4 cfg={{ lineHeight: 3 }}>

--- a/packages/layout/src/components/cards/corporateGroup/corporateGroupMachine.ts
+++ b/packages/layout/src/components/cards/corporateGroup/corporateGroupMachine.ts
@@ -38,6 +38,7 @@ export interface CorporateGroupContext {
 	complete: boolean;
 	remove?: RemoveReasonProps;
 	corporateGroup: Partial<CorporateGroup>;
+	preValidatedData?: boolean | null;
 }
 
 const corporateGroupMachine = Machine<

--- a/packages/layout/src/components/cards/corporateGroup/views/name/name.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/name/name.tsx
@@ -2,11 +2,7 @@ import React, { useState } from 'react';
 import { FieldProps } from '@tpr/forms';
 import { useCorporateGroupContext } from '../../context';
 import { CorporateGroupI18nProps } from '../../i18n';
-import {
-	RecursivePartial,
-	cardType,
-	cardTypeName,
-} from '../../../common/interfaces';
+import { RecursivePartial, cardType } from '../../../common/interfaces';
 import NameForm from '../../../common/views/nameForm/nameForm';
 
 const getFields = (
@@ -57,7 +53,7 @@ export const NameScreen: React.FC = () => {
 	return (
 		<NameForm
 			type={cardType.corporateGroup}
-			typeName={cardTypeName.corporateGroup}
+			typeName={'chair of the board'}
 			onSubmit={onSubmit}
 			fields={fields}
 			initialValues={{

--- a/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
@@ -7,11 +7,15 @@ import styles from './preview.module.scss';
 
 export const Preview: React.FC<any> = () => {
 	const { current, send, onCorrect, i18n } = useCorporateGroupContext();
-	const { corporateGroup, complete } = current.context;
+	const { corporateGroup, complete, preValidatedData } = current.context;
 
 	return (
 		<div
-			className={classNames([{ [styles.complete]: complete }, styles.content])}
+			className={
+				preValidatedData
+					? classNames([styles.content, styles.complete])
+					: classNames([{ [styles.complete]: complete }, styles.content])
+			}
 		>
 			<Flex>
 				{/* Address section: display only	 */}

--- a/packages/layout/src/components/cards/employer/context.tsx
+++ b/packages/layout/src/components/cards/employer/context.tsx
@@ -53,6 +53,7 @@ export interface Employer extends CardDefaultProps {
 
 export const EmployerProvider = ({
 	complete,
+	preValidatedData,
 	employer,
 	children,
 	i18n: i18nOverrides = {},
@@ -63,6 +64,7 @@ export const EmployerProvider = ({
 		context: {
 			complete,
 			employer,
+			preValidatedData,
 		},
 	});
 

--- a/packages/layout/src/components/cards/employer/employer.mdx
+++ b/packages/layout/src/components/cards/employer/employer.mdx
@@ -58,6 +58,7 @@ import { EmployerCard } from '@tpr/layout';
 				onCorrect={(value) => setComplete(value)}
 				complete={complete}
 				employer={employer}
+				preValidatedData={true}
 				i18n={{
 					preview: {
 						buttons: {

--- a/packages/layout/src/components/cards/employer/employer.tsx
+++ b/packages/layout/src/components/cards/employer/employer.tsx
@@ -98,7 +98,7 @@ export const EmployerCard: React.FC<EmployerProviderProps> = ({
 				return (
 					<Flex cfg={cfg} data-testid={testId} className={styles.card}>
 						<Toolbar
-							complete={context.complete}
+							complete={context.preValidatedData ? true : context.complete}
 							subtitle={() => <EmployerSubtitle {...context.employer} />}
 							buttonLeft={() => (
 								<ToolbarButton title={i18n.preview.buttons.one} />

--- a/packages/layout/src/components/cards/employer/employerMachine.ts
+++ b/packages/layout/src/components/cards/employer/employerMachine.ts
@@ -29,6 +29,7 @@ export interface EmployerContext {
 	complete: boolean;
 	remove: { confirm: boolean; date: string } | null;
 	employer: Partial<Employer>;
+	preValidatedData?: boolean | null;
 }
 
 const employerMachine = Machine<

--- a/packages/layout/src/components/cards/employer/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/employer/views/preview/preview.tsx
@@ -17,7 +17,7 @@ const IdentifiersItem: React.FC<IdentifiersItemProps> = ({ title, number }) => {
 
 export const Preview: React.FC<any> = () => {
 	const { current, send, onCorrect, i18n } = useEmployerContext();
-	const { employer, complete } = current.context;
+	const { employer, complete, preValidatedData } = current.context;
 	const [items] = useState(
 		[
 			{
@@ -37,7 +37,11 @@ export const Preview: React.FC<any> = () => {
 
 	return (
 		<div
-			className={classNames([{ [styles.complete]: complete }, styles.content])}
+			className={
+				preValidatedData
+					? classNames([styles.content, styles.complete])
+					: classNames([{ [styles.complete]: complete }, styles.content])
+			}
 		>
 			<Flex>
 				<Flex

--- a/packages/layout/src/components/cards/inHouse/context.tsx
+++ b/packages/layout/src/components/cards/inHouse/context.tsx
@@ -63,6 +63,7 @@ export interface InHouseAdminProviderProps extends CardProviderProps {
 
 export const InHouseAdminProvider = ({
 	complete,
+	preValidatedData,
 	inHouseAdmin,
 	children,
 	i18n: i18nOverrides = {},
@@ -73,6 +74,7 @@ export const InHouseAdminProvider = ({
 		context: {
 			complete,
 			inHouseAdmin,
+			preValidatedData,
 		},
 	});
 

--- a/packages/layout/src/components/cards/inHouse/inHouse.mdx
+++ b/packages/layout/src/components/cards/inHouse/inHouse.mdx
@@ -62,6 +62,7 @@ import { InHouseCard } from '@tpr/layout';
 					get: (endpont) => experianApiGet(endpont),
 					limit: 100,
 				}}
+				preValidatedData={true}
 			/>
 		);
 	}}

--- a/packages/layout/src/components/cards/inHouse/inHouse.tsx
+++ b/packages/layout/src/components/cards/inHouse/inHouse.tsx
@@ -103,7 +103,7 @@ export const InHouseCard: React.FC<InHouseAdminProviderProps> = ({
 				return (
 					<Flex cfg={cfg} data-testid={testId} className={styles.card}>
 						<Toolbar
-							complete={context.complete}
+							complete={context.preValidatedData ? true : context.complete}
 							subtitle={() => (
 								<H4 cfg={{ lineHeight: 3 }}>
 									{[

--- a/packages/layout/src/components/cards/inHouse/inHouseMachine.ts
+++ b/packages/layout/src/components/cards/inHouse/inHouseMachine.ts
@@ -38,6 +38,7 @@ export interface InHouseAdminContext {
 	complete: boolean;
 	remove: { confirm: boolean; date: string } | null;
 	inHouseAdmin: Partial<InHouseAdmin>;
+	preValidatedData?: boolean | null;
 }
 
 const inHouseAdminMachine = Machine<

--- a/packages/layout/src/components/cards/inHouse/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/preview/preview.tsx
@@ -7,11 +7,15 @@ import styles from './preview.module.scss';
 
 export const Preview: React.FC<any> = () => {
 	const { current, send, onCorrect, i18n } = useInHouseAdminContext();
-	const { inHouseAdmin, complete } = current.context;
+	const { inHouseAdmin, complete, preValidatedData } = current.context;
 
 	return (
 		<div
-			className={classNames([{ [styles.complete]: complete }, styles.content])}
+			className={
+				preValidatedData
+					? classNames([styles.content, styles.complete])
+					: classNames([{ [styles.complete]: complete }, styles.content])
+			}
 		>
 			<Flex>
 				{/* Addres section: open for editing	 */}

--- a/packages/layout/src/components/cards/independentTrustee/context.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/context.tsx
@@ -49,6 +49,7 @@ export const IndependentTrusteeContext = createContext<
 
 export const IndependentTrusteeProvider = ({
 	complete,
+	preValidatedData,
 	independentTrustee,
 	children,
 	i18n: i18nOverrides = {},
@@ -59,6 +60,7 @@ export const IndependentTrusteeProvider = ({
 		context: {
 			complete,
 			independentTrustee,
+			preValidatedData,
 		},
 	});
 

--- a/packages/layout/src/components/cards/independentTrustee/independentTrustee.mdx
+++ b/packages/layout/src/components/cards/independentTrustee/independentTrustee.mdx
@@ -54,6 +54,7 @@ import { IndependentTrusteeCard } from '@tpr/layout';
 				onCorrect={(value) => setComplete(value)}
 				complete={complete}
 				independentTrustee={independentTrustee}
+        preValidatedData={true}
 			/>
 		);
   }}

--- a/packages/layout/src/components/cards/independentTrustee/independentTrustee.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/independentTrustee.tsx
@@ -70,7 +70,7 @@ export const IndependentTrusteeCard: React.FC<IndependentTrusteeProviderProps> =
 				return (
 					<Flex cfg={cfg} data-testid={testId} className={styles.card}>
 						<Toolbar
-							complete={context.complete}
+							complete={context.preValidatedData ? true : context.complete}
 							subtitle={() => (
 								<>
 									<H4 cfg={{ lineHeight: 3 }}>

--- a/packages/layout/src/components/cards/independentTrustee/independentTrusteeMachine.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/independentTrusteeMachine.tsx
@@ -34,6 +34,7 @@ export interface IndependentTrusteeContext {
 	complete: boolean;
 	remove?: RemoveReasonProps;
 	independentTrustee: Partial<IndependentTrustee>;
+	preValidatedData?: boolean | null;
 }
 
 const independentTrusteeMachine = Machine<

--- a/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
@@ -7,11 +7,15 @@ import styles from './preview.module.scss';
 
 export const Preview: React.FC<any> = () => {
 	const { current, send, onCorrect, i18n } = useIndependentTrusteeContext();
-	const { independentTrustee, complete } = current.context;
+	const { independentTrustee, complete, preValidatedData } = current.context;
 
 	return (
 		<div
-			className={classNames([{ [styles.complete]: complete }, styles.content])}
+			className={
+				preValidatedData
+					? classNames([styles.content, styles.complete])
+					: classNames([{ [styles.complete]: complete }, styles.content])
+			}
 		>
 			<Flex>
 				{/* Address section: display only	 */}

--- a/packages/layout/src/components/cards/insurer/context.tsx
+++ b/packages/layout/src/components/cards/insurer/context.tsx
@@ -47,6 +47,7 @@ export interface InsurerProviderProps extends CardProviderProps {
 
 export const InsurerProvider = ({
 	complete,
+	preValidatedData,
 	insurer,
 	children,
 	i18n: i18nOverrides = {},
@@ -57,6 +58,7 @@ export const InsurerProvider = ({
 		context: {
 			complete,
 			insurer,
+			preValidatedData,
 		},
 	});
 

--- a/packages/layout/src/components/cards/insurer/insurer.mdx
+++ b/packages/layout/src/components/cards/insurer/insurer.mdx
@@ -56,6 +56,7 @@ import { InsurerCard } from '@tpr/layout';
 				onCorrect={(value) => setComplete(value)}
 				complete={complete}
 				insurer={insurer}
+				preValidatedData={true}
 			/>
 		);
 	}}

--- a/packages/layout/src/components/cards/insurer/insurer.tsx
+++ b/packages/layout/src/components/cards/insurer/insurer.tsx
@@ -64,7 +64,7 @@ export const InsurerCard: React.FC<InsurerProviderProps> = ({
 				return (
 					<Flex cfg={cfg} data-testid={testId} className={styles.card}>
 						<Toolbar
-							complete={context.complete}
+							complete={context.preValidatedData ? true : context.complete}
 							subtitle={() => <H4>{context.insurer.organisationName}</H4>}
 							buttonLeft={() => (
 								<UnderlinedButton>{i18n.preview.buttons.one}</UnderlinedButton>

--- a/packages/layout/src/components/cards/insurer/insurerMachine.ts
+++ b/packages/layout/src/components/cards/insurer/insurerMachine.ts
@@ -33,6 +33,7 @@ export interface InsurerContext {
 	complete: boolean;
 	remove: { confirm: boolean; date: string } | null;
 	insurer: Partial<Insurer>;
+	preValidatedData?: boolean | null;
 }
 
 const insurerMachine = Machine<InsurerContext, InsurerStates, InsurerEvents>({

--- a/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
@@ -7,11 +7,15 @@ import styles from './preview.module.scss';
 
 export const Preview: React.FC<any> = () => {
 	const { current, send, onCorrect, i18n } = useInsurerContext();
-	const { insurer, complete } = current.context;
+	const { insurer, complete, preValidatedData } = current.context;
 
 	return (
 		<div
-			className={classNames([{ [styles.complete]: complete }, styles.content])}
+			className={
+				preValidatedData
+					? classNames([styles.content, styles.complete])
+					: classNames([{ [styles.complete]: complete }, styles.content])
+			}
 		>
 			<Flex>
 				{/* Address block: display only	 */}

--- a/packages/layout/src/components/cards/thirdParty/context.tsx
+++ b/packages/layout/src/components/cards/thirdParty/context.tsx
@@ -44,6 +44,7 @@ export interface ThirdPartyProviderProps extends CardProviderProps {
 
 export const ThirdPartyProvider = ({
 	complete,
+	preValidatedData,
 	thirdParty,
 	children,
 	i18n: i18nOverrides = {},
@@ -54,6 +55,7 @@ export const ThirdPartyProvider = ({
 		context: {
 			complete,
 			thirdParty,
+			preValidatedData,
 		},
 	});
 

--- a/packages/layout/src/components/cards/thirdParty/thirdParty.mdx
+++ b/packages/layout/src/components/cards/thirdParty/thirdParty.mdx
@@ -52,6 +52,7 @@ import { ThirdPartyCard } from '@tpr/layout';
 				onCorrect={(value) => setComplete(value)}
 				complete={complete}
 				thirdParty={thirdParty}
+				preValidatedData={true}
 			/>
 		);
 	}}

--- a/packages/layout/src/components/cards/thirdParty/thirdParty.tsx
+++ b/packages/layout/src/components/cards/thirdParty/thirdParty.tsx
@@ -61,7 +61,7 @@ export const ThirdPartyCard: React.FC<ThirdPartyProviderProps> = ({
 				return (
 					<Flex cfg={cfg} data-testid={testId} className={styles.card}>
 						<Toolbar
-							complete={context.complete}
+							complete={context.preValidatedData ? true : context.complete}
 							subtitle={() => <H4>{context.thirdParty.organisationName}</H4>}
 							buttonLeft={() => (
 								<UnderlinedButton>{i18n.preview.buttons.one}</UnderlinedButton>

--- a/packages/layout/src/components/cards/thirdParty/thirdPartyMachine.ts
+++ b/packages/layout/src/components/cards/thirdParty/thirdPartyMachine.ts
@@ -26,6 +26,7 @@ export interface ThirdPartyContext {
 	complete: boolean;
 	remove: { confirm: boolean; date: string } | null;
 	thirdParty: Partial<ThirdPartyProps>;
+	preValidatedData?: boolean | null;
 }
 
 const thirdPartyMachine = Machine<

--- a/packages/layout/src/components/cards/thirdParty/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/thirdParty/views/preview/preview.tsx
@@ -7,11 +7,15 @@ import styles from './preview.module.scss';
 
 export const Preview: React.FC<any> = () => {
 	const { current, send, onCorrect, i18n } = useThirdPartyContext();
-	const { thirdParty, complete } = current.context;
+	const { thirdParty, complete, preValidatedData } = current.context;
 
 	return (
 		<div
-			className={classNames([{ [styles.complete]: complete }, styles.content])}
+			className={
+				preValidatedData
+					? classNames([styles.content, styles.complete])
+					: classNames([{ [styles.complete]: complete }, styles.content])
+			}
 		>
 			<Flex>
 				<Flex

--- a/packages/layout/src/components/cards/trustee/context.tsx
+++ b/packages/layout/src/components/cards/trustee/context.tsx
@@ -48,6 +48,7 @@ export interface Trustee
 
 export interface TrusteeContextProps {
 	complete?: boolean;
+	preValidatedData?: boolean;
 	testId?: string | number;
 	children?: RenderProps | ReactElement;
 	cfg?: SpaceProps;
@@ -62,6 +63,7 @@ export interface TrusteeContextProps {
 export interface TrusteeCardProps {
 	trustee: Trustee;
 	complete?: boolean;
+	preValidatedData?: boolean;
 	i18n?: RecursivePartial<TrusteeI18nProps>;
 	onCorrect: (...args: any[]) => void;
 	onRemove: (...args: any[]) => Promise<any>;
@@ -78,6 +80,7 @@ export interface TrusteeCardProps {
 export const TrusteeProvider = ({
 	trustee,
 	complete,
+	preValidatedData,
 	children,
 	onDetailsSave,
 	onContactSave,
@@ -98,6 +101,7 @@ export const TrusteeProvider = ({
 				...modifiedTrustee,
 				address: trusteeAddress,
 			},
+			preValidatedData,
 		},
 		services: {
 			onDetailsSave: ({ trustee }) => {

--- a/packages/layout/src/components/cards/trustee/trustee.mdx
+++ b/packages/layout/src/components/cards/trustee/trustee.mdx
@@ -77,6 +77,7 @@ import { TrusteeCard } from '@tpr/layout';
 					},
 				}}
 				trustee={trustee}
+				preValidatedData={true}
 			/>
 		);
 	}}

--- a/packages/layout/src/components/cards/trustee/trustee.tsx
+++ b/packages/layout/src/components/cards/trustee/trustee.tsx
@@ -117,7 +117,9 @@ export const TrusteeCard: React.FC<Omit<TrusteeCardProps, 'children'>> = ({
 			{({ current }) => (
 				<Flex cfg={cfg} data-testid={props.testId} className={styles.card}>
 					<Toolbar
-						complete={current.context.complete}
+						complete={
+							current.context.preValidatedData ? true : current.context.complete
+						}
 						buttonLeft={() => <TrusteeButton />}
 						buttonRight={() => <RemoveButton />}
 						subtitle={() => (

--- a/packages/layout/src/components/cards/trustee/trusteeMachine.ts
+++ b/packages/layout/src/components/cards/trustee/trusteeMachine.ts
@@ -77,6 +77,7 @@ export interface TrusteeContext {
 		reason: null | string;
 		date: null | string;
 	};
+	preValidatedData?: boolean | null;
 }
 
 const trusteeMachine = Machine<TrusteeContext, TrusteeStates, TrusteeEvents>({

--- a/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
@@ -8,11 +8,15 @@ import styles from './preview.module.scss';
 
 export const Preview: React.FC = () => {
 	const { current, send, onCorrect, i18n } = useTrusteeContext();
-	const { trustee, complete } = current.context;
+	const { trustee, complete, preValidatedData } = current.context;
 
 	return (
 		<div
-			className={classNames([{ [styles.complete]: complete }, styles.content])}
+			className={
+				preValidatedData
+					? classNames([styles.content, styles.complete])
+					: classNames([{ [styles.complete]: complete }, styles.content])
+			}
 		>
 			<P cfg={{ mb: 4 }}>{capitalize(trustee.trusteeType)} trustee</P>
 			<Flex>


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

The status of the cards ("green or red") now can be controlled via props too.
Change implemented in order to fix the related issue (https://dev.azure.com/thepensionsregulator/TPR/_workitems/edit/59659)

#### Reviewers should focus on:

- adding new boolean parameter (preValidatedData) to Cards for preventing from showing "Incomplete" when the 'All details are correct' checkbox is not ticked.
- preValidatedData is optional, it won't break components if not specified.
- when not specified, the card's validation remains the same, depending on the "All details are correct" checkbox.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
