### PR TITLE
adding optional 'before' & 'optionalText' props

### DIFF
--- a/packages/forms/src/elements/input/input.module.scss
+++ b/packages/forms/src/elements/input/input.module.scss
@@ -44,7 +44,13 @@ input[type='number'] {
 	position: absolute;
 	left: 100%;
 	line-height: 50px;
-	margin-left: 1rem;
+	margin-left: 0.5rem;
+}
+
+.before {
+	line-height: 50px;
+	margin-right: 0.5rem;
+	flex-shrink: inherit;
 }
 
 .input-wrapper_relative {

--- a/packages/forms/src/elements/input/input.tsx
+++ b/packages/forms/src/elements/input/input.tsx
@@ -7,7 +7,8 @@ export type InputProps = {
 	testId?: string;
 	label?: string;
 	touched?: boolean;
-	after?: any;
+	after?: string;
+	before?: string;
 	decimalPlaces?: number;
 	[key: string]: any;
 };
@@ -19,6 +20,7 @@ export const Input: React.FC<InputProps> = ({
 	touched = false,
 	className,
 	after: After,
+	before: Before,
 	decimalPlaces,
 	...rest
 }) => {
@@ -27,6 +29,7 @@ export const Input: React.FC<InputProps> = ({
 			cfg={{ flex: width ? '0 0 auto' : '1 1 auto', width }}
 			className={After ? styles['input-wrapper_relative'] : ''}
 		>
+			{Before && <span className={styles.before}>{Before}</span>}
 			<input
 				type={type}
 				data-testid={testId}

--- a/packages/forms/src/elements/number/number.mdx
+++ b/packages/forms/src/elements/number/number.mdx
@@ -62,6 +62,20 @@ import { FFInputNumber } from '@tpr/forms';
 					required={true}
 					noLeftBorder={true}
 				/>
+				<FFInputNumber
+					name="amount"
+					label="Total expenses"
+					hint="amount in GBP"
+					validate={(value) => {}}
+					inputWidth={5}
+					cfg={{ my: 5 }}
+					required={false}
+					noLeftBorder={true}
+					optionalText={false}
+					decimalPlaces={2}
+					min={0}
+					before="£"
+				/>
 				<button type="submit" style={{ display: 'none' }} children="Submit" />
 			</form>
 		)}
@@ -127,12 +141,14 @@ Accepted config props: FlexProps, SpaceProps
 
 | Property      | Required | Type     | Description                                                |
 | ------------- | -------- | -------- | ---------------------------------------------------------- |
-| cfg           | false    | object   | FlexProps & SpaceProps                                     |
-| disabled      | false    | boolean  | Disable checkbox                                           |
-| testId        | false    | string   | data attribute for testers                                 |
-| label         | true     | string   | Checkbox description                                       |
-| hint          | false    | string   | More detailed description about the checkbox               |
-| callback      | false    | function | callback function to be executed after onChange            |
 | after         | false    | string   | emulates text passed to ::after pseudo-selector            |
+| before        | false    | string   | emulates text passed to ::before pseudo-selector           |
+| callback      | false    | function | callback function to be executed after onChange            |
+| cfg           | false    | object   | FlexProps & SpaceProps                                     |
 | decimalPlaces | false    | number   | the number of decimal places used for formatting the value |
+| disabled      | false    | boolean  | Disable input field                                        |
+| hint          | false    | string   | More detailed description about the field                  |
+| label         | true     | string   | Input description                                          |
 | noLeftBorder  | false    | boolean  | disables the left border when detecting error              |
+| optionalText  | false    | boolean  | allows hiding "optional" text when field is not required   |
+| testId        | false    | string   | data attribute for testers                                 |

--- a/packages/forms/src/elements/number/number.mdx
+++ b/packages/forms/src/elements/number/number.mdx
@@ -60,7 +60,6 @@ import { FFInputNumber } from '@tpr/forms';
 					cfg={{ my: 5 }}
 					callback={(e) => console.log(e.target.value)}
 					required={true}
-					noLeftBorder={true}
 				/>
 				<FFInputNumber
 					name="amount"
@@ -71,10 +70,28 @@ import { FFInputNumber } from '@tpr/forms';
 					cfg={{ my: 5 }}
 					required={false}
 					noLeftBorder={true}
-					optionalText={false}
 					decimalPlaces={2}
 					min={0}
 					before="£"
+				/>
+				<FFInputNumber
+					name="percentage"
+					label="Amount deducted from expenses"
+					hint="amount in %"
+					validate={(value) => {}}
+					inputWidth={5}
+					cfg={{ my: 5 }}
+					required={false}
+					noLeftBorder={true}
+					optionalText={false}
+					decimalPlaces={2}
+					min={0}
+					max={100}
+					after="%"
+					validate={(value) => {
+						if (value < 0 || value > 100)
+							return 'must be value between 0 and 100%';
+					}}
 				/>
 				<button type="submit" style={{ display: 'none' }} children="Submit" />
 			</form>
@@ -112,6 +129,7 @@ import { Form, validate, renderFields } from '@tpr/forms';
 					}
 					return undefined;
 				},
+				noLeftBorder: true,
 			},
 		];
 		return (

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -6,10 +6,12 @@ import { Input } from '../input/input';
 import { parseToDecimals, handleBlur } from '../helpers';
 
 interface InputNumberProps extends FieldRenderProps<number>, FieldExtraProps {
-	after?: any;
+	after?: string;
+	before?: string;
 	callback?: (e: any) => void;
 	decimalPlaces?: number;
 	noLeftBorder?: boolean;
+	noOptionalText?: boolean;
 }
 
 const InputNumber: React.FC<InputNumberProps> = ({
@@ -23,9 +25,11 @@ const InputNumber: React.FC<InputNumberProps> = ({
 	inputWidth: width,
 	cfg,
 	after,
+	before,
 	callback,
 	decimalPlaces,
 	noLeftBorder,
+	optionalText,
 	...props
 }) => {
 	return (
@@ -36,7 +40,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 		>
 			<InputElementHeading
 				label={label}
-				required={required}
+				required={optionalText !== undefined ? !optionalText : required}
 				hint={hint}
 				meta={meta}
 			/>
@@ -68,6 +72,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 						: null;
 				}}
 				after={after}
+				before={before}
 				{...props}
 			/>
 		</StyledInputLabel>


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- new `before` and `optionalText` props to `FFinputNumber`
(`before` prop requested in https://dev.azure.com/thepensionsregulator/TPR/_workitems/edit/64733/)

#### Reviewers should focus on:

Both new props are optional and won't cause any issue if not specified. 
- `before` allows to pass a text to be displayed before the input, simulating the behavior of ::before pseudo-element
- `optionalText` allows to hide the "**(optional)**" text which is automatically added at the end of the label when the field is not required

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
