### PR TITLE
ffinputnumber placing "after" pseudo-element outside of the input width

### DIFF
--- a/packages/forms/src/elements/input/input.module.scss
+++ b/packages/forms/src/elements/input/input.module.scss
@@ -41,6 +41,12 @@ input[type='number'] {
 }
 
 .after {
+	position: absolute;
+	left: 100%;
 	line-height: 50px;
 	margin-left: 1rem;
+}
+
+.input-wrapper_relative {
+	position: relative;
 }

--- a/packages/forms/src/elements/input/input.tsx
+++ b/packages/forms/src/elements/input/input.tsx
@@ -23,7 +23,10 @@ export const Input: React.FC<InputProps> = ({
 	...rest
 }) => {
 	return (
-		<Flex cfg={{ flex: width ? '0 0 auto' : '1 1 auto', width }}>
+		<Flex
+			cfg={{ flex: width ? '0 0 auto' : '1 1 auto', width }}
+			className={After ? styles['input-wrapper_relative'] : ''}
+		>
 			<input
 				type={type}
 				data-testid={testId}


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Changing the position of `after` to `absolute`, that way it won't affect the width of the input and it will have the same dimensions as all other inputs where `after` is not specified.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
