### PR TITLE
Cards - make remove actions same for all

### DIFF
--- a/packages/layout/src/components/cards/actuary/actuary.mdx
+++ b/packages/layout/src/components/cards/actuary/actuary.mdx
@@ -30,10 +30,6 @@ import { ActuaryCard } from '@tpr/layout';
 			console.log(_fullActuaryObject);
 			return Promise.resolve(values);
 		};
-		const saveName = (...args) => {
-			console.log(...args);
-			return Promise.resolve();
-		};
 		const actuary = {
 			schemeRoleId: 123,
 			title: 'Mr',
@@ -57,7 +53,7 @@ import { ActuaryCard } from '@tpr/layout';
 		return (
 			<ActuaryCard
 				onSaveContacts={callbackFn}
-				onSaveName={saveName}
+				onSaveName={callbackFn}
 				onRemove={callbackFn}
 				onCorrect={(value) => setComplete(value)}
 				complete={complete}

--- a/packages/layout/src/components/cards/actuary/actuary.mdx
+++ b/packages/layout/src/components/cards/actuary/actuary.mdx
@@ -30,6 +30,10 @@ import { ActuaryCard } from '@tpr/layout';
 			console.log(_fullActuaryObject);
 			return Promise.resolve(values);
 		};
+		const saveName = (...args) => {
+			console.log(...args);
+			return Promise.resolve();
+		};
 		const actuary = {
 			schemeRoleId: 123,
 			title: 'Mr',
@@ -53,7 +57,7 @@ import { ActuaryCard } from '@tpr/layout';
 		return (
 			<ActuaryCard
 				onSaveContacts={callbackFn}
-				onSaveName={callbackFn}
+				onSaveName={saveName}
 				onRemove={callbackFn}
 				onCorrect={(value) => setComplete(value)}
 				complete={complete}

--- a/packages/layout/src/components/cards/actuary/views/remove/confirm/confirm.tsx
+++ b/packages/layout/src/components/cards/actuary/views/remove/confirm/confirm.tsx
@@ -30,7 +30,7 @@ export const ConfirmRemove = () => {
 	);
 	const { actuary, remove } = current.context;
 
-	async function handleRemove() {
+	const handleRemove = async () => {
 		setLoading(true);
 		await onRemove(
 			{
@@ -47,7 +47,7 @@ export const ConfirmRemove = () => {
 			.catch(() => {
 				setLoading(false);
 			});
-	}
+	};
 
 	return (
 		<Confirm

--- a/packages/layout/src/components/cards/employer/employer.tsx
+++ b/packages/layout/src/components/cards/employer/employer.tsx
@@ -13,6 +13,8 @@ import {
 	EmployerProviderProps,
 	Employer,
 } from './context';
+import RemovedBox from '../components/removedBox';
+import { cardTypeName } from '../common/interfaces';
 import styles from '../cards.module.scss';
 
 const CardContentSwitch: React.FC = () => {
@@ -26,6 +28,9 @@ const CardContentSwitch: React.FC = () => {
 			return <RemoveDateForm />;
 		case current.matches({ remove: 'confirm' }):
 			return <ConfirmRemove />;
+		case current.matches({ remove: 'deleted' }):
+			// message to show when successfuly deleted.
+			return <RemovedBox type={cardTypeName.employer} />;
 		default:
 			return null;
 	}

--- a/packages/layout/src/components/cards/employer/views/remove/confirm/confirm.tsx
+++ b/packages/layout/src/components/cards/employer/views/remove/confirm/confirm.tsx
@@ -30,7 +30,7 @@ export const ConfirmRemove: React.FC = () => {
 	);
 	const { employer, remove } = current.context;
 
-	async function handleRemove() {
+	const handleRemove = async () => {
 		setLoading(true);
 		await onRemove(
 			{
@@ -42,11 +42,12 @@ export const ConfirmRemove: React.FC = () => {
 		)
 			.then(() => {
 				setLoading(false);
+				send('DELETE');
 			})
 			.catch(() => {
 				setLoading(false);
 			});
-	}
+	};
 
 	return (
 		<Confirm

--- a/packages/layout/src/components/cards/inHouse/views/remove/confirm/confirm.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/remove/confirm/confirm.tsx
@@ -30,7 +30,7 @@ export const ConfirmRemove: React.FC = () => {
 	);
 	const { inHouseAdmin, remove } = current.context;
 
-	async function handleRemove() {
+	const handleRemove = async () => {
 		setLoading(true);
 		await onRemove(
 			{
@@ -47,7 +47,7 @@ export const ConfirmRemove: React.FC = () => {
 			.catch(() => {
 				setLoading(false);
 			});
-	}
+	};
 
 	return (
 		<Confirm

--- a/packages/layout/src/components/cards/insurer/insurer.tsx
+++ b/packages/layout/src/components/cards/insurer/insurer.tsx
@@ -11,6 +11,8 @@ import { Preview } from './views/preview/preview';
 import { RemoveDateForm } from './views/remove/date/date';
 import { ConfirmRemove } from './views/remove/confirm/confirm';
 import { Reference } from './views/reference';
+import RemovedBox from '../components/removedBox';
+import { cardTypeName } from '../common/interfaces';
 import styles from '../cards.module.scss';
 
 const CardContentSwitch: React.FC = () => {
@@ -24,6 +26,9 @@ const CardContentSwitch: React.FC = () => {
 			return <RemoveDateForm />;
 		case current.matches({ remove: 'confirm' }):
 			return <ConfirmRemove />;
+		case current.matches({ remove: 'deleted' }):
+			// message to show when successfuly deleted.
+			return <RemovedBox type={cardTypeName.insurer} />;
 		default:
 			return null;
 	}

--- a/packages/layout/src/components/cards/insurer/views/remove/confirm/confirm.tsx
+++ b/packages/layout/src/components/cards/insurer/views/remove/confirm/confirm.tsx
@@ -30,21 +30,24 @@ export const ConfirmRemove: React.FC = () => {
 	);
 	const { insurer, remove } = current.context;
 
-	async function handleRemove() {
+	const handleRemove = async () => {
 		setLoading(true);
-		try {
-			const params = {
+		await onRemove(
+			{
 				schemeRoleId: insurer.schemeRoleId,
 				effectiveDate: insurer.effectiveDate,
 				date: remove.date,
-			};
-			await onRemove(params, insurer);
-			setLoading(false);
-		} catch (error) {
-			console.error(error);
-			setLoading(false);
-		}
-	}
+			},
+			insurer,
+		)
+			.then(() => {
+				setLoading(false);
+				send('DELETE');
+			})
+			.catch(() => {
+				setLoading(false);
+			});
+	};
 
 	return (
 		<Confirm

--- a/packages/layout/src/components/cards/thirdParty/thirdParty.tsx
+++ b/packages/layout/src/components/cards/thirdParty/thirdParty.tsx
@@ -10,6 +10,8 @@ import { UnderlinedButton } from '../components/button';
 import { Preview } from './views/preview/preview';
 import { RemoveDateForm } from './views/remove/date/date';
 import { ConfirmRemove } from './views/remove/confirm/confirm';
+import RemovedBox from '../components/removedBox';
+import { cardTypeName } from '../common/interfaces';
 import styles from '../cards.module.scss';
 
 const CardContentSwitch: React.FC = () => {
@@ -21,6 +23,9 @@ const CardContentSwitch: React.FC = () => {
 			return <RemoveDateForm />;
 		case current.matches({ remove: 'confirm' }):
 			return <ConfirmRemove />;
+		case current.matches({ remove: 'deleted' }):
+			// message to show when successfuly deleted.
+			return <RemovedBox type={cardTypeName.thirdParty} />;
 		default:
 			return null;
 	}

--- a/packages/layout/src/components/cards/thirdParty/views/remove/confirm/confirm.tsx
+++ b/packages/layout/src/components/cards/thirdParty/views/remove/confirm/confirm.tsx
@@ -30,7 +30,7 @@ export const ConfirmRemove: React.FC = () => {
 	);
 	const { thirdParty, remove } = current.context;
 
-	async function handleRemove() {
+	const handleRemove = async () => {
 		setLoading(true);
 		await onRemove(
 			{
@@ -42,11 +42,12 @@ export const ConfirmRemove: React.FC = () => {
 		)
 			.then(() => {
 				setLoading(false);
+				send('DELETE');
 			})
 			.catch(() => {
 				setLoading(false);
 			});
-	}
+	};
 
 	return (
 		<Confirm

--- a/packages/layout/src/components/cards/trustee/trustee.tsx
+++ b/packages/layout/src/components/cards/trustee/trustee.tsx
@@ -14,6 +14,8 @@ import Address from './views/address';
 import { Contacts } from './views/contacts';
 import RemoveReason from './views/remove/reason/reason';
 import { ConfirmRemove } from './views/remove/confirm';
+import RemovedBox from '../components/removedBox';
+import { cardTypeName } from '../common/interfaces';
 
 import styles from '../cards.module.scss';
 
@@ -42,6 +44,9 @@ const CardContent: React.FC = () => {
 		return <RemoveReason />;
 	} else if (current.matches({ remove: 'confirm' })) {
 		return <ConfirmRemove />;
+	} else if (current.matches({ remove: 'deleted' })) {
+		// message to show when successfuly deleted.
+		return <RemovedBox type={cardTypeName.trustee} />;
 	} else {
 		return null;
 	}

--- a/packages/layout/src/components/cards/trustee/trusteeMachine.ts
+++ b/packages/layout/src/components/cards/trustee/trusteeMachine.ts
@@ -35,6 +35,7 @@ interface TrusteeStates {
 			states: {
 				reason: {};
 				confirm: {};
+				deleted: {};
 			};
 		};
 	};
@@ -56,7 +57,8 @@ type TrusteeEvents =
 				reason: null | string;
 				date: null | string;
 			};
-	  };
+	  }
+	| { type: 'DELETE' };
 
 export interface TrusteeProps extends CardPersonalDetails, CardContactDetails {
 	schemeRoleId: string;
@@ -238,7 +240,11 @@ const trusteeMachine = Machine<TrusteeContext, TrusteeStates, TrusteeEvents>({
 						EDIT_TRUSTEE: '#edit.trustee.name',
 						BACK: 'reason',
 						CANCEL: '#preview',
+						DELETE: 'deleted',
 					},
+				},
+				deleted: {
+					type: 'final',
 				},
 			},
 		},

--- a/packages/layout/src/components/cards/trustee/views/remove/confirm/index.tsx
+++ b/packages/layout/src/components/cards/trustee/views/remove/confirm/index.tsx
@@ -27,7 +27,7 @@ export const ConfirmRemove: React.FC = () => {
 	);
 	const { trustee, remove } = current.context;
 
-	function handleRemove() {
+	const handleRemove = async () => {
 		setLoading(true);
 		onRemove(
 			{
@@ -39,11 +39,12 @@ export const ConfirmRemove: React.FC = () => {
 		)
 			.then(() => {
 				setLoading(false);
+				send('DELETE');
 			})
 			.catch(() => {
 				setLoading(false);
 			});
-	}
+	};
 
 	return (
 		<Confirm


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Making the process of removing a card, the same and making sure that sends the same details for all of them:
- schemeRoleId
- effectiveDate
- date

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
