### PR TITLE
#58909 Resolve issues with address field validation in both auto (pos…

### DIFF
--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tpr/forms",
-	"version": "2.2.10",
+	"version": "2.2.11",
 	"description": "TPR Forms components",
 	"author": "David Alekna <david.alekna@tpr.gov.uk>",
 	"license": "MIT",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tpr/layout",
-	"version": "2.2.18",
+	"version": "2.2.19",
 	"description": "TPR Layout components",
 	"author": "David Alekna <david.alekna@tpr.gov.uk>",
 	"license": "MIT",

--- a/packages/layout/src/components/__tests__/inHouse.spec.tsx
+++ b/packages/layout/src/components/__tests__/inHouse.spec.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import {
+	getAllByLabelText,
+	getAllByText,
+	getByDisplayValue,
+	getByLabelText,
+	render,
+	waitFor,
+} from '@testing-library/react';
 import { InHouseCard } from '../cards/inHouse/inHouse';
 import { axe } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
@@ -189,5 +196,257 @@ describe('InHouse Remove', () => {
 		expect(
 			getByText('Are you sure you want to remove this in house admin?'),
 		).toBeInTheDocument();
+	});
+
+	describe('InHouse Auto Address', () => {
+		test('is accessible', async () => {
+			const { container, getByText } = render(
+				<InHouseCard
+					onSaveContacts={noop}
+					onSaveAddress={noop}
+					onSaveName={noop}
+					onRemove={noop}
+					onCorrect={(_value) => {}}
+					complete={true}
+					addressAPI={{
+						get: (_endpont) => Promise.resolve(),
+						limit: 100,
+					}}
+					inHouseAdmin={inHouseAdmin}
+				/>,
+			);
+
+			getByText('Address').click();
+
+			// wait for initial postcode to be loaded
+			await waitFor(() => {});
+
+			const results = await axe(container);
+			expect(results).toHaveNoViolations();
+		});
+
+		test('invalid postcodes disable the find address function', async () => {
+			inHouseAdmin.address.postcode = 'INVALID POSTCODE';
+
+			const { container, getByText } = render(
+				<InHouseCard
+					onSaveContacts={noop}
+					onSaveAddress={noop}
+					onSaveName={noop}
+					onRemove={noop}
+					onCorrect={(_value) => {}}
+					complete={true}
+					addressAPI={{
+						get: (_endpont) => Promise.resolve(),
+						limit: 100,
+					}}
+					inHouseAdmin={inHouseAdmin}
+				/>,
+			);
+
+			getByText('Address').click();
+			await waitFor(() => {});
+
+			getByText('Change').click();
+			await waitFor(() => {});
+
+			expect(getByDisplayValue(container, inHouseAdmin.address.postcode))
+				.toBeDefined;
+			expect(getByText('Find Address')).toBeDisabled();
+
+			const results = await axe(container);
+			expect(results).toHaveNoViolations();
+		});
+	});
+
+	describe('InHouse Manual Address', () => {
+		test('is accessible', async () => {
+			const { container, getByText } = render(
+				<InHouseCard
+					onSaveContacts={noop}
+					onSaveAddress={noop}
+					onSaveName={noop}
+					onRemove={noop}
+					onCorrect={(_value) => {}}
+					complete={true}
+					addressAPI={{
+						get: (_endpont) => Promise.resolve(),
+						limit: 100,
+					}}
+					inHouseAdmin={inHouseAdmin}
+				/>,
+			);
+
+			getByText('Address').click();
+
+			// wait for initial postcode to be loaded
+			await waitFor(() => {});
+
+			getByText(`I can't find my address in the list`).click();
+
+			const results = await axe(container);
+			expect(results).toHaveNoViolations();
+		});
+
+		test('address line 1 is required', async () => {
+			const { container, getByText } = render(
+				<InHouseCard
+					onSaveContacts={noop}
+					onSaveAddress={noop}
+					onSaveName={noop}
+					onRemove={noop}
+					onCorrect={(_value) => {}}
+					complete={true}
+					addressAPI={{
+						get: (_endpont) => Promise.resolve(),
+						limit: 100,
+					}}
+					inHouseAdmin={inHouseAdmin}
+				/>,
+			);
+
+			await navigateToManuallyEnteredAddress(getByText);
+
+			expect(getByText(`Address line 1`).nextSibling.textContent).toEqual(
+				'This is a required field',
+			);
+
+			userEvent.type(getByLabelText(container, `Address line 1`), 'a');
+
+			expect(getByText(`Address line 1`).nextSibling.textContent).toEqual(
+				'Must be at least 2 chars',
+			);
+
+			const results = await axe(container);
+			expect(results).toHaveNoViolations();
+		});
+
+		test('city is required', async () => {
+			const { container, getByText } = render(
+				<InHouseCard
+					onSaveContacts={noop}
+					onSaveAddress={noop}
+					onSaveName={noop}
+					onRemove={noop}
+					onCorrect={(_value) => {}}
+					complete={true}
+					addressAPI={{
+						get: (_endpont) => Promise.resolve(),
+						limit: 100,
+					}}
+					inHouseAdmin={inHouseAdmin}
+				/>,
+			);
+
+			await navigateToManuallyEnteredAddress(getByText);
+			await fillInAddressLine1(container);
+
+			expect(getByText(`City`).nextSibling.textContent).toEqual(
+				'This is a required field',
+			);
+
+			const results = await axe(container);
+			expect(results).toHaveNoViolations();
+		});
+
+		test('valid postcode is required', async () => {
+			const { container, getByText } = render(
+				<InHouseCard
+					onSaveContacts={noop}
+					onSaveAddress={noop}
+					onSaveName={noop}
+					onRemove={noop}
+					onCorrect={(_value) => {}}
+					complete={true}
+					addressAPI={{
+						get: (_endpont) => Promise.resolve(),
+						limit: 100,
+					}}
+					inHouseAdmin={inHouseAdmin}
+				/>,
+			);
+
+			await navigateToManuallyEnteredAddress(getByText);
+			await fillInAddressLine1(container);
+			await fillInCity(container);
+
+			let addressElement = getByText(`Address`).parentElement;
+
+			userEvent.clear(getAllByLabelText(addressElement, 'Postcode')[0]);
+			expect(getAllByLabelText(addressElement, 'Postcode')[0]).toBeDefined();
+
+			expect(
+				getAllByText(addressElement, 'Postcode')[0].nextSibling.textContent,
+			).toEqual('This is a required field');
+
+			userEvent.type(
+				getAllByLabelText(addressElement, 'Postcode')[0],
+				'INVALID POSTCODE',
+			);
+
+			expect(
+				getAllByText(addressElement, 'Postcode')[0].nextSibling.textContent,
+			).toEqual('Incorrect postcode format');
+
+			const results = await axe(container);
+			expect(results).toHaveNoViolations();
+		});
+
+		test('county is required', async () => {
+			const { container, getByText } = render(
+				<InHouseCard
+					onSaveContacts={noop}
+					onSaveAddress={noop}
+					onSaveName={noop}
+					onRemove={noop}
+					onCorrect={(_value) => {}}
+					complete={true}
+					addressAPI={{
+						get: (_endpont) => Promise.resolve(),
+						limit: 100,
+					}}
+					inHouseAdmin={inHouseAdmin}
+				/>,
+			);
+
+			await navigateToManuallyEnteredAddress(getByText);
+			await fillInAddressLine1(container);
+			await fillInCity(container);
+			await fillInPostcode(container);
+
+			expect(getByText(`County`).nextSibling.textContent).toEqual(
+				'This is a required field',
+			);
+
+			const results = await axe(container);
+			expect(results).toHaveNoViolations();
+		});
+
+		const navigateToManuallyEnteredAddress = async (getByText) => {
+			getByText('Address').click();
+			await waitFor(() => {});
+
+			getByText(`I can't find my address in the list`).click();
+			await waitFor(() => {});
+
+			getByText('Save and close').click();
+			await waitFor(() => {});
+		};
+
+		const fillInAddressLine1 = async (container) => {
+			userEvent.type(
+				getByLabelText(container, 'Address line 1'),
+				'Valid address line 1',
+			);
+		};
+
+		const fillInCity = async (container) => {
+			userEvent.type(getByLabelText(container, 'City'), 'Valid city');
+		};
+
+		const fillInPostcode = async (container) => {
+			userEvent.clear(getAllByLabelText(container, 'Postcode')[0]);
+			userEvent.type(getByLabelText(container, 'Postcode'), 'BN11AA');
+		};
 	});
 });

