### PR TITLE
fixing bug where validateCurrency receives a value of type number

### DIFF
--- a/packages/forms/src/elements/helpers.ts
+++ b/packages/forms/src/elements/helpers.ts
@@ -134,7 +134,7 @@ export const validateCurrency = (
 						'empty' when the field is empty
 	*/
 	if (value !== undefined && value !== null) {
-		const numericValue = Number(value.replace(/,/g, ''));
+		const numericValue = Number(value.toString().replace(/,/g, ''));
 		if (min && numericValue < min) return 'tooSmall';
 		if (max && numericValue > max) return 'tooBig';
 		return undefined;


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Event though `validateCurrency` specifies that must receive `value:string`, when used in conjunction with `initialValues` of the `Form` component, there is the possibility that will replace the `value` of `FFInputCurrency` to a one of type `number`.
For this reason, when calling `.replace()` will provoke an error because it's a function for the `string` type.
This can be fix by making sure of converting `value` to `string` using the `toString()` function.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
