### PR TITLE
added functionality for passing decimals as props to FFInputNumber

### DIFF
--- a/packages/forms/src/elements/helpers.tsx
+++ b/packages/forms/src/elements/helpers.tsx
@@ -1,0 +1,14 @@
+export const parseToDecimals = (num: string, decimals: number): number => {
+	// first we detect if the number already contains decimals
+	const firstDot = num.indexOf('.');
+	// if contains decimals, only allow n number of decimals
+	// to avoid unnexpected rounds when using toFixed() in handleBlur
+	if (firstDot > -1) {
+		let newNum = num.slice(0, firstDot + decimals + 1);
+		return Number(newNum);
+	} else return Number(num);
+};
+
+export const handleBlur = (value: string, decimals: number): string => {
+	return Number(value).toFixed(decimals);
+};

--- a/packages/forms/src/elements/input/input.tsx
+++ b/packages/forms/src/elements/input/input.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { classNames, Flex, LayoutProps } from '@tpr/core';
 import styles from './input.module.scss';
-
 export type InputProps = {
 	type: string;
 	width?: LayoutProps['width'];
@@ -9,6 +8,7 @@ export type InputProps = {
 	label?: string;
 	touched?: boolean;
 	after?: any;
+	decimals?: number;
 	[key: string]: any;
 };
 export const Input: React.FC<InputProps> = ({
@@ -19,6 +19,7 @@ export const Input: React.FC<InputProps> = ({
 	touched = false,
 	className,
 	after: After,
+	decimals,
 	...rest
 }) => {
 	return (
@@ -27,6 +28,7 @@ export const Input: React.FC<InputProps> = ({
 				type={type}
 				data-testid={testId}
 				aria-label={label}
+				step={type !== 'number' ? null : decimals ? Math.pow(10, -decimals) : 1}
 				className={classNames([
 					styles.inputText,
 					className,

--- a/packages/forms/src/elements/input/input.tsx
+++ b/packages/forms/src/elements/input/input.tsx
@@ -8,7 +8,7 @@ export type InputProps = {
 	label?: string;
 	touched?: boolean;
 	after?: any;
-	decimals?: number;
+	decimalPlaces?: number;
 	[key: string]: any;
 };
 export const Input: React.FC<InputProps> = ({
@@ -19,7 +19,7 @@ export const Input: React.FC<InputProps> = ({
 	touched = false,
 	className,
 	after: After,
-	decimals,
+	decimalPlaces,
 	...rest
 }) => {
 	return (
@@ -28,7 +28,13 @@ export const Input: React.FC<InputProps> = ({
 				type={type}
 				data-testid={testId}
 				aria-label={label}
-				step={type !== 'number' ? null : decimals ? Math.pow(10, -decimals) : 1}
+				step={
+					type !== 'number'
+						? null
+						: decimalPlaces
+						? Math.pow(10, -decimalPlaces)
+						: 1
+				}
 				className={classNames([
 					styles.inputText,
 					className,

--- a/packages/forms/src/elements/number/number.mdx
+++ b/packages/forms/src/elements/number/number.mdx
@@ -86,13 +86,13 @@ import { Form, validate, renderFields } from '@tpr/forms';
 				placeholder: "e.g. 456.77",
 				cfg: { my: 5 },
 				after: "mi",
-				decimals: 2,
+				decimalPlaces: 2,
 				validate: (value) => {
 					if (!value) {
 						return 'value not valid or empty';
 					}
 					if (value <= 0 || value > 100000) {
-						return 'value must be between 0 and 100000 and accepts 2 decimals';
+						return 'value must be between 0 and 100000 and accepts 2 decimal places';
 					}
 					return undefined;
 				},
@@ -123,13 +123,13 @@ Accepted config props: FlexProps, SpaceProps
 
 ### Props
 
-| Property | Required | Type     | Description                                          |
-| -------- | -------- | -------- | ---------------------------------------------------- |
-| cfg      | false    | object   | FlexProps & SpaceProps                               |
-| disabled | false    | boolean  | Disable checkbox                                     |
-| testId   | false    | string   | data attribute for testers                           |
-| label    | true     | string   | Checkbox description                                 |
-| hint     | false    | string   | More detailed description about the checkbox         |
-| callback | false    | function | callback function to be executed after onChange      |
-| after    | false    | string   | emulates text passed to ::after pseudo-selector      |
-| decimals | false    | number   | the number of decimals used for formatting the value |
+| Property      | Required | Type     | Description                                                |
+| ------------- | -------- | -------- | ---------------------------------------------------------- |
+| cfg           | false    | object   | FlexProps & SpaceProps                                     |
+| disabled      | false    | boolean  | Disable checkbox                                           |
+| testId        | false    | string   | data attribute for testers                                 |
+| label         | true     | string   | Checkbox description                                       |
+| hint          | false    | string   | More detailed description about the checkbox               |
+| callback      | false    | function | callback function to be executed after onChange            |
+| after         | false    | string   | emulates text passed to ::after pseudo-selector            |
+| decimalPlaces | false    | number   | the number of decimal places used for formatting the value |

--- a/packages/forms/src/elements/number/number.mdx
+++ b/packages/forms/src/elements/number/number.mdx
@@ -49,7 +49,7 @@ import { FFInputNumber } from '@tpr/forms';
 				<FFInputNumber
 					name="number_of_participants"
 					label="Number of participants"
-					hint="How many people are entering this event"
+					hint="people attending this event, maximum of 20"
 					validate={(value) => {
 						if (value < 1 || value > 20 || !value || value === 0) {
 							return 'Must be between 1 and 20';
@@ -58,7 +58,6 @@ import { FFInputNumber } from '@tpr/forms';
 					}}
 					inputWidth={5}
 					cfg={{ my: 5 }}
-					after="cm"
 					callback={(e) => console.log(e.target.value)}
 				/>
 				<button type="submit" style={{ display: 'none' }} children="Submit" />
@@ -79,12 +78,24 @@ import { Form, validate, renderFields } from '@tpr/forms';
 		const fields = [
 			{
 				type: 'number',
-				name: 'number_of_participants',
-				label: 'Number of participants',
-				hint: 'must be between 1 and 20',
+				name: 'cities_distance',
+				label: 'Distance between the 2 cities',
+				hint: 'must be expressed in miles',
 				error: 'Cannot be empty',
 				inputWidth: 5,
+				placeholder: "e.g. 456.77",
 				cfg: { my: 5 },
+				after: "mi",
+				decimals: 2,
+				validate: (value) => {
+					if (!value) {
+						return 'value not valid or empty';
+					}
+					if (value <= 0 || value > 100000) {
+						return 'value must be between 0 and 100000 and accepts 2 decimals';
+					}
+					return undefined;
+				},
 			},
 		];
 		return (
@@ -112,10 +123,13 @@ Accepted config props: FlexProps, SpaceProps
 
 ### Props
 
-| Property | Required | Type    | Description                                  |
-| -------- | -------- | ------- | -------------------------------------------- |
-| cfg      | false    | object  | FlexProps & SpaceProps                       |
-| disabled | false    | boolean | Disable checkbox                             |
-| testId   | false    | string  | data attribute for testers                   |
-| label    | true     | string  | Checkbox description                         |
-| hint     | false    | string  | More detailed description about the checkbox |
+| Property | Required | Type     | Description                                          |
+| -------- | -------- | -------- | ---------------------------------------------------- |
+| cfg      | false    | object   | FlexProps & SpaceProps                               |
+| disabled | false    | boolean  | Disable checkbox                                     |
+| testId   | false    | string   | data attribute for testers                           |
+| label    | true     | string   | Checkbox description                                 |
+| hint     | false    | string   | More detailed description about the checkbox         |
+| callback | false    | function | callback function to be executed after onChange      |
+| after    | false    | string   | emulates text passed to ::after pseudo-selector      |
+| decimals | false    | number   | the number of decimals used for formatting the value |

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -8,7 +8,7 @@ import { parseToDecimals, handleBlur } from '../helpers';
 interface InputNumberProps extends FieldRenderProps<number>, FieldExtraProps {
 	after?: any;
 	callback?: (e: any) => void;
-	decimals?: number;
+	decimalPlaces?: number;
 }
 
 const InputNumber: React.FC<InputNumberProps> = ({
@@ -23,7 +23,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 	cfg,
 	after,
 	callback,
-	decimals,
+	decimalPlaces,
 	...props
 }) => {
 	return (
@@ -44,13 +44,14 @@ const InputNumber: React.FC<InputNumberProps> = ({
 				label={label}
 				touched={meta && meta.touched && meta.error}
 				placeholder={placeholder}
-				decimals={decimals}
+				decimalPlaces={decimalPlaces}
 				{...input}
 				onKeyDown={(e) => e.key.toLowerCase() === 'e' && e.preventDefault()}
 				onChange={(evt: ChangeEvent<HTMLInputElement>) => {
-					decimals
+					decimalPlaces
 						? input.onChange(
-								evt.target.value && parseToDecimals(evt.target.value, decimals),
+								evt.target.value &&
+									parseToDecimals(evt.target.value, decimalPlaces),
 						  )
 						: input.onChange(
 								evt.target.value && parseInt(evt.target.value, 10),
@@ -60,7 +61,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 				onBlur={(e: any) => {
 					input.onBlur(e); // without this call, validate won't be executed even if specified
 					e.target.value = e.target.value
-						? handleBlur(e.target.value, decimals)
+						? handleBlur(e.target.value, decimalPlaces)
 						: null;
 				}}
 				after={after}

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -3,10 +3,12 @@ import { Field, FieldRenderProps } from 'react-final-form';
 import { StyledInputLabel, InputElementHeading } from '../elements';
 import { FieldProps, FieldExtraProps } from '../../renderFields';
 import { Input } from '../input/input';
+import { parseToDecimals, handleBlur } from '../helpers';
 
 interface InputNumberProps extends FieldRenderProps<number>, FieldExtraProps {
 	after?: any;
 	callback?: (e: any) => void;
+	decimals?: number;
 }
 
 const InputNumber: React.FC<InputNumberProps> = ({
@@ -21,6 +23,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 	cfg,
 	after,
 	callback,
+	decimals,
 	...props
 }) => {
 	return (
@@ -41,11 +44,24 @@ const InputNumber: React.FC<InputNumberProps> = ({
 				label={label}
 				touched={meta && meta.touched && meta.error}
 				placeholder={placeholder}
+				decimals={decimals}
 				{...input}
 				onKeyDown={(e) => e.key.toLowerCase() === 'e' && e.preventDefault()}
 				onChange={(evt: ChangeEvent<HTMLInputElement>) => {
-					input.onChange(evt.target.value && parseInt(evt.target.value, 10));
+					decimals
+						? input.onChange(
+								evt.target.value && parseToDecimals(evt.target.value, decimals),
+						  )
+						: input.onChange(
+								evt.target.value && parseInt(evt.target.value, 10),
+						  );
 					callback && callback(evt);
+				}}
+				onBlur={(e: any) => {
+					input.onBlur(e); // without this call, validate won't be executed even if specified
+					e.target.value = e.target.value
+						? handleBlur(e.target.value, decimals)
+						: null;
 				}}
 				after={after}
 				{...props}


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Implementing the ability of specifying the format with a number of decimals

#### Reviewers should focus on:

- new optional prop "`decimals`" for `FFInputNumber`, which takes the number of decimal places.
- when `decimals` is specified, it will detect automatically when typing ` . ` and will allow only the number of decimals indicated.
- when a number with no decimals is typed, the auto-formatting will occur on `onBlur`.
- when `decimals` is specified, the `step` attribute is added to the input, so the value can increment/decrement as needed using the arrow-keys.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