--- a/packages/layout/src/components/__tests__/trustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/trustee.spec.tsx
@@ -1,8 +1,16 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import {
+	getAllByLabelText,
+	getAllByText,
+	getByDisplayValue,
+	getByLabelText,
+	render,
+	waitFor,
+} from '@testing-library/react';
 import { TrusteeCard } from '../cards/trustee/trustee';
 import { axe } from 'jest-axe';
 import { Trustee } from '../cards/trustee/context';
+import userEvent from '@testing-library/user-event';
 
 // TODO: write more tests
 
@@ -284,6 +292,39 @@ describe('Trustee Auto Address', () => {
 		const results = await axe(container);
 		expect(results).toHaveNoViolations();
 	});
+
+	test('invalid postcodes disable the find address function', async () => {
+		trustee.postcode = 'INVALID POSTCODE';
+
+		const { container, getByText } = render(
+			<TrusteeCard
+				onDetailsSave={noop}
+				onContactSave={noop}
+				onAddressSave={noop}
+				onRemove={noop}
+				onCorrect={(_value) => {}}
+				addressAPI={{
+					get: (_endpont) => Promise.resolve(),
+					limit: 100,
+				}}
+				complete={true}
+				trustee={trustee}
+				testId={trustee.schemeRoleId}
+			/>,
+		);
+
+		getByText('Correspondence address').click();
+		await waitFor(() => {});
+
+		getByText('Change').click();
+		await waitFor(() => {});
+
+		expect(getByDisplayValue(container, trustee.postcode)).toBeDefined;
+		expect(getByText('Find Address')).toBeDisabled();
+
+		const results = await axe(container);
+		expect(results).toHaveNoViolations();
+	});
 });
 
 describe('Trustee Manual Address', () => {
@@ -315,4 +356,169 @@ describe('Trustee Manual Address', () => {
 		const results = await axe(container);
 		expect(results).toHaveNoViolations();
 	});
+
+	test('address line 1 is required', async () => {
+		const { container, getByText } = render(
+			<TrusteeCard
+				onDetailsSave={noop}
+				onContactSave={noop}
+				onAddressSave={noop}
+				onRemove={noop}
+				onCorrect={(_value) => {}}
+				addressAPI={{
+					get: (_endpont) => Promise.resolve(),
+					limit: 100,
+				}}
+				complete={true}
+				trustee={trustee}
+				testId={trustee.schemeRoleId}
+			/>,
+		);
+
+		await navigateToManuallyEnteredAddress(getByText);
+
+		expect(getByText(`Address line 1`).nextSibling.textContent).toEqual(
+			'This is a required field',
+		);
+
+		userEvent.type(getByLabelText(container, `Address line 1`), 'a');
+
+		expect(getByText(`Address line 1`).nextSibling.textContent).toEqual(
+			'Must be at least 2 chars',
+		);
+
+		const results = await axe(container);
+		expect(results).toHaveNoViolations();
+	});
+
+	test('city is required', async () => {
+		const { container, getByText } = render(
+			<TrusteeCard
+				onDetailsSave={noop}
+				onContactSave={noop}
+				onAddressSave={noop}
+				onRemove={noop}
+				onCorrect={(_value) => {}}
+				addressAPI={{
+					get: (_endpont) => Promise.resolve(),
+					limit: 100,
+				}}
+				complete={true}
+				trustee={trustee}
+				testId={trustee.schemeRoleId}
+			/>,
+		);
+
+		await navigateToManuallyEnteredAddress(getByText);
+		await fillInAddressLine1(container);
+
+		expect(getByText(`City`).nextSibling.textContent).toEqual(
+			'This is a required field',
+		);
+
+		const results = await axe(container);
+		expect(results).toHaveNoViolations();
+	});
+
+	test('valid postcode is required', async () => {
+		const { container, getByText } = render(
+			<TrusteeCard
+				onDetailsSave={noop}
+				onContactSave={noop}
+				onAddressSave={noop}
+				onRemove={noop}
+				onCorrect={(_value) => {}}
+				addressAPI={{
+					get: (_endpont) => Promise.resolve(),
+					limit: 100,
+				}}
+				complete={true}
+				trustee={trustee}
+				testId={trustee.schemeRoleId}
+			/>,
+		);
+
+		await navigateToManuallyEnteredAddress(getByText);
+		await fillInAddressLine1(container);
+		await fillInCity(container);
+
+		let addressElement = getByText(`Address`).parentElement;
+
+		userEvent.clear(getAllByLabelText(addressElement, 'Postcode')[0]);
+		expect(getAllByLabelText(addressElement, 'Postcode')[0]).toBeDefined();
+
+		expect(
+			getAllByText(addressElement, 'Postcode')[0].nextSibling.textContent,
+		).toEqual('This is a required field');
+
+		userEvent.type(
+			getAllByLabelText(addressElement, 'Postcode')[0],
+			'INVALID POSTCODE',
+		);
+
+		expect(
+			getAllByText(addressElement, 'Postcode')[0].nextSibling.textContent,
+		).toEqual('Incorrect postcode format');
+
+		const results = await axe(container);
+		expect(results).toHaveNoViolations();
+	});
+
+	test('county is required', async () => {
+		const { container, getByText } = render(
+			<TrusteeCard
+				onDetailsSave={noop}
+				onContactSave={noop}
+				onAddressSave={noop}
+				onRemove={noop}
+				onCorrect={(_value) => {}}
+				addressAPI={{
+					get: (_endpont) => Promise.resolve(),
+					limit: 100,
+				}}
+				complete={true}
+				trustee={trustee}
+				testId={trustee.schemeRoleId}
+			/>,
+		);
+
+		await navigateToManuallyEnteredAddress(getByText);
+		await fillInAddressLine1(container);
+		await fillInCity(container);
+		await fillInPostcode(container);
+
+		expect(getByText(`County`).nextSibling.textContent).toEqual(
+			'This is a required field',
+		);
+
+		const results = await axe(container);
+		expect(results).toHaveNoViolations();
+	});
+
+	const navigateToManuallyEnteredAddress = async (getByText) => {
+		getByText('Correspondence address').click();
+		await waitFor(() => {});
+
+		getByText(`I can't find my address in the list`).click();
+		await waitFor(() => {});
+
+		getByText('Save and close').click();
+		await waitFor(() => {});
+	};
+
+	const fillInAddressLine1 = async (container) => {
+		userEvent.type(
+			getByLabelText(container, 'Address line 1'),
+			'Valid address line 1',
+		);
+	};
+
+	const fillInCity = async (container) => {
+		userEvent.type(getByLabelText(container, 'City'), 'Valid city');
+	};
+
+	const fillInPostcode = async (container) => {
+		userEvent.clear(getAllByLabelText(container, 'Postcode')[0]);
+		userEvent.type(getByLabelText(container, 'Postcode'), 'BN11AA');
+	};
 });

