### PR TITLE
Fixing bug on FFInputCurrency when reaching maxInputLength

### DIFF
--- a/packages/forms/src/elements/currency/currency.mdx
+++ b/packages/forms/src/elements/currency/currency.mdx
@@ -63,7 +63,42 @@ import { FFInputCurrency } from '@tpr/forms';
 							noLeftBorder={true}
 							optionalText={false}
 							callback={handleChange}
-							initialV={null}
+						/>
+						<button
+							type="submit"
+							style={{ display: 'none' }}
+							children="Submit"
+						/>
+					</form>
+				)}
+			</Form>
+		);
+	}}
+</Playground>
+
+### With initial value passed to the initialV prop
+
+<Playground>
+	{() => {
+		const handleChange = (value) => {
+			console.log(value);
+		};
+		return (
+			<Form onSubmit={(values) => console.log(values)}>
+				{({ handleSubmit }) => (
+					<form onSubmit={handleSubmit}>
+						<FFInputCurrency
+							name="income"
+							label="Annual income"
+							hint="total amount of income for last year, in GBP"
+							before="£"
+							inputWidth={5}
+							cfg={{ my: 5 }}
+							required={false}
+							noLeftBorder={true}
+							optionalText={false}
+							callback={handleChange}
+							initialV={15000000}
 						/>
 						<button
 							type="submit"

--- a/packages/forms/src/elements/currency/currency.tsx
+++ b/packages/forms/src/elements/currency/currency.tsx
@@ -75,15 +75,18 @@ const InputCurrency: React.FC<InputCurrencyProps> = ({
 		return numFormatted;
 	};
 
+	const keyPressedIsNotAllowed = (e: any): boolean => {
+		if (!digits.includes(e.key) && !validKeys.includes(e.key)) return true;
+		return false;
+	};
+
 	const handleKeyDown = (e: any) => {
 		// typing '.' when already exists one in the value
 		if (e.key === '.') {
 			dot ? e.preventDefault() : setDot(true);
 			return true;
 		}
-		// only allow valid keys
-		if (!digits.includes(e.key) && !validKeys.includes(e.key))
-			e.preventDefault();
+		keyPressedIsNotAllowed(e) && e.preventDefault();
 	};
 
 	const valueLengthValid = (value: string): boolean => {

--- a/packages/forms/src/elements/helpers.ts
+++ b/packages/forms/src/elements/helpers.ts
@@ -89,6 +89,23 @@ export const formatWithDecimals = (value: string, decimals: number): string => {
 	return intValueFormatted + decimalPart;
 };
 
+export const getFinalValueWithFormat = (
+	value: string,
+	decimals: number,
+): string => {
+	const newValueWithNoCommas = value.replace(/,/g, '');
+	if (firstDotPosition(newValueWithNoCommas) === -1) {
+		// if the value doesn't contain decimals, we return the value with the required format
+		const newValueWithDecimals = newValueWithNoCommas.concat(
+			'.',
+			new Array(decimals).fill('0').join(''),
+		);
+		const val = formatWithDecimals(newValueWithDecimals, decimals);
+		return val;
+	}
+	return value;
+};
+
 export const appendMissingZeros = (value: string, decimals: number): string => {
 	if (value !== '') {
 		let decimalPart = getDecimalPart(value, decimals);

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -61,12 +61,12 @@ const InputNumber: React.FC<InputNumberProps> = ({
 		// the value is processed only when is a valid value
 		if (e.target.value !== '' && e.target.value !== '-') {
 			decimalPlaces
-			// if decimalPlaces => newEvent.target.value = adaptValueToFormat(value, decimalPlaces)
-				? (newEvent.target.value =
-					e.target.value &&
-					adaptValueToFormat(newEvent.target.value, decimalPlaces))
-					// if !decimalPlaces => newEvent.target.value = parseInt(value)
-				: (newEvent.target.value =
+				? // if decimalPlaces => newEvent.target.value = adaptValueToFormat(value, decimalPlaces)
+				  (newEvent.target.value =
+						e.target.value &&
+						adaptValueToFormat(newEvent.target.value, decimalPlaces))
+				: // if !decimalPlaces => newEvent.target.value = parseInt(value)
+				  (newEvent.target.value =
 						e.target.value && parseInt(newEvent.target.value, 10).toString());
 		}
 		// if the new value.length is greater than the maxLength
@@ -74,10 +74,10 @@ const InputNumber: React.FC<InputNumberProps> = ({
 			(newEvent.target.value = prevValue);
 
 		reachedMaxIntDigits(newEvent.target.value)
-			// if the value of integers === maxIntDigits => newEvent.target.value = prevValue
-			? (newEvent.target.value = prevValue)
-			// if the value of integers < maxIntDigits => setPrevValue(e.target.value)
-			: setPrevValue(newEvent.target.value);
+			? // if the value of integers === maxIntDigits => newEvent.target.value = prevValue
+			  (newEvent.target.value = prevValue)
+			: // if the value of integers < maxIntDigits => setPrevValue(e.target.value)
+			  setPrevValue(newEvent.target.value);
 		// call input.onChange with the new value
 		input.onChange(newEvent.target.value);
 		// return the new value in the callback

--- a/packages/layout/src/components/helplink/helplink.tsx
+++ b/packages/layout/src/components/helplink/helplink.tsx
@@ -12,45 +12,45 @@ type HelpLinkProps = {
 };
 
 export const HelpLink: React.FC<HelpLinkProps> = (props) => {
-  // Use a separate component for the trigger so that we can set aria-expanded, and place the inline SVG inside the button
-  const [expanded, setExpanded] = React.useState(false);
-  const Trigger = () => (
-    <button aria-expanded={expanded}>
-      <ArrowDown />
+	// Use a separate component for the trigger so that we can set aria-expanded, and place the inline SVG inside the button
+	const [expanded, setExpanded] = React.useState(false);
+	const Trigger = () => (
+		<button aria-expanded={expanded}>
+			<ArrowDown />
 			{props.title}
-    </button>
-  );
+		</button>
+	);
 
-  // Create an alert when the component is expanded/collapsed, because the trigger button loses focus which prevents the change to aria-expanded being announced.
-  // Using a ref to get the button element and call its focus() method doesn't work.
-  const [accessibleAlert, setAccessibleAlert] = React.useState<JSX.Element>();
-  function createAccessibleAlert() {
-    return (
-      <p role="alert" className={Styles.visuallyHidden}>
-        {expanded ? 'collapsed' : 'expanded'}
-      </p>
-    );
-	}
-	
-	return (
-    <>
-		<Collapsible
-			trigger={<Trigger />}
-			classParentString={`${Styles.helpLink} ${props.className}`.trim()}
-			contentInnerClassName={`${Styles.helpLinkContent} ${props.contentClassName}`.trim()}
-			overflowWhenOpen="visible"
-			onOpening={() => {
-				setExpanded(true);
-				setAccessibleAlert(createAccessibleAlert());
-			}}
-			onClosing={() => {
-				setExpanded(false);
-				setAccessibleAlert(createAccessibleAlert());
-			}}
-		>
-			<Hint>{props.children}</Hint>
-		</Collapsible>
-		{accessibleAlert}
-		</>
+	// Create an alert when the component is expanded/collapsed, because the trigger button loses focus which prevents the change to aria-expanded being announced.
+	// Using a ref to get the button element and call its focus() method doesn't work.
+	const [accessibleAlert, setAccessibleAlert] = React.useState<JSX.Element>();
+	function createAccessibleAlert() {
+		return (
+			<p role="alert" className={Styles.visuallyHidden}>
+				{expanded ? 'collapsed' : 'expanded'}
+			</p>
 		);
+	}
+
+	return (
+		<>
+			<Collapsible
+				trigger={<Trigger />}
+				classParentString={`${Styles.helpLink} ${props.className}`.trim()}
+				contentInnerClassName={`${Styles.helpLinkContent} ${props.contentClassName}`.trim()}
+				overflowWhenOpen="visible"
+				onOpening={() => {
+					setExpanded(true);
+					setAccessibleAlert(createAccessibleAlert());
+				}}
+				onClosing={() => {
+					setExpanded(false);
+					setAccessibleAlert(createAccessibleAlert());
+				}}
+			>
+				<Hint>{props.children}</Hint>
+			</Collapsible>
+			{accessibleAlert}
+		</>
+	);
 };


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Changing the way that the input allows changing its value once the length of this is already the maximum allowed.
Before was controlled on the `onKeyDown` event. Now is in the` onChange` event, only keeping the change after checking if the new value is valid.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
