### PR TITLE
fixing bug on ffinputnumber #67637

### DIFF
--- a/packages/forms/src/elements/currency/currency.tsx
+++ b/packages/forms/src/elements/currency/currency.tsx
@@ -99,9 +99,8 @@ const InputCurrency: React.FC<InputCurrencyProps> = ({
 		if (!containsDecimals(e.target.value)) setDot(false);
 		e.target.value === '' && setInputValue('');
 		if (callback) {
-			const numericValue = parseToDecimals(
-				e.target.value.replace(/,/g, ''),
-				decimalPlaces,
+			const numericValue = Number(
+				parseToDecimals(e.target.value.replace(/,/g, ''), decimalPlaces),
 			);
 			e.target.value === ''
 				? callback(null)

--- a/packages/forms/src/elements/currency/currency.tsx
+++ b/packages/forms/src/elements/currency/currency.tsx
@@ -11,7 +11,7 @@ import {
 	fixToDecimals,
 	getNumDecimalPlaces,
 	appendMissingZeros,
-	parseToDecimals,
+	adaptValueToFormat,
 } from '../helpers';
 
 interface InputCurrencyProps extends FieldRenderProps<number>, FieldExtraProps {
@@ -100,7 +100,7 @@ const InputCurrency: React.FC<InputCurrencyProps> = ({
 		e.target.value === '' && setInputValue('');
 		if (callback) {
 			const numericValue = Number(
-				parseToDecimals(e.target.value.replace(/,/g, ''), decimalPlaces),
+				adaptValueToFormat(e.target.value.replace(/,/g, ''), decimalPlaces),
 			);
 			e.target.value === ''
 				? callback(null)

--- a/packages/forms/src/elements/helpers.ts
+++ b/packages/forms/src/elements/helpers.ts
@@ -16,7 +16,7 @@ export const firstDotPosition = (num: string): number => {
 	return num.indexOf('.');
 };
 
-export const parseToDecimals = (num: string, decimals: number): string => {
+export const adaptValueToFormat = (num: string, decimals: number): string => {
 	const firstDot = firstDotPosition(num);
 	// if contains decimals, only allow n number of decimals
 	// to avoid unnexpected rounds when using toFixed() in handleBlur

--- a/packages/forms/src/elements/helpers.ts
+++ b/packages/forms/src/elements/helpers.ts
@@ -16,14 +16,14 @@ export const firstDotPosition = (num: string): number => {
 	return num.indexOf('.');
 };
 
-export const parseToDecimals = (num: string, decimals: number): number => {
+export const parseToDecimals = (num: string, decimals: number): string => {
 	const firstDot = firstDotPosition(num);
 	// if contains decimals, only allow n number of decimals
 	// to avoid unnexpected rounds when using toFixed() in handleBlur
 	if (firstDot > -1) {
 		let newNum = num.slice(0, firstDot + decimals + 1);
-		return Number(newNum);
-	} else return Number(num);
+		return newNum;
+	} else return num;
 };
 
 export const fixToDecimals = (value: string, decimals: number): string => {

--- a/packages/forms/src/elements/number/number.mdx
+++ b/packages/forms/src/elements/number/number.mdx
@@ -133,7 +133,7 @@ import { Form, validate, renderFields } from '@tpr/forms';
 					return undefined;
 				},
 				noLeftBorder: true,
-				callback: (e) => console.log(.target.value),
+				callback: (e) => console.log(e.target.value),
 			},
 		];
 		return (

--- a/packages/forms/src/elements/number/number.mdx
+++ b/packages/forms/src/elements/number/number.mdx
@@ -50,17 +50,17 @@ import { FFInputNumber } from '@tpr/forms';
 					name="number_of_participants"
 					label="Number of participants"
 					hint="people attending this event, maximum of 20"
+					inputWidth={5}
+					cfg={{ my: 5 }}
+					required={true}
+					maxLength={2}
 					validate={(value) => {
 						if (value < 1 || value > 20 || !value || value === 0) {
 							return 'Must be between 1 and 20';
 						}
 						return undefined;
 					}}
-					inputWidth={5}
-					cfg={{ my: 5 }}
 					callback={(e) => console.log(e.target.value)}
-					required={true}
-					maxLength={2}
 				/>
 				<FFInputNumber
 					name="amount"
@@ -94,6 +94,7 @@ import { FFInputNumber } from '@tpr/forms';
 						if (value < 0 || value > 100)
 							return 'must be value between 0 and 100%';
 					}}
+					callback={(e) => console.log(e.target.value)}
 				/>
 				<button type="submit" style={{ display: 'none' }} children="Submit" />
 			</form>
@@ -132,6 +133,7 @@ import { Form, validate, renderFields } from '@tpr/forms';
 					return undefined;
 				},
 				noLeftBorder: true,
+				callback: (e) => console.log(.target.value),
 			},
 		];
 		return (

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -3,7 +3,7 @@ import { Field, FieldRenderProps } from 'react-final-form';
 import { StyledInputLabel, InputElementHeading } from '../elements';
 import { FieldProps, FieldExtraProps } from '../../renderFields';
 import { Input } from '../input/input';
-import { validKeys, parseToDecimals, fixToDecimals } from '../helpers';
+import { validKeys, adaptValueToFormat, fixToDecimals } from '../helpers';
 
 interface InputNumberProps extends FieldRenderProps<number>, FieldExtraProps {
 	after?: string;
@@ -55,7 +55,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 		decimalPlaces
 			? (newEvent.target.value =
 					e.target.value &&
-					parseToDecimals(newEvent.target.value, decimalPlaces))
+					adaptValueToFormat(newEvent.target.value, decimalPlaces))
 			: (newEvent.target.value =
 					e.target.value && parseInt(newEvent.target.value, 10).toString());
 		reachedMaxIntDigits(newEvent.target.value)

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -55,7 +55,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 		decimalPlaces
 			? (newEvent.target.value =
 					e.target.value &&
-					parseToDecimals(newEvent.target.value, decimalPlaces).toString())
+					parseToDecimals(newEvent.target.value, decimalPlaces))
 			: (newEvent.target.value =
 					e.target.value && parseInt(newEvent.target.value, 10).toString());
 		reachedMaxIntDigits(newEvent.target.value)


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

when typing a number with decimal places, after the '.' if the first number was zero, the input was removing the decimal places because parseToDecimals was returning a number value when called after every onChange.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