--- a/packages/layout/src/components/cards/common/interfaces.ts
+++ b/packages/layout/src/components/cards/common/interfaces.ts
@@ -97,7 +97,7 @@ export interface addressLabelsFields {
 	};
 	addressLine2: { label: string; error?: string };
 	addressLine3: { label: string; error?: string };
-	postTown: { label: string; error?: string };
+	postTown: { label: string; emptyError?: string };
 	postcode: {
 		label: string;
 		invalidError?: string;

--- a/packages/layout/src/components/cards/common/views/address/Postcode.module.scss
+++ b/packages/layout/src/components/cards/common/views/address/Postcode.module.scss
@@ -30,6 +30,8 @@
 }
 
 .inputWrapper {
-	width: 160px;
+	width: 230px;
 	margin-bottom: $space-2;
 }
+
+

--- a/packages/layout/src/components/cards/common/views/address/Postcode.tsx
+++ b/packages/layout/src/components/cards/common/views/address/Postcode.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useCallback, ChangeEvent } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import { Flex, Button, P, Link } from '@tpr/core';
-import { Input } from '@tpr/forms';
-import { extractToObject } from './helpers';
+import { FFInputText, useFormState } from '@tpr/forms';
+import { extractToObject, postcodeIsValid } from './helpers';
 import { PostcodeProps } from '../../../common/interfaces';
 import styles from './Postcode.module.scss';
 
