### PR TITLE
Bugfix/56780 support read only

### DIFF
--- a/packages/forms/src/__tests__/currency.spec.tsx
+++ b/packages/forms/src/__tests__/currency.spec.tsx
@@ -109,5 +109,16 @@ describe('Currency', () => {
 			fireEvent.blur(getByTestId(testId));
 			expect(getByTestId(testId)).toHaveValue('12,345.500');
 		});
+
+		test('renders readonly', () => {
+			const { queryByTestId } = formSetup({
+				render: (
+					<FFInputCurrency testId="text-input" name="name" readOnly={true} />
+				),
+			});
+
+			const label = queryByTestId('text-input');
+			expect(label).toHaveAttribute('readonly');
+		});
 	});
 });

--- a/packages/forms/src/__tests__/date.spec.tsx
+++ b/packages/forms/src/__tests__/date.spec.tsx
@@ -153,4 +153,37 @@ Object {
 `);
 		expect(handleSubmit).toBeCalledTimes(0);
 	});
+
+	test('date fields render readonly', () => {
+		const fields: FieldProps[] = [
+			{
+				name: 'date-1',
+				label: 'passport-expiry',
+				hint: 'For example, 12 11 2007',
+				type: 'date',
+				required: true,
+				readOnly: true,
+			},
+		];
+		const handleSubmit = jest.fn();
+		const { container } = formSetup({
+			render: renderFields(fields),
+			validate: validate(fields),
+			onSubmit: handleSubmit,
+		});
+
+		const dd = container.querySelector(
+			'input[aria-label="dd-passport-expiry"]',
+		);
+		const mm = container.querySelector(
+			'input[aria-label="mm-passport-expiry"]',
+		);
+		const yyyy = container.querySelector(
+			'input[aria-label="yyyy-passport-expiry"]',
+		);
+
+		expect(dd).toHaveAttribute('readonly');
+		expect(mm).toHaveAttribute('readonly');
+		expect(yyyy).toHaveAttribute('readonly');
+	});
 });

--- a/packages/forms/src/__tests__/email.spec.tsx
+++ b/packages/forms/src/__tests__/email.spec.tsx
@@ -79,4 +79,13 @@ describe('Email input', () => {
 		expect(queryByText(errorMessage)).toBeInTheDocument();
 		expect(form.getState().valid).toBeFalsy();
 	});
+
+	test('renders readonly', () => {
+		const { queryByTestId } = formSetup({
+			render: <FFInputEmail testId="text-input" name="name" readOnly={true} />,
+		});
+
+		const label = queryByTestId('text-input');
+		expect(label).toHaveAttribute('readonly');
+	});
 });

--- a/packages/forms/src/__tests__/number.spec.tsx
+++ b/packages/forms/src/__tests__/number.spec.tsx
@@ -132,5 +132,16 @@ describe('Number', () => {
 			fireEvent.blur(getByTestId(testId));
 			expect(getByTestId(testId)).toHaveValue(-123.12);
 		});
+
+		test('renders readonly', () => {
+			const { queryByTestId } = formSetup({
+				render: (
+					<FFInputNumber testId="text-input" name="name" readOnly={true} />
+				),
+			});
+
+			const label = queryByTestId('text-input');
+			expect(label).toHaveAttribute('readonly');
+		});
 	});
 });

--- a/packages/forms/src/__tests__/phone.spec.tsx
+++ b/packages/forms/src/__tests__/phone.spec.tsx
@@ -91,4 +91,13 @@ describe('Phone input', () => {
 		expect(queryByText(errorMessage)).toBeInTheDocument();
 		expect(form.getState().valid).toBeFalsy();
 	});
+
+	test('renders readonly', () => {
+		const { queryByTestId } = formSetup({
+			render: <FFInputPhone testId="text-input" name="name" readOnly={true} />,
+		});
+
+		const label = queryByTestId('text-input');
+		expect(label).toHaveAttribute('readonly');
+	});
 });

--- a/packages/forms/src/__tests__/select.spec.tsx
+++ b/packages/forms/src/__tests__/select.spec.tsx
@@ -59,4 +59,32 @@ describe('Select input', () => {
 			expect(getByText(item.label)).toBeDefined();
 		});
 	});
+
+	test('renders readonly', () => {
+		const testId = 'select-input';
+		const items = [
+			{ label: 'apple', value: 'apple' },
+			{ label: 'pear', value: 'pear' },
+			{ label: 'orange', value: 'orange' },
+			{ label: 'grape', value: 'grape' },
+			{ label: 'banana', value: 'banana' },
+		];
+
+		const { queryByTestId } = formSetup({
+			render: (
+				<FFSelect
+					label="Select your favourite fruit"
+					testId={testId}
+					name="fruits"
+					error="required"
+					required={true}
+					options={items}
+					readOnly={true}
+				/>
+			),
+		});
+
+		const label = queryByTestId(testId);
+		expect(label).toHaveAttribute('readonly');
+	});
 });

--- a/packages/forms/src/__tests__/text.spec.tsx
+++ b/packages/forms/src/__tests__/text.spec.tsx
@@ -118,4 +118,20 @@ describe('Text input', () => {
 		}
 	`);
 	});
