### PR TITLE
Change branch filters for deploy-rc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,10 +49,4 @@ workflows:
           filters:
             branches:
               only:
-                - /rc-.*/
-                - /feature-.*/
-                - /bug-.*/
-                - /release/.*/
-                - /feature/.*/
-                - /bug/.*/
-                - /bugfix/.*/
+                - /develop/


### PR DESCRIPTION
# The way we deploy to NPM is cumbersome, this is how we fix it

## The Problem
When creating a branch from develop the version tag is copied over to the feature branch, when a commit from that feature branch is pushed to GitHub, [CircleCI](https://app.circleci.com/pipelines/github/thepensionsregulator/react-components) creates a release candidate for this commit and increase the @next version number.

This works when one developer has only one `feature/` branch in this repo. If another developer creates another `feature/` branch before the first `feature/` branch is merged into `develop`, both `feature/` branches will have the same version tag. This will cause an error when CircleCI tries to publish a release candidate as the version number that it is being used will already be taken by the first `feature/` branch.

## The Solution
We should only release a @next version of a package once the changes have been peer reviewed and passed the build step on [CircleCI](https://app.circleci.com/pipelines/github/thepensionsregulator/react-components). This should prevent Lerna from becoming confused about what tags to use for a release as it only has to track the tags in the `develop` branch.

To solve this I have changed the list of branches that a release candidate should be made for 
from:
 - `/rc-.*/`
 - `/feature-.*/`
 - `/bug-.*/`
 - `/release/.*/`
 - `/feature/.*/`
 - `/bug/.*/`
 - `/bugfix/.*/`
to `/develop/` 

This brings the CD for this repo in line with other repos at TPR. @Sitecorgi please review before merging.