@@ -16,6 +16,7 @@ const Postcode: React.FC<PostcodeProps> = ({
 	addressAPI,
 	i18n,
 }) => {
+	const utils = useFormState();
 	const search = useCallback(
 		(postcode: string, country = 'GBR') => {
 			setLoading(true);
@@ -85,26 +86,28 @@ const Postcode: React.FC<PostcodeProps> = ({
 			<P cfg={{ mb: 2, fontWeight: 3 }}>{i18n.address.postcode.title}</P>
 			{lookup ? (
 				<>
-					<div className={styles.inputWrapper}>
-						<Input
-							type="text"
-							value={postcode}
-							onChange={(evt: ChangeEvent<HTMLInputElement>) =>
-								setPostcode(evt.target.value)
-							}
-							disabled={loading}
-						/>
-					</div>
-					<Flex>
-						<Button
-							onClick={() => {
-								search(postcode);
-							}}
-							disabled={loading}
-						>
-							{loading ? 'Loading...' : i18n.address.postcode.button}
-						</Button>
-					</Flex>
+						<div className={styles.inputWrapper}>
+							<FFInputText
+								name="postcode"
+								label=""
+								disabled={loading}
+								validate={ (value) => (postcodeIsValid(value, i18n?.address.postcode.regExPattern) ? undefined : i18n.address.auto.fields.postcode.invalidError)}
+								inputWidth={7}>
+							</FFInputText>
+						</div>
+						<Flex>
+							<Button
+								onClick={() => {
+									if (postcodeIsValid(utils.values.postcode, i18n?.address.postcode.regExPattern)) {
+										setPostcode(utils.values.postcode);
+										search(postcode);
+									}
+								}}
+								disabled={!postcodeIsValid(utils.values.postcode, i18n?.address.postcode.regExPattern) || loading}
+							>
+								{loading ? 'Loading...' : i18n.address.postcode.button}
+							</Button>
+						</Flex>
 				</>
 			) : (
 				<Flex>

--- a/packages/layout/src/components/cards/common/views/address/fields.ts
+++ b/packages/layout/src/components/cards/common/views/address/fields.ts
@@ -1,10 +1,11 @@
 import { FieldProps } from '@tpr/forms';
 import { addressLabelsFields } from '../../interfaces';
 import { RecursivePartial } from '../../../common/interfaces';
-import { validPostcode } from './helpers';
+import { postcodeIsValid } from './helpers';
 
 export const getFields = (
 	labels: RecursivePartial<addressLabelsFields>,
+	postcodeRegExPattern: string
 ): FieldProps[] => [
 	{
 		name: 'addressLine1',
@@ -12,7 +13,7 @@ export const getFields = (
 		label: labels.addressLine1.label,
 		error: (value: string) => {
 			if (!value) return labels.addressLine1.emptyError;
-			return value.length < 3 ? labels.addressLine1.invalidError : undefined;
+			return value.length < 2 ? labels.addressLine1.invalidError : undefined;
 		},
 		inputWidth: 6,
 		cfg: { mb: 3 },
@@ -37,6 +38,9 @@ export const getFields = (
 	{
 		name: 'postTown',
 		label: labels.postTown.label,
+		error: (value: string) => {
+			return !value ? labels.postTown.emptyError : undefined;
+		},
 		type: 'text',
 		inputWidth: 6,
 		cfg: { mb: 3 },
@@ -47,7 +51,7 @@ export const getFields = (
 		type: 'text',
 		error: (postcode: string) => {
 			if (!postcode) return labels.postcode.emptyError;
-			return validPostcode(postcode) ? undefined : labels.postcode.invalidError;
+			return postcodeIsValid(postcode, postcodeRegExPattern) ? undefined : labels.postcode.invalidError;
 		},
 		inputWidth: 6,
 		cfg: { mb: 3 },

--- a/packages/layout/src/components/cards/common/views/address/helpers.ts
+++ b/packages/layout/src/components/cards/common/views/address/helpers.ts
@@ -14,8 +14,9 @@ export const extractToObject = (
 	}, {});
 };
 
-export function validPostcode(postcode: string) {
-	const PC = postcode.replace(/\s/g, '');
-	const regex = /^[A-Z]{1,2}[0-9]{1,2} ?[0-9][A-Z]{2}$/i;
-	return regex.test(PC);
-}
+export const postcodeIsValid = ((postcodeToValidate: string, postcodeRegExPattern: any) => {
+	if (!postcodeToValidate) return false;
+
+	const cleanedPostcode = postcodeToValidate.replace(/[\s()-.]/g, '');
+	return cleanedPostcode != null && RegExp(postcodeRegExPattern, 'i').test(cleanedPostcode);
+});

--- a/packages/layout/src/components/cards/inHouse/i18n.ts
+++ b/packages/layout/src/components/cards/inHouse/i18n.ts
@@ -30,10 +30,16 @@ export type InHouseAdminI18nProps = {
 			title: string;
 			link: string;
 			button: string;
+			regExPattern?: string;
 		};
 		auto: {
 			title: string;
 			subtitle: string;
+			fields: {
+				postcode: {
+					invalidError?: string;
+				};
+			},
 			dropdown: {
 				placeholder: string;
 				link: string;
@@ -50,7 +56,10 @@ export type InHouseAdminI18nProps = {
 				};
 				addressLine2: { label: string; error?: string };
 				addressLine3: { label: string; error?: string };
-				postTown: { label: string; error?: string };
+				postTown: { 
+					label: string; 
+					emptyError?: string
+				};
 				postcode: {
 					label: string;
 					invalidError?: string;
@@ -143,10 +152,16 @@ export const i18n: InHouseAdminI18nProps = {
 			button: 'Find Address',
 			title: 'Postcode',
 			link: 'Change',
+			regExPattern: '^[a-z]{1,2}\\d[a-z\\d]?\\d?[a-z]{0,2}$',
 		},
 		auto: {
 			title: 'Address',
 			subtitle: "Find the in house admin's correspondence address",
+			fields: {
+				postcode: {
+					invalidError: 'Incorrect postcode format',
+				},
+			},
 			dropdown: {
 				placeholder: 'Please select the address from the dropdown',
 				link: "I can't find my address in the list",
@@ -162,12 +177,12 @@ export const i18n: InHouseAdminI18nProps = {
 					emptyError: 'This is a required field',
 					invalidError: 'Must be at least 2 chars',
 				},
-				addressLine2: {
-					label: 'Address line 2',
-					error: 'This is a required field',
-				},
+				addressLine2: { label: 'Address line 2' },
 				addressLine3: { label: 'Address line 3' },
-				postTown: { label: 'City' },
+				postTown: { 
+					label: 'City',
+					emptyError: 'This is a required field',
+				},
 				postcode: {
 					label: 'Postcode',
 					emptyError: 'This is a required field',

--- a/packages/layout/src/components/cards/inHouse/views/address/ManualComplete.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/address/ManualComplete.tsx
@@ -8,7 +8,7 @@ const ManualComplete: React.FC = () => {
 	const [loading, setLoading] = useState(false);
 	const { current, send, i18n, onSaveAddress } = useInHouseAdminContext();
 	const { inHouseAdmin } = current.context;
-	const fields = getFields(i18n?.address?.manual?.fields);
+	const fields = getFields(i18n?.address?.manual?.fields, i18n?.address.postcode.regExPattern);
 
 	const onSubmit = async (values) => {
 		setLoading(true);

--- a/packages/layout/src/components/cards/inHouse/views/address/index.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/address/index.tsx
@@ -7,6 +7,7 @@ import AutoComplete from './AutoComplete';
 import ManualComplete from './ManualComplete';
 import Postcode from '../../../common/views/address/Postcode';
 import { cardType, cardTypeName } from '../../../common/interfaces';
+import { Form } from '@tpr/forms';
 
 export const AddressPage: React.FC = () => {
 	const { current, i18n, addressAPI } = useInHouseAdminContext();
@@ -26,17 +27,27 @@ export const AddressPage: React.FC = () => {
 			typeName={cardTypeName.inHouseAdmin}
 			title={i18n.address.title}
 		>
-			<Postcode
-				lookup={lookup}
-				loading={loading}
-				postcode={postcode}
-				setPostcode={(postcode: string) => setState({ postcode })}
-				showLookup={(lookup: boolean) => setState({ lookup })}
-				setLoading={(loading: boolean) => setState({ loading })}
-				setOptions={(options: any[]) => setState({ options })}
-				addressAPI={addressAPI}
-				i18n={i18n}
-			/>
+			<Form 
+				onSubmit={() => {}}
+				initialValues={{
+					postcode: postcode
+				}}>
+					{({ }) => (
+					<form>
+						<Postcode
+							lookup={lookup}
+							loading={loading}
+							postcode={postcode}
+							setPostcode={(postcode: string) => setState({ postcode })}
+							showLookup={(lookup: boolean) => setState({ lookup })}
+							setLoading={(loading: boolean) => setState({ loading })}
+							setOptions={(options: any[]) => setState({ options })}
+							addressAPI={addressAPI}
+							i18n={i18n}
+						/>
+					</form>
+				)}
+			</Form>
 			<Flex cfg={{ flexDirection: 'column' }}>
 				{manual ? (
 					<ManualComplete />

--- a/packages/layout/src/components/cards/trustee/i18n.ts
+++ b/packages/layout/src/components/cards/trustee/i18n.ts
@@ -7,6 +7,7 @@ export type TrusteeI18nProps = {
 			title: string;
 			link: string;
 			button: string;
+			regExPattern?: string;
 		};
 		auto: {
 			title: string;
@@ -16,6 +17,11 @@ export type TrusteeI18nProps = {
 				link: string;
 				error: string;
 			};
+			fields: {
+				postcode: {
+					invalidError?: string;
+				};
+			}
 		};
 		manual: {
 			subtitle: string;
@@ -27,7 +33,10 @@ export type TrusteeI18nProps = {
 				};
 				addressLine2: { label: string; error?: string };
 				addressLine3: { label: string; error?: string };
-				postTown: { label: string; error?: string };
+				postTown: { 
+					label: string; 
+					emptyError?: string 
+				};
 				postcode: {
 					label: string;
 					invalidError?: string;
@@ -124,10 +133,16 @@ export const i18n: TrusteeI18nProps = {
 			button: 'Find Address',
 			title: 'Postcode',
 			link: 'Change',
+			regExPattern: '^[a-z]{1,2}\\d[a-z\\d]?\\d?[a-z]{0,2}$',
 		},
 		auto: {
 			title: 'Address',
 			subtitle: "Find the trustee's correspondence address",
+			fields: {
+				postcode: {
+					invalidError: 'Incorrect postcode format',
+				},
+			},
 			dropdown: {
 				placeholder: 'Please select the address from the dropdown',
 				link: "I can't find my address in the list",
@@ -143,12 +158,12 @@ export const i18n: TrusteeI18nProps = {
 					emptyError: 'This is a required field',
 					invalidError: 'Must be at least 2 chars',
 				},
-				addressLine2: {
-					label: 'Address line 2',
-					error: 'This is a required field',
-				},
+				addressLine2: { label: 'Address line 2' },
 				addressLine3: { label: 'Address line 3' },
-				postTown: { label: 'City' },
+				postTown: { 
+					label: 'City', 
+					emptyError: 'This is a required field' 
+				},
 				postcode: {
 					label: 'Postcode',
 					emptyError: 'This is a required field',

--- a/packages/layout/src/components/cards/trustee/views/address/ManualComplete.tsx
+++ b/packages/layout/src/components/cards/trustee/views/address/ManualComplete.tsx
@@ -7,7 +7,7 @@ import { cardTypeName } from '../../../common/interfaces';
 const ManualComplete: React.FC = () => {
 	const { current, send, i18n } = useTrusteeContext();
 	const { trustee, loading } = current.context;
-	const fields = getFields(i18n?.address?.manual?.fields);
+	const fields = getFields(i18n?.address?.manual?.fields, i18n?.address.postcode.regExPattern);
 
 	const onSubmit = (values) => {
 		send('SAVE', { address: values });

--- a/packages/layout/src/components/cards/trustee/views/address/index.tsx
+++ b/packages/layout/src/components/cards/trustee/views/address/index.tsx
@@ -7,6 +7,7 @@ import AutoComplete from './AutoComplete';
 import ManualComplete from './ManualComplete';
 import Postcode from '../../../common/views/address/Postcode';
 import { cardType } from '../../../common/interfaces';
+import { Form } from '@tpr/forms';
 
 const AddressPage: React.FC = () => {
 	const { current, i18n, addressAPI } = useTrusteeContext();
@@ -22,17 +23,27 @@ const AddressPage: React.FC = () => {
 
 	return (
 		<Content type={cardType.trustee} title={i18n.address.title}>
-			<Postcode
-				lookup={lookup}
-				loading={loading}
-				postcode={postcode}
-				setPostcode={(postcode: string) => setState({ postcode })}
-				showLookup={(lookup: boolean) => setState({ lookup })}
-				setLoading={(loading: boolean) => setState({ loading })}
-				setOptions={(options: any[]) => setState({ options })}
-				addressAPI={addressAPI}
-				i18n={i18n}
-			/>
+			<Form 
+				onSubmit={() => {}}
+				initialValues={{
+					postcode: postcode
+				}}>
+					{({ }) => (
+					<form>
+						<Postcode
+							lookup={lookup}
+							loading={loading}
+							postcode={postcode}
+							setPostcode={(postcode: string) => {console.log('poscode got set'); console.log(postcode); setState({ postcode })}}
+							showLookup={(lookup: boolean) => setState({ lookup })}
+							setLoading={(loading: boolean) => setState({ loading })}
+							setOptions={(options: any[]) => setState({ options })}
+							addressAPI={addressAPI}
+							i18n={i18n}
+						/>
+					</form>
+					)}
+			</Form>
 			<Flex cfg={{ flexDirection: 'column' }}>
 				{manual ? (
 					<ManualComplete />


### PR DESCRIPTION
#### Fixes AzureDevOps #58909

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- When finding addresses via a postcode lookup (in the Trustee and InHouseAdmin cards), then the postcode is validated before being passed off to the address lookup service. 
- When entering addresses manually (again in the Trustee and InHouseAdmin cards) then Address Line 1 validation has been corrected to ensure it requires at least 2 characters.
-  The City, and County are also now marked as mandatory and must be supplied.
-  Postcode must be provided and applies the same postcode pattern check as the address lookup.

#### Reviewers should focus on:

- Ensuring that the two existing cards which allow address modification (Trustee and InHouseAdmin) work as expected and that no regression bugs have been introduced.
- That future updates to other existing cards (to add address editing ability) will not require any changes to the postcode lookup or address field validation.