+
+	test('renders readonly', () => {
+		const { queryByTestId } = formSetup({
+			render: (
+				<FFInputText
+					testId="text-input"
+					name="name"
+					type="text"
+					readOnly={true}
+				/>
+			),
+		});
+
+		const label = queryByTestId('text-input');
+		expect(label).toHaveAttribute('readonly');
+	});
 });

--- a/packages/forms/src/elements/currency/currency.tsx
+++ b/packages/forms/src/elements/currency/currency.tsx
@@ -34,6 +34,7 @@ const InputCurrency: React.FC<InputCurrencyProps> = ({
 	meta,
 	required,
 	placeholder,
+	readOnly,
 	inputWidth: width,
 	cfg,
 	after,
@@ -164,6 +165,7 @@ const InputCurrency: React.FC<InputCurrencyProps> = ({
 				label={label}
 				touched={meta && meta.touched && meta.error}
 				placeholder={placeholder}
+				readOnly={readOnly}
 				decimalPlaces={decimalPlaces}
 				{...input}
 				onKeyDown={handleKeyDown}

--- a/packages/forms/src/elements/date/date.mdx
+++ b/packages/forms/src/elements/date/date.mdx
@@ -80,10 +80,11 @@ Accepted config props: FlexProps, SpaceProps
 
 ### Props
 
-| Property | Required | Type    | Description                                  |
-| -------- | -------- | ------- | -------------------------------------------- |
-| cfg      | false    | object  | FlexProps & SpaceProps                       |
-| disabled | false    | boolean | Disable checkbox                             |
-| testId   | false    | string  | data attribute for testers                   |
-| label    | true     | string  | Checkbox description                         |
-| hint     | false    | string  | More detailed description about the checkbox |
+| Property | Required | Type    | Description                                    |
+| -------- | -------- | ------- | --------------------------------------------   |
+| cfg      | false    | object  | FlexProps & SpaceProps                         |
+| disabled | false    | boolean | Disable date field                             |
+| testId   | false    | string  | data attribute for testers                     |
+| label    | true     | string  | Date field description                         |
+| hint     | false    | string  | More detailed description about the date field |
+| readOnly | false    | boolean | Sets whether the field is read only            |

--- a/packages/forms/src/elements/date/date.tsx
+++ b/packages/forms/src/elements/date/date.tsx
@@ -48,6 +48,7 @@ type DateInputFieldProps = {
 	meta: any;
 	label: string;
 	disabled?: boolean;
+	readOnly: boolean;
 };
 const DateInputField: React.FC<DateInputFieldProps> = ({
 	small = true,
@@ -61,6 +62,7 @@ const DateInputField: React.FC<DateInputFieldProps> = ({
 	onBlur,
 	meta,
 	disabled,
+	readOnly
 }) => {
 	return (
 		<label className={small ? styles.inputSmall : styles.inputLarge}>
@@ -71,6 +73,7 @@ const DateInputField: React.FC<DateInputFieldProps> = ({
 				aria-label={ariaLabel}
 				data-testid={testId}
 				value={value}
+				readOnly={readOnly}
 				onFocus={({ target }: ChangeEvent<HTMLInputElement>) => target.select()}
 				onChange={handleChange(updateFn, maxInt)}
 				onBlur={(evt: ChangeEvent<HTMLInputElement>) => {

--- a/packages/forms/src/elements/date/date.tsx
+++ b/packages/forms/src/elements/date/date.tsx
@@ -48,7 +48,7 @@ type DateInputFieldProps = {
 	meta: any;
 	label: string;
 	disabled?: boolean;
-	readOnly: boolean;
+	readOnly?: boolean;
 };
 const DateInputField: React.FC<DateInputFieldProps> = ({
 	small = true,
@@ -62,7 +62,7 @@ const DateInputField: React.FC<DateInputFieldProps> = ({
 	onBlur,
 	meta,
 	disabled,
-	readOnly
+	readOnly,
 }) => {
 	return (
 		<label className={small ? styles.inputSmall : styles.inputLarge}>
@@ -91,7 +91,17 @@ const DateInputField: React.FC<DateInputFieldProps> = ({
 
 type InputDateProps = FieldRenderProps<string> & FieldExtraProps;
 export const InputDate: React.FC<InputDateProps> = memo(
-	({ label, hint, required, input, meta, testId = 'field', cfg, disabled }) => {
+	({
+		label,
+		hint,
+		required,
+		input,
+		meta,
+		testId = 'field',
+		cfg,
+		disabled,
+		readOnly,
+	}) => {
 		// react-final-form types says it's a string, incorrect, it's a date object.
 		const { dd, mm, yyyy } = transformDate(meta.initial);
 		const [{ dd: day, mm: month, yyyy: year }, setState] = useReducer(
@@ -144,6 +154,7 @@ export const InputDate: React.FC<InputDateProps> = memo(
 						onBlur={input.onBlur}
 						meta={meta}
 						disabled={disabled}
+						readOnly={readOnly}
 					/>
 					<DateInputField
 						label="Month"
@@ -156,6 +167,7 @@ export const InputDate: React.FC<InputDateProps> = memo(
 						onBlur={input.onBlur}
 						meta={meta}
 						disabled={disabled}
+						readOnly={readOnly}
 					/>
 					<DateInputField
 						label="Year"
@@ -169,6 +181,7 @@ export const InputDate: React.FC<InputDateProps> = memo(
 						onBlur={input.onBlur}
 						meta={meta}
 						disabled={disabled}
+						readOnly={readOnly}
 					/>
 				</Flex>
 			</StyledInputLabel>

--- a/packages/forms/src/elements/email/email.mdx
+++ b/packages/forms/src/elements/email/email.mdx
@@ -77,10 +77,11 @@ Accepted config props: FlexProps, SpaceProps
 
 ### Props
 
-| Property | Required | Type    | Description                                  |
-| -------- | -------- | ------- | -------------------------------------------- |
-| cfg      | false    | object  | FlexProps & SpaceProps                       |
-| disabled | false    | boolean | Disable checkbox                             |
-| testId   | false    | string  | data attribute for testers                   |
-| label    | true     | string  | Checkbox description                         |
-| hint     | false    | string  | More detailed description about the checkbox |
+| Property | Required | Type    | Description                                     |
+| -------- | -------- | ------- | --------------------------------------------    |
+| cfg      | false    | object  | FlexProps & SpaceProps                          |
+| disabled | false    | boolean | Disable email field                             |
+| testId   | false    | string  | data attribute for testers                      |
+| label    | true     | string  | Email field description                         |
+| hint     | false    | string  | More detailed description about the email field |
+| readOnly | false    | boolean | Sets whether the field is read only             |

--- a/packages/forms/src/elements/email/email.tsx
+++ b/packages/forms/src/elements/email/email.tsx
@@ -18,6 +18,7 @@ const InputEmail: React.FC<InputEmailProps> = ({
 	meta,
 	required,
 	placeholder,
+	readOnly,
 	inputWidth: width,
 	cfg,
 }) => {
@@ -39,6 +40,7 @@ const InputEmail: React.FC<InputEmailProps> = ({
 				label={label}
 				required={required}
 				placeholder={placeholder}
+				readOnly={readOnly}
 				touched={meta && meta.touched && meta.error}
 				{...input}
 			/>

--- a/packages/forms/src/elements/input/input.tsx
+++ b/packages/forms/src/elements/input/input.tsx
@@ -11,6 +11,7 @@ export type InputProps = {
 	before?: string;
 	decimalPlaces?: number;
 	parentRef?: any;
+	readOnly?: boolean;
 	[key: string]: any;
 };
 export const Input: React.FC<InputProps> = ({
@@ -20,6 +21,7 @@ export const Input: React.FC<InputProps> = ({
 	label,
 	touched = false,
 	className,
+	readOnly,
 	after: After,
 	before: Before,
 	decimalPlaces,
@@ -37,6 +39,7 @@ export const Input: React.FC<InputProps> = ({
 				type={type}
 				data-testid={testId}
 				aria-label={label}
+				readOnly={readOnly}
 				step={
 					type !== 'number'
 						? null

--- a/packages/forms/src/elements/number/number.mdx
+++ b/packages/forms/src/elements/number/number.mdx
@@ -176,3 +176,4 @@ Accepted config props: FlexProps, SpaceProps
 | noLeftBorder  | false    | boolean  | disables the left border when detecting error                                  |
 | optionalText  | false    | boolean  | allows hiding "optional" text when field is not required                       |
 | testId        | false    | string   | data attribute for testers                                                     |
+| readOnly      | false    | boolean  | Sets whether the field is read only                                            |

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -24,6 +24,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 	meta,
 	required,
 	placeholder,
+	readOnly,
 	inputWidth: width,
 	cfg,
 	after,
@@ -110,6 +111,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 				label={label}
 				touched={meta && meta.touched && meta.error}
 				placeholder={placeholder}
+				readOnly={readOnly}
 				decimalPlaces={decimalPlaces}
 				{...input}
 				onKeyDown={handleKeyDown}

--- a/packages/forms/src/elements/phone/phone.mdx
+++ b/packages/forms/src/elements/phone/phone.mdx
@@ -77,10 +77,11 @@ Accepted config props: FlexProps, SpaceProps
 
 ### Props
 
-| Property | Required | Type    | Description                                  |
-| -------- | -------- | ------- | -------------------------------------------- |
-| cfg      | false    | object  | FlexProps & SpaceProps                       |
-| disabled | false    | boolean | Disable checkbox                             |
-| testId   | false    | string  | data attribute for testers                   |
-| label    | true     | string  | Checkbox description                         |
-| hint     | false    | string  | More detailed description about the checkbox |
+| Property | Required | Type    | Description                                     |
+| -------- | -------- | ------- | --------------------------------------------    |
+| cfg      | false    | object  | FlexProps & SpaceProps                          |
+| disabled | false    | boolean | Disable phone field                             |
+| testId   | false    | string  | data attribute for testers                      |
+| label    | true     | string  | Phone field description                         |
+| hint     | false    | string  | More detailed description about the phone field |
+| readOnly | false    | boolean | Sets whether the field is read only             |

--- a/packages/forms/src/elements/phone/phone.tsx
+++ b/packages/forms/src/elements/phone/phone.tsx
@@ -18,6 +18,7 @@ const InputPhone: React.FC<InputPhoneProps> = ({
 	meta,
 	required,
 	placeholder,
+	readOnly,
 	inputWidth: width,
 	cfg,
 }) => {
@@ -38,6 +39,7 @@ const InputPhone: React.FC<InputPhoneProps> = ({
 				testId={testId}
 				label={label}
 				placeholder={placeholder}
+				readOnly={readOnly}
 				touched={meta && meta.touched && meta.error}
 				required={required}
 				{...input}

--- a/packages/forms/src/elements/select/select.mdx
+++ b/packages/forms/src/elements/select/select.mdx
@@ -90,6 +90,6 @@ Accepted config props: FlexProps, SpaceProps
 | Property | Required | Type    | Description                                 |
 | -------- | -------- | ------- | ------------------------------------------- |
 | cfg      | false    | object  | FlexProps & SpaceProps                      |
-| disabled | false    | boolean | Disable checkbox                            |
+| disabled | false    | boolean | Disable the select                          |
 | testId   | false    | string  | data attribute for testers                  |
-| checked  | true     | boolean | Specifies whether the checkbox is selected. |
+| readOnly | false    | boolean | Specifies whether the control is read only like a select, or editable like a combobox. |

--- a/packages/forms/src/elements/select/select.tsx
+++ b/packages/forms/src/elements/select/select.tsx
@@ -35,6 +35,7 @@ export const Select: React.FC<SelectProps & FieldRenderProps<string>> = ({
 	testId = 'select',
 	showToggleButton = true,
 	placeholder,
+	readOnly,
 	inputWidth: width,
 	cfg,
 	...rest
@@ -78,6 +79,7 @@ export const Select: React.FC<SelectProps & FieldRenderProps<string>> = ({
 								label={label}
 								disabled={disabled}
 								placeholder={placeholder}
+								readOnly={readOnly}
 								onClick={() => toggleMenu()}
 								{...getInputProps()}
 							/>

--- a/packages/forms/src/elements/text/text.mdx
+++ b/packages/forms/src/elements/text/text.mdx
@@ -131,4 +131,5 @@ Although neither `label` or `ariaLabel` are required props, you should always us
 | testId   | false    | string  | data attribute for testers                     |
 | label    | false    | string  | Visible field label                            |
 | ariaLabel| false    | string  | Invisible field label for assistive technology |
-| hint     | false    | string  | More detailed description about the checkbox   |
+| hint     | false    | string  | More detailed description about the text field |
+| readOnly | false    | boolean | Sets whether the field is read only            |

--- a/packages/forms/src/elements/text/text.tsx
+++ b/packages/forms/src/elements/text/text.tsx
@@ -14,6 +14,7 @@ const InputText: React.FC<InputTextProps> = ({
 	meta,
 	required,
 	placeholder,
+	readOnly,
 	inputWidth: width,
 	cfg,
 }) => {
@@ -34,6 +35,7 @@ const InputText: React.FC<InputTextProps> = ({
 				testId={testId}
 				label={ariaLabel ? ariaLabel : label}
 				placeholder={placeholder}
+				readOnly={readOnly}
 				touched={meta && meta.touched && meta.error}
 				{...input}
 			/>

--- a/packages/forms/src/renderFields.tsx
+++ b/packages/forms/src/renderFields.tsx
@@ -35,6 +35,7 @@ export type FieldExtraProps = {
 	hint?: string;
 	/** for radio buttons */
 	checked?: boolean;
+	readOnly?: boolean;
 	/** argument for tests */
 	testId?: string;
 	/** options for Select input field */


### PR DESCRIPTION
#### Fixes AB#56780

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

AB#56780 requires `<FFSelect />` to support the HTML `readonly` attribute.  This needed to be added to `FieldExtraProps`. Rather than make this property available to all relevant field types but only have it function on one, I've enabled support for the `readonly` attribute on all relevant field types.
