### PR TITLE
changing onChange on FFInputNumber for fixing bug AB#67880

### DIFF
--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -60,22 +60,23 @@ const InputNumber: React.FC<InputNumberProps> = ({
 		let newEvent = { ...e };
 		// the value is processed only when is a valid value
 		if (e.target.value !== '' && e.target.value !== '-') {
-			// if decimalPlaces && value not null => e.target.value = adaptValueToFormat(value, decimalPlaces)
-			// if decimalPlaces && value is null => e.target.value = parseInt(value)
 			decimalPlaces
+			// if decimalPlaces => newEvent.target.value = adaptValueToFormat(value, decimalPlaces)
 				? (newEvent.target.value =
-						e.target.value &&
-						adaptValueToFormat(newEvent.target.value, decimalPlaces))
+					e.target.value &&
+					adaptValueToFormat(newEvent.target.value, decimalPlaces))
+					// if !decimalPlaces => newEvent.target.value = parseInt(value)
 				: (newEvent.target.value =
 						e.target.value && parseInt(newEvent.target.value, 10).toString());
 		}
 		// if the new value.length is greater than the maxLength
 		!valueLengthValid(newEvent.target.value) &&
 			(newEvent.target.value = prevValue);
-		// if the value of integers === maxIntDigits => e.target.value = prevValue
-		// if the value of integers < maxIntDigits => setPrevValue(e.target.value)
+
 		reachedMaxIntDigits(newEvent.target.value)
+			// if the value of integers === maxIntDigits => newEvent.target.value = prevValue
 			? (newEvent.target.value = prevValue)
+			// if the value of integers < maxIntDigits => setPrevValue(e.target.value)
 			: setPrevValue(newEvent.target.value);
 		// call input.onChange with the new value
 		input.onChange(newEvent.target.value);

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -3,7 +3,7 @@ import { Field, FieldRenderProps } from 'react-final-form';
 import { StyledInputLabel, InputElementHeading } from '../elements';
 import { FieldProps, FieldExtraProps } from '../../renderFields';
 import { Input } from '../input/input';
-import { validKeys, adaptValueToFormat, fixToDecimals } from '../helpers';
+import { adaptValueToFormat, fixToDecimals } from '../helpers';
 
 interface InputNumberProps extends FieldRenderProps<number>, FieldExtraProps {
 	after?: string;
@@ -44,22 +44,34 @@ const InputNumber: React.FC<InputNumberProps> = ({
 	};
 
 	const handleKeyDown = (e: any): void => {
-		e.target.value.length >= maxLength &&
-			!validKeys.includes(e.key) &&
-			e.preventDefault();
+		// avoid entering the number 'E'
 		e.key.toLowerCase() === 'e' && e.preventDefault();
+	};
+
+	const valueLengthValid = (value: string): boolean => {
+		// if maxLength specified, returns false when the length of the input is greater than maxLength
+		if (value.length > maxLength) {
+			return false;
+		}
+		return true;
 	};
 
 	const handleOnChange = (e: ChangeEvent<HTMLInputElement>): void => {
 		let newEvent = { ...e };
-		// if decimalPlaces && value not null => e.target.value = adaptValueToFormat(value, decimalPlaces)
-		// if decimalPlaces && value is null => e.target.value = parseInt(value)
-		decimalPlaces
-			? (newEvent.target.value =
-					e.target.value &&
-					adaptValueToFormat(newEvent.target.value, decimalPlaces))
-			: (newEvent.target.value =
-					e.target.value && parseInt(newEvent.target.value, 10).toString());
+		// the value is processed only when is a valid value
+		if (e.target.value !== '' && e.target.value !== '-') {
+			// if decimalPlaces && value not null => e.target.value = adaptValueToFormat(value, decimalPlaces)
+			// if decimalPlaces && value is null => e.target.value = parseInt(value)
+			decimalPlaces
+				? (newEvent.target.value =
+						e.target.value &&
+						adaptValueToFormat(newEvent.target.value, decimalPlaces))
+				: (newEvent.target.value =
+						e.target.value && parseInt(newEvent.target.value, 10).toString());
+		}
+		// if the new value.length is greater than the maxLength
+		!valueLengthValid(newEvent.target.value) &&
+			(newEvent.target.value = prevValue);
 		// if the value of integers === maxIntDigits => e.target.value = prevValue
 		// if the value of integers < maxIntDigits => setPrevValue(e.target.value)
 		reachedMaxIntDigits(newEvent.target.value)


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
https://dev.azure.com/thepensionsregulator/TPR/_workitems/edit/67880/

This update will fix a bug on `FFInputNumber` when the user has reached the `maxLength` of the input and when highlighting the value and trying to modify it, this was not possible unless the input value was deleted before.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
