### PR TITLE
FFInputCurrency updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build-and-test:
     working_directory: ~/react-components
     docker:
-      - image: 'cimg/base:stable'
+      - image: 'circleci/python:3.6.12'
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
   deploy-rc:
     working_directory: ~/react-components
     docker:
-      - image: 'cimg/base:stable'
+      - image: 'circleci/python:3.6.12'
     steps:
       - checkout
       - restore_cache:

--- a/packages/forms/src/elements/currency/currency.mdx
+++ b/packages/forms/src/elements/currency/currency.mdx
@@ -103,7 +103,7 @@ import { FFInputCurrency, validateCurrency } from '@tpr/forms';
 							optionalText={false}
 							callback={handleChange}
 							validate={(value) =>
-								validateCurrency(value, null, 999999999999.99)
+								validateCurrency(value, 999.99, 999999999999.99)
 							}
 						/>
 						<button

--- a/packages/forms/src/elements/currency/currency.mdx
+++ b/packages/forms/src/elements/currency/currency.mdx
@@ -173,7 +173,7 @@ Accepted config props: FlexProps, SpaceProps
 | -------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------- |
 | after          | false    | string   | emulates text passed to ::after pseudo-selector                                                          |
 | before         | false    | string   | emulates text passed to ::before pseudo-selector                                                         |
-| callback       | false    | function | callback function to be called after onChange, receives the input value as a number                      |
+| callback       | false    | function | callback function to be executed after onChange, receives the input value as a number                    |
 | cfg            | false    | object   | FlexProps & SpaceProps                                                                                   |
 | decimalPlaces  | false    | number   | the number of decimal places used for formatting the value, default is 2                                 |
 | disabled       | false    | boolean  | Disable input field                                                                                      |

--- a/packages/forms/src/elements/currency/currency.mdx
+++ b/packages/forms/src/elements/currency/currency.mdx
@@ -9,6 +9,7 @@ import { Form } from 'react-final-form';
 import { FFInputCurrency } from './currency';
 import { validate } from '../../validation';
 import { renderFields } from '../../renderFields';
+import { validateCurrency } from '../helpers';
 
 # Currency Input
 
@@ -40,47 +41,124 @@ import { FFInputCurrency } from '@tpr/forms';
 
 ## Examples
 
