### PR TITLE
Making error-left-border optional for ffinputnumber

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,10 +49,4 @@ workflows:
           filters:
             branches:
               only:
-                - /rc-.*/
-                - /feature-.*/
-                - /bug-.*/
-                - /release/.*/
-                - /feature/.*/
-                - /bug/.*/
-                - /bugfix/.*/
+                - /develop/

--- a/packages/forms/src/elements/elements.tsx
+++ b/packages/forms/src/elements/elements.tsx
@@ -8,6 +8,7 @@ interface StyledInputLabelProps {
 	className?: string;
 	cfg?: FlexProps | SpaceProps;
 	[key: string]: any;
+	noLeftBorder?: boolean;
 }
 export const StyledInputLabel: React.FC<StyledInputLabelProps> = ({
 	element = 'label',
@@ -15,11 +16,12 @@ export const StyledInputLabel: React.FC<StyledInputLabelProps> = ({
 	isError,
 	className,
 	children,
+	noLeftBorder,
 	...props
 }) => {
 	const classNames = useClassNames(cfg, [
 		styles.label,
-		{ [styles['labelError']]: isError },
+		{ [styles['labelError']]: isError && !noLeftBorder },
 		className,
 	]);
 	return createElement(

--- a/packages/forms/src/elements/number/number.mdx
+++ b/packages/forms/src/elements/number/number.mdx
@@ -60,6 +60,7 @@ import { FFInputNumber } from '@tpr/forms';
 					cfg={{ my: 5 }}
 					callback={(e) => console.log(e.target.value)}
 					required={true}
+					noLeftBorder={true}
 				/>
 				<button type="submit" style={{ display: 'none' }} children="Submit" />
 			</form>
@@ -134,3 +135,4 @@ Accepted config props: FlexProps, SpaceProps
 | callback      | false    | function | callback function to be executed after onChange            |
 | after         | false    | string   | emulates text passed to ::after pseudo-selector            |
 | decimalPlaces | false    | number   | the number of decimal places used for formatting the value |
+| noLeftBorder  | false    | boolean  | disables the left border when detecting error              |

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -9,6 +9,7 @@ interface InputNumberProps extends FieldRenderProps<number>, FieldExtraProps {
 	after?: any;
 	callback?: (e: any) => void;
 	decimalPlaces?: number;
+	noLeftBorder?: boolean;
 }
 
 const InputNumber: React.FC<InputNumberProps> = ({
@@ -24,12 +25,14 @@ const InputNumber: React.FC<InputNumberProps> = ({
 	after,
 	callback,
 	decimalPlaces,
+	noLeftBorder,
 	...props
 }) => {
 	return (
 		<StyledInputLabel
 			isError={meta && meta.touched && meta.error}
 			cfg={Object.assign({ flexDirection: 'column', mt: 1 }, cfg)}
+			noLeftBorder={noLeftBorder}
 		>
 			<InputElementHeading
 				label={label}


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Adding the ability of disabling the red left border for `FFInputNumber` that appears when error is detected.
Will be needed for group validation where that extra red border is not needed, e.g. for Asset-Breakdown form.

#### Reviewers should focus on:

This can be specified using `noLeftBorder={true}` on `FFInputNumber`

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
