### PR TITLE
adding initialV prop to currency component

### DIFF
--- a/packages/forms/src/elements/currency/currency.mdx
+++ b/packages/forms/src/elements/currency/currency.mdx
@@ -61,6 +61,22 @@ import { FFInputCurrency } from '@tpr/forms';
 							return 'value cannot be greater than 999,999,999,999.99';
 					}}
 				/>
+				<FFInputCurrency
+					name="income2"
+					label="Annual income with initial value"
+					hint="total amount of income for last year, in GBP"
+					before="£"
+					inputWidth={5}
+					cfg={{ my: 5 }}
+					required={false}
+					noLeftBorder={true}
+					optionalText={false}
+					initialV={22500.6}
+					validate={(value) => {
+						if (value && value.length > 18)
+							return 'value cannot be greater than 999,999,999,999.99';
+					}}
+				/>
 				<button type="submit" style={{ display: 'none' }} children="Submit" />
 			</form>
 		)}
@@ -84,6 +100,7 @@ Accepted config props: FlexProps, SpaceProps
 | decimalPlaces  | false    | number   | the number of decimal places used for formatting the value, default is 2                                 |
 | disabled       | false    | boolean  | Disable input field                                                                                      |
 | hint           | false    | string   | More detailed description about the field                                                                |
+| initialV       | false    | number   | Initial value for the input, will be automatically formatted                                             |
 | label          | true     | string   | Input description                                                                                        |
 | maxInputLength | false    | number   | the max length for the input (including ',' and '.'), default is 16 + decimalPlaces (999,999,999,999.99) |
 | noLeftBorder   | false    | boolean  | disables the left border when detecting error                                                            |

--- a/packages/forms/src/elements/currency/currency.tsx
+++ b/packages/forms/src/elements/currency/currency.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState } from 'react';
+import React, { ChangeEvent, useState, useEffect, useRef } from 'react';
 import { Field, FieldRenderProps } from 'react-final-form';
 import { StyledInputLabel, InputElementHeading } from '../elements';
 import { FieldProps, FieldExtraProps } from '../../renderFields';
@@ -21,6 +21,7 @@ interface InputCurrencyProps extends FieldRenderProps<number>, FieldExtraProps {
 	noLeftBorder?: boolean;
 	optionalText?: boolean;
 	maxInputLength?: number;
+	initialV?: number;
 }
 
 const InputCurrency: React.FC<InputCurrencyProps> = ({
@@ -40,6 +41,7 @@ const InputCurrency: React.FC<InputCurrencyProps> = ({
 	noLeftBorder,
 	optionalText,
 	maxInputLength = 16 + decimalPlaces,
+	initialV,
 	...props
 }) => {
 	const digits = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.'];
@@ -48,6 +50,7 @@ const InputCurrency: React.FC<InputCurrencyProps> = ({
 
 	const [inputValue, setInputValue] = useState<string>('');
 	const [dot, setDot] = useState<boolean>(false);
+	const [firstLoad, setFirstLoad] = useState<boolean>(true);
 
 	const formatWithCommas = (value: string): string => {
 		const numString: string = value.replace(/,/g, '');
@@ -105,6 +108,20 @@ const InputCurrency: React.FC<InputCurrencyProps> = ({
 				: inputValue;
 		input.onChange(e);
 	};
+	
+	const innerInput = useRef(null);
+
+	useEffect(() => {
+		// if "initialV" is specified, it needs to trigger manually the onBlur event to apply the format
+		const myEvent = new Event('blur', { bubbles: true })
+		if(initialV) {
+			const newInitialValue = formatWithCommas(initialV.toFixed(decimalPlaces));
+			setInputValue(newInitialValue);
+			innerInput.current.value = newInitialValue;
+			setFirstLoad(false);
+			innerInput.current.dispatchEvent(myEvent);
+		}
+	}, [firstLoad]);
 
 	return (
 		<StyledInputLabel
@@ -119,6 +136,7 @@ const InputCurrency: React.FC<InputCurrencyProps> = ({
 				meta={meta}
 			/>
 			<Input
+				parentRef={innerInput}
 				type="text"
 				width={width}
 				testId={testId}

--- a/packages/forms/src/elements/input/input.tsx
+++ b/packages/forms/src/elements/input/input.tsx
@@ -10,6 +10,7 @@ export type InputProps = {
 	after?: string;
 	before?: string;
 	decimalPlaces?: number;
+	parentRef?: any;
 	[key: string]: any;
 };
 export const Input: React.FC<InputProps> = ({
@@ -22,6 +23,7 @@ export const Input: React.FC<InputProps> = ({
 	after: After,
 	before: Before,
 	decimalPlaces,
+	parentRef,
 	...rest
 }) => {
 	return (
@@ -31,6 +33,7 @@ export const Input: React.FC<InputProps> = ({
 		>
 			{Before && <span className={styles.before}>{Before}</span>}
 			<input
+				ref={parentRef}
 				type={type}
 				data-testid={testId}
 				aria-label={label}


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Adding `initialV` (optional) prop to `FFInputCurrency`

#### Reviewers should focus on:

- when receiving `initialValue` prop, this is not handled correctly because the type of the input is "text" and the value needs to have the comma separated format applied.
- needs to use a different prop name to receive the initial value, in this case is called `initialV`
- the format is applied on the component first mount (if the `initialV` prop exists) by modifying the inner input.value and triggering an `onBlur` event which updates the value of the input.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