-[CodeSandbox](https://codesandbox.io)
+### With no validation
 
 <Playground>
-	<Form onSubmit={(values) => console.log(values)}>
-		{({ handleSubmit }) => (
-			<form onSubmit={handleSubmit}>
-				<FFInputCurrency
-					name="income"
-					label="Annual income"
-					hint="total amount of income for last year, in GBP"
-					before="£"
-					inputWidth={5}
-					cfg={{ my: 5 }}
-					required={false}
-					noLeftBorder={true}
-					optionalText={false}
-					validate={(value) => {
-						if (value && value.length > 18)
-							return 'value cannot be greater than 999,999,999,999.99';
-					}}
-				/>
-				<FFInputCurrency
-					name="income2"
-					label="Annual income with initial value"
-					hint="total amount of income for last year, in GBP"
-					before="£"
-					inputWidth={5}
-					cfg={{ my: 5 }}
-					required={false}
-					noLeftBorder={true}
-					optionalText={false}
-					initialV={22500.6}
-					validate={(value) => {
-						if (value && value.length > 18)
-							return 'value cannot be greater than 999,999,999,999.99';
-					}}
-				/>
-				<button type="submit" style={{ display: 'none' }} children="Submit" />
-			</form>
-		)}
-	</Form>
+	{() => {
+		const handleChange = (value) => {
+			console.log(value);
+		};
+		return (
+			<Form onSubmit={(values) => console.log(values)}>
+				{({ handleSubmit }) => (
+					<form onSubmit={handleSubmit}>
+						<FFInputCurrency
+							name="income"
+							label="Annual income"
+							hint="total amount of income for last year, in GBP"
+							before="£"
+							inputWidth={5}
+							cfg={{ my: 5 }}
+							required={false}
+							noLeftBorder={true}
+							optionalText={false}
+							callback={handleChange}
+						/>
+						<button
+							type="submit"
+							style={{ display: 'none' }}
+							children="Submit"
+						/>
+					</form>
+				)}
+			</Form>
+		);
+	}}
+</Playground>
+
+### Usign the validateCurrency function included in @tpr/forms
+
+```js
+import { FFInputCurrency, validateCurrency } from '@tpr/forms';
+```
+
+<Playground>
+	{() => {
+		const handleChange = (value) => {
+			console.log(value);
+		};
+		return (
+			<Form onSubmit={(values) => console.log(values)}>
+				{({ handleSubmit }) => (
+					<form onSubmit={handleSubmit}>
+						<FFInputCurrency
+							name="income"
+							label="Annual income"
+							hint="total amount of income for last year, in GBP"
+							before="£"
+							inputWidth={5}
+							cfg={{ my: 5 }}
+							required={false}
+							noLeftBorder={true}
+							optionalText={false}
+							callback={handleChange}
+							validate={(value) =>
+								validateCurrency(value, null, 999999999999.99)
+							}
+						/>
+						<button
+							type="submit"
+							style={{ display: 'none' }}
+							children="Submit"
+						/>
+					</form>
+				)}
+			</Form>
+		);
+	}}
+</Playground>
+
+### Usign the return value from validateCurrency as reference
+
+```js
+import { FFInputCurrency, validateCurrency } from '@tpr/forms';
+```
+
+<Playground>
+	{() => {
+		const handleChange = (value) => {
+			console.log(value);
+		};
+		return (
+			<Form onSubmit={(values) => console.log(values)}>
+				{({ handleSubmit }) => (
+					<form onSubmit={handleSubmit}>
+						<FFInputCurrency
+							name="income"
+							label="Annual income"
+							hint="total amount of income for last year, in GBP"
+							before="£"
+							inputWidth={5}
+							cfg={{ my: 5 }}
+							required={false}
+							noLeftBorder={true}
+							optionalText={false}
+							callback={handleChange}
+							validate={(value) => {
+								if (validateCurrency(value, null, 999999999999.99) === 'tooBig')
+									return 'Value cannot be greater than 999,999,999,999.99';
+							}}
+						/>
+						<button
+							type="submit"
+							style={{ display: 'none' }}
+							children="Submit"
+						/>
+					</form>
+				)}
+			</Form>
+		);
+	}}
 </Playground>
 
 ## API

--- a/packages/forms/src/elements/currency/currency.mdx
+++ b/packages/forms/src/elements/currency/currency.mdx
@@ -76,7 +76,7 @@ import { FFInputCurrency } from '@tpr/forms';
 	}}
 </Playground>
 
-### Usign the validateCurrency function included in @tpr/forms
+### Using the validateCurrency function included in @tpr/forms
 
 ```js
 import { FFInputCurrency, validateCurrency } from '@tpr/forms';
@@ -118,7 +118,7 @@ import { FFInputCurrency, validateCurrency } from '@tpr/forms';
 	}}
 </Playground>
 
-### Usign the return value from validateCurrency as reference
+### Using the returned value from validateCurrency as reference
 
 ```js
 import { FFInputCurrency, validateCurrency } from '@tpr/forms';
@@ -173,7 +173,7 @@ Accepted config props: FlexProps, SpaceProps
 | -------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------- |
 | after          | false    | string   | emulates text passed to ::after pseudo-selector                                                          |
 | before         | false    | string   | emulates text passed to ::before pseudo-selector                                                         |
-| callback       | false    | function | callback function to be executed after onChange                                                          |
+| callback       | false    | function | callback function to be called after onChange, receives the input value as a number                      |
 | cfg            | false    | object   | FlexProps & SpaceProps                                                                                   |
 | decimalPlaces  | false    | number   | the number of decimal places used for formatting the value, default is 2                                 |
 | disabled       | false    | boolean  | Disable input field                                                                                      |

