### PR TITLE
new prop for FFInputNumber

### DIFF
--- a/packages/forms/src/__tests__/number.spec.tsx
+++ b/packages/forms/src/__tests__/number.spec.tsx
@@ -62,8 +62,8 @@ describe('Number', () => {
 		});
 	});
 
-	describe('specifying maxLength', () => {
-		test('adding the amount of decimal places specified', () => {
+	describe('specifying max length props', () => {
+		test('adding maxLength', () => {
 			const { getByTestId } = formSetup({
 				render: (
 					<FFInputNumber
@@ -78,6 +78,59 @@ describe('Number', () => {
 			userEvent.type(getByTestId(testId), '123456');
 			fireEvent.blur(getByTestId(testId));
 			expect(getByTestId(testId)).toHaveValue(123);
+		});
+
+		test('adding maxIntDigits', () => {
+			const { getByTestId } = formSetup({
+				render: (
+					<FFInputNumber
+						label="Number"
+						testId={testId}
+						name="number"
+						maxIntDigits={3}
+						decimalPlaces={2}
+					/>
+				),
+			});
+			userEvent.type(getByTestId(testId), '123456.5');
+			fireEvent.blur(getByTestId(testId));
+			expect(getByTestId(testId)).toHaveValue(123.50);
+		});
+
+		test('adding maxIntDigits & maxLength', () => {
+			const { getByTestId } = formSetup({
+				render: (
+					<FFInputNumber
+						label="Number"
+						testId={testId}
+						name="number"
+						maxLength={7}
+						maxIntDigits={3}
+						decimalPlaces={2}
+					/>
+				),
+			});
+			userEvent.type(getByTestId(testId), '123456.12345');
+			fireEvent.blur(getByTestId(testId));
+			expect(getByTestId(testId)).toHaveValue(123.12);
+		});
+
+		test('adding maxIntDigits & maxLength in negative number', () => {
+			const { getByTestId } = formSetup({
+				render: (
+					<FFInputNumber
+						label="Number"
+						testId={testId}
+						name="number"
+						maxLength={7}
+						maxIntDigits={3}
+						decimalPlaces={2}
+					/>
+				),
+			});
+			userEvent.type(getByTestId(testId), '-123456.12345');
+			fireEvent.blur(getByTestId(testId));
+			expect(getByTestId(testId)).toHaveValue(-123.12);
 		});
 	});
 });

--- a/packages/forms/src/elements/email/email.mdx
+++ b/packages/forms/src/elements/email/email.mdx
@@ -10,7 +10,7 @@ import { FFInputEmail } from './email';
 import { validate } from '../../validation';
 import { renderFields } from '../../renderFields';
 
-# Input
+# Email Input
 
 A basic widget for getting the user input as a email field. Keyboard and mouse can be used for providing or changing data.
 

--- a/packages/forms/src/elements/number/number.mdx
+++ b/packages/forms/src/elements/number/number.mdx
@@ -74,6 +74,7 @@ import { FFInputNumber } from '@tpr/forms';
 					decimalPlaces={2}
 					min={0}
 					before="£"
+					maxIntDigits={3}
 				/>
 				<FFInputNumber
 					name="percentage"
@@ -157,17 +158,18 @@ Accepted config props: FlexProps, SpaceProps
 
 ### Props
 
-| Property      | Required | Type     | Description                                                   |
-| ------------- | -------- | -------- | ------------------------------------------------------------- |
-| after         | false    | string   | emulates text passed to ::after pseudo-selector               |
-| before        | false    | string   | emulates text passed to ::before pseudo-selector              |
-| callback      | false    | function | callback function to be executed after onChange               |
-| cfg           | false    | object   | FlexProps & SpaceProps                                        |
-| decimalPlaces | false    | number   | the number of decimal places used for formatting the value    |
-| disabled      | false    | boolean  | Disable input field                                           |
-| hint          | false    | string   | More detailed description about the field                     |
-| label         | true     | string   | Input description                                             |
-| maxLength     | false    | number   | sets a maximum length for the input (decimal places included) |
-| noLeftBorder  | false    | boolean  | disables the left border when detecting error                 |
-| optionalText  | false    | boolean  | allows hiding "optional" text when field is not required      |
-| testId        | false    | string   | data attribute for testers                                    |
+| Property      | Required | Type     | Description                                                                    |
+| ------------- | -------- | -------- | ------------------------------------------------------------------------------ |
+| after         | false    | string   | emulates text passed to ::after pseudo-selector                                |
+| before        | false    | string   | emulates text passed to ::before pseudo-selector                               |
+| callback      | false    | function | callback function to be executed after onChange                                |
+| cfg           | false    | object   | FlexProps & SpaceProps                                                         |
+| decimalPlaces | false    | number   | the number of decimal places used for formatting the value                     |
+| disabled      | false    | boolean  | Disable input field                                                            |
+| hint          | false    | string   | More detailed description about the field                                      |
+| label         | true     | string   | Input description                                                              |
+| maxIntDigits  | false    | number   | sets a maximum length for the integer part of the value                        |
+| maxLength     | false    | number   | sets a maximum length for the input value (e.g. 123.00 &#x27A1; maxLength={6}) |
+| noLeftBorder  | false    | boolean  | disables the left border when detecting error                                  |
+| optionalText  | false    | boolean  | allows hiding "optional" text when field is not required                       |
+| testId        | false    | string   | data attribute for testers                                                     |

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, useState } from 'react';
 import { Field, FieldRenderProps } from 'react-final-form';
 import { StyledInputLabel, InputElementHeading } from '../elements';
 import { FieldProps, FieldExtraProps } from '../../renderFields';
@@ -13,6 +13,7 @@ interface InputNumberProps extends FieldRenderProps<number>, FieldExtraProps {
 	noLeftBorder?: boolean;
 	optionalText?: boolean;
 	maxLength?: number;
+	maxIntDigits?: number;
 }
 
 const InputNumber: React.FC<InputNumberProps> = ({
@@ -32,25 +33,36 @@ const InputNumber: React.FC<InputNumberProps> = ({
 	noLeftBorder,
 	optionalText,
 	maxLength,
+	maxIntDigits,
 	...props
 }) => {
-	const handleKeyDown = (e: any) => {
+	const [prevValue, setPrevValue] = useState<string | null>(null);
+
+	const reachedMaxIntDigits = (value:string): boolean => {
+		const newInt:number = parseInt(value);
+		return Math.abs(newInt).toString().length > maxIntDigits ? true : false;
+	};
+
+	const handleKeyDown = (e: any): void => {
 		e.target.value.length >= maxLength &&
 			!validKeys.includes(e.key) &&
 			e.preventDefault();
 		e.key.toLowerCase() === 'e' && e.preventDefault();
 	};
 
-	const handleOnChange = (e: ChangeEvent<HTMLInputElement>) => {
+	const handleOnChange = (e: ChangeEvent<HTMLInputElement>): void => {
 		decimalPlaces
 			? input.onChange(
 					e.target.value && parseToDecimals(e.target.value, decimalPlaces),
 			  )
 			: input.onChange(e.target.value && parseInt(e.target.value, 10));
+		reachedMaxIntDigits(e.target.value)
+			? input.onChange(prevValue)
+			: setPrevValue(e.target.value);
 		callback && callback(e);
 	};
 
-	const handleBlur = (e: any) => {
+	const handleBlur = (e: any): void => {
 		input.onBlur(e); // without this call, validate won't be executed even if specified
 		const newValue = fixToDecimals(e.target.value, decimalPlaces);
 		e.target.value = e.target.value ? newValue : null;

--- a/packages/forms/src/elements/phone/phone.mdx
+++ b/packages/forms/src/elements/phone/phone.mdx
@@ -10,7 +10,7 @@ import { FFInputPhone } from './phone';
 import { validate } from '../../validation';
 import { renderFields } from '../../renderFields';
 
-# Input
+# Phone Input
 
 A basic widget for getting the user input as a phone field. Keyboard and mouse can be used for providing or changing data.
 


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

new `maxIntDigits` prop for `FFInputNumber`
will fix this bug (https://dev.azure.com/thepensionsregulator/TPR/_workitems/edit/65955)

#### Reviewers should focus on:

`maxIntDigits` will prevent the user from entering a new value with a number of integer digits longer than the value specified in the prop.
It will not prevent from entering decimal places if the input defines the `decimalPlaces` prop.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