--- a/packages/forms/src/elements/currency/currency.tsx
+++ b/packages/forms/src/elements/currency/currency.tsx
@@ -98,9 +98,14 @@ const InputCurrency: React.FC<InputCurrencyProps> = ({
 		}
 		if (!containsDecimals(e.target.value)) setDot(false);
 		e.target.value === '' && setInputValue('');
-		if(callback) {
-			const numericValue = parseToDecimals(e.target.value.replace(/,/g, ''), decimalPlaces);
-			e.target.value === '' ? callback(null) : callback(Number(numericValue.toFixed(decimalPlaces)));
+		if (callback) {
+			const numericValue = parseToDecimals(
+				e.target.value.replace(/,/g, ''),
+				decimalPlaces,
+			);
+			e.target.value === ''
+				? callback(null)
+				: callback(Number(numericValue.toFixed(decimalPlaces)));
 		}
 	};
 
@@ -112,13 +117,13 @@ const InputCurrency: React.FC<InputCurrencyProps> = ({
 				: inputValue;
 		input.onChange(e);
 	};
-	
+
 	const innerInput = useRef(null);
 
 	useEffect(() => {
 		// if "initialV" is specified, it needs to trigger manually the onBlur event to apply the format
-		const myEvent = new Event('blur', { bubbles: true })
-		if(initialV) {
+		const myEvent = new Event('blur', { bubbles: true });
+		if (initialV) {
 			const newInitialValue = formatWithCommas(initialV.toFixed(decimalPlaces));
 			setInputValue(newInitialValue);
 			innerInput.current.value = newInitialValue;

--- a/packages/forms/src/elements/currency/currency.tsx
+++ b/packages/forms/src/elements/currency/currency.tsx
@@ -11,6 +11,7 @@ import {
 	fixToDecimals,
 	getNumDecimalPlaces,
 	appendMissingZeros,
+	parseToDecimals,
 } from '../helpers';
 
 interface InputCurrencyProps extends FieldRenderProps<number>, FieldExtraProps {
@@ -97,7 +98,10 @@ const InputCurrency: React.FC<InputCurrencyProps> = ({
 		}
 		if (!containsDecimals(e.target.value)) setDot(false);
 		e.target.value === '' && setInputValue('');
-		callback && callback(e);
+		if(callback) {
+			const numericValue = parseToDecimals(e.target.value.replace(/,/g, ''), decimalPlaces);
+			e.target.value === '' ? callback(null) : callback(Number(numericValue.toFixed(decimalPlaces)));
+		}
 	};
 
 	const handleBlur = (e: any): void => {

--- a/packages/forms/src/elements/helpers.tsx
+++ b/packages/forms/src/elements/helpers.tsx
@@ -99,3 +99,26 @@ export const appendMissingZeros = (value: string, decimals: number): string => {
 	}
 	return value;
 };
+
+export const validateCurrency = (
+	value: string,
+	min: number | null,
+	max: number | null,
+) => {
+	/*
+		receives a number (as string in comma separated format), 
+						 the minimum value for the field or null
+						 the maximum value for the field or null
+		returns	
+						'tooSmall' when the value is < min
+						'tooBig' when the value is > max
+						'empty' when the field is empty
+	*/
+	if (value !== undefined) {
+		const numericValue = Number(value.replace(/,/g, ''));
+		if (min && numericValue < min) return 'tooSmall';
+		if (max && numericValue > max) return 'tooBig';
+		return undefined;
+	}
+	return 'empty';
+};

--- a/packages/forms/src/index.ts
+++ b/packages/forms/src/index.ts
@@ -15,3 +15,4 @@ export * from './renderFields';
 export * from './validation';
 export * from './finalFormExports';
 export * from './validators';
+export * from './elements/helpers';

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -33,10 +33,10 @@
 		"report-coverage": "codecov"
 	},
 	"peerDependencies": {
-		"@tpr/core": "~2.1.7",
-		"@tpr/forms": "~2.2.0",
-		"@tpr/icons": "~2.1.7",
-		"@tpr/theming": "~2.1.5",
+		"@tpr/core": "~2.2.4",
+		"@tpr/forms": "~2.3.9",
+		"@tpr/icons": "~2.2.6",
+		"@tpr/theming": "~2.2.2",
 		"react": "^16.12.0",
 		"react-dom": "^16.12.0"
 	},


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- `callback` function now only receives the value (type `number`) instead of the whole event. When the input field is empty, the returned value is `null`.

- Because the type of the input is text, the `min` & `max` props are not applied. 
If we define them, it won't make any difference because the input won't be able to display any error message out of the in-built `validate` function, the only thing that could do is not allowing the user to keep typing which can create more bugs. 
The solution is making use of `min` & `max` inside the `validate` prop. But when using `(value)` in `validate`, the type of value is `string`, therefore we need to use a separate function that will convert the `string` value to `number` and validate it according the `min` & `max` values needed.

- I've created a new `validateCurrency` inside the helpers functions, to handle this validation. Considering a starting case where the validate result can be one of 3 types (`value < min`, `value > max`, `!value`).
- `validateCurrency` receives` (value:string, min:number|null, max:number|null) `
- `validateCurrency` returns a `string` (`'tooSmall'`, `'tooBig'`, `'empty'`) depending on the result of the validation.
The `validateCurrency` function can be imported from `@tpr/forms`

- `validateCurrency` is just an option, having it as an example, we could create any different function and pass it to the validate prop of FFInputCurrency.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
