### PR TITLE
Defect/66184 select first item on loading dropdown

### DIFF
--- a/packages/layout/src/components/cards/common/interfaces.ts
+++ b/packages/layout/src/components/cards/common/interfaces.ts
@@ -86,6 +86,7 @@ export interface PostcodeProps {
 	showLookup: Function;
 	setLoading: Function;
 	setOptions: Function;
+	setInitialValue?:Function;
 	addressAPI: any;
 	i18n: any;
 }
@@ -111,6 +112,7 @@ export type AutoCompleteProps = {
 	onClick: (evt: any) => void;
 	options: any[];
 	loading: boolean;
+	initialValue?:[key:string]
 };
 
 export type AddressAPIType = {

--- a/packages/layout/src/components/cards/common/interfaces.ts
+++ b/packages/layout/src/components/cards/common/interfaces.ts
@@ -86,7 +86,7 @@ export interface PostcodeProps {
 	showLookup: Function;
 	setLoading: Function;
 	setOptions: Function;
-	setInitialValue?:Function;
+	setSelectedItem?:Function;
 	addressAPI: any;
 	i18n: any;
 }
@@ -112,7 +112,7 @@ export type AutoCompleteProps = {
 	onClick: (evt: any) => void;
 	options: any[];
 	loading: boolean;
-	initialValue?:{ [key: string]: string };
+	selectedItem?:any;
 };
 
 export type AddressAPIType = {

--- a/packages/layout/src/components/cards/common/interfaces.ts
+++ b/packages/layout/src/components/cards/common/interfaces.ts
@@ -112,7 +112,7 @@ export type AutoCompleteProps = {
 	onClick: (evt: any) => void;
 	options: any[];
 	loading: boolean;
-	initialValue?:[key:string]
+	initialValue?:{ [key: string]: string };
 };
 
 export type AddressAPIType = {

--- a/packages/layout/src/components/cards/common/views/address/AutoCompleteForm.tsx
+++ b/packages/layout/src/components/cards/common/views/address/AutoCompleteForm.tsx
@@ -33,6 +33,8 @@ const AutoCompleteForm: React.FC<AutoCompleteFormProps> = ({
 						validate={(value) => (!value ? dropdown.error : undefined)}
 						disabled={loading || submitLoading}
 						initialValue = {initialValue}
+						selectedItem ={initialValue}
+						inputValue={initialValue && initialValue.singleLineAddress}
 					/>
 					<Link onClick={onClick} cfg={{ mt: 3 }}>
 						{dropdown.link}

--- a/packages/layout/src/components/cards/common/views/address/AutoCompleteForm.tsx
+++ b/packages/layout/src/components/cards/common/views/address/AutoCompleteForm.tsx
@@ -30,7 +30,7 @@ const AutoCompleteForm: React.FC<AutoCompleteFormProps> = ({
 						placeholder={dropdown.placeholder}
 						options={options}
 						inputWidth={6}
-						validate={(value) => !value || (!(Object.keys(value).length > 0) ? dropdown.error : undefined)}
+						validate={(value) => (!value || (!(Object.keys(value).length > 0)) ? dropdown.error : undefined)}
 						disabled={loading || submitLoading}
 						selectedItem = {selectedItem}
 					/>

--- a/packages/layout/src/components/cards/common/views/address/AutoCompleteForm.tsx
+++ b/packages/layout/src/components/cards/common/views/address/AutoCompleteForm.tsx
@@ -14,7 +14,7 @@ interface AutoCompleteFormProps extends AutoCompleteProps {
 const AutoCompleteForm: React.FC<AutoCompleteFormProps> = ({
 	onClick,
 	options,
-	initialValue,
+	selectedItem,
 	loading,
 	onSubmit,
 	dropdown,
@@ -30,11 +30,9 @@ const AutoCompleteForm: React.FC<AutoCompleteFormProps> = ({
 						placeholder={dropdown.placeholder}
 						options={options}
 						inputWidth={6}
-						validate={(value) => (!value ? dropdown.error : undefined)}
+						validate={(value) => !value || (!(Object.keys(value).length > 0) ? dropdown.error : undefined)}
 						disabled={loading || submitLoading}
-						initialValue = {initialValue}
-						selectedItem ={initialValue}
-						inputValue={initialValue && initialValue.singleLineAddress}
+						selectedItem = {selectedItem}
 					/>
 					<Link onClick={onClick} cfg={{ mt: 3 }}>
 						{dropdown.link}

--- a/packages/layout/src/components/cards/common/views/address/AutoCompleteForm.tsx
+++ b/packages/layout/src/components/cards/common/views/address/AutoCompleteForm.tsx
@@ -14,6 +14,7 @@ interface AutoCompleteFormProps extends AutoCompleteProps {
 const AutoCompleteForm: React.FC<AutoCompleteFormProps> = ({
 	onClick,
 	options,
+	initialValue,
 	loading,
 	onSubmit,
 	dropdown,
@@ -31,6 +32,7 @@ const AutoCompleteForm: React.FC<AutoCompleteFormProps> = ({
 						inputWidth={6}
 						validate={(value) => (!value ? dropdown.error : undefined)}
 						disabled={loading || submitLoading}
+						initialValue = {initialValue}
 					/>
 					<Link onClick={onClick} cfg={{ mt: 3 }}>
 						{dropdown.link}

--- a/packages/layout/src/components/cards/common/views/address/Postcode.tsx
+++ b/packages/layout/src/components/cards/common/views/address/Postcode.tsx
@@ -13,7 +13,7 @@ const Postcode: React.FC<PostcodeProps> = ({
 	showLookup,
 	setLoading,
 	setOptions,
-	setInitialValue,
+	setSelectedItem,
 	addressAPI,
 	i18n,
 }) => {
@@ -60,7 +60,7 @@ const Postcode: React.FC<PostcodeProps> = ({
 							}),
 						).then((results) => {
 							setOptions(results);
-							setInitialValue(results ? results[0]:{})
+							setSelectedItem(results ? results[0]:{})
 							showLookup(false);
 							setLoading(false);
 						});
@@ -73,7 +73,7 @@ const Postcode: React.FC<PostcodeProps> = ({
 					setLoading(false);
 				});
 		},
-		[setOptions, setInitialValue],
+		[setOptions, setSelectedItem],
 	);
 
 	useEffect(() => {
@@ -111,7 +111,7 @@ const Postcode: React.FC<PostcodeProps> = ({
 									)
 								) {
 									setPostcode(utils.values.postcode);
-									setInitialValue({});
+									setSelectedItem({});
 									search(utils.values.postcode);
 								}
 							}}

--- a/packages/layout/src/components/cards/common/views/address/Postcode.tsx
+++ b/packages/layout/src/components/cards/common/views/address/Postcode.tsx
@@ -13,6 +13,7 @@ const Postcode: React.FC<PostcodeProps> = ({
 	showLookup,
 	setLoading,
 	setOptions,
+	setInitialValue,
 	addressAPI,
 	i18n,
 }) => {
@@ -59,6 +60,7 @@ const Postcode: React.FC<PostcodeProps> = ({
 							}),
 						).then((results) => {
 							setOptions(results);
+							setInitialValue(results ? results[0]:{})
 							showLookup(false);
 							setLoading(false);
 						});
@@ -71,7 +73,7 @@ const Postcode: React.FC<PostcodeProps> = ({
 					setLoading(false);
 				});
 		},
-		[setOptions],
+		[setOptions, setInitialValue],
 	);
 
 	useEffect(() => {

--- a/packages/layout/src/components/cards/common/views/address/Postcode.tsx
+++ b/packages/layout/src/components/cards/common/views/address/Postcode.tsx
@@ -111,6 +111,7 @@ const Postcode: React.FC<PostcodeProps> = ({
 									)
 								) {
 									setPostcode(utils.values.postcode);
+									setInitialValue({});
 									search(postcode);
 								}
 							}}

--- a/packages/layout/src/components/cards/common/views/address/Postcode.tsx
+++ b/packages/layout/src/components/cards/common/views/address/Postcode.tsx
@@ -112,7 +112,7 @@ const Postcode: React.FC<PostcodeProps> = ({
 								) {
 									setPostcode(utils.values.postcode);
 									setInitialValue({});
-									search(postcode);
+									search(utils.values.postcode);
 								}
 							}}
 							disabled={
@@ -129,7 +129,10 @@ const Postcode: React.FC<PostcodeProps> = ({
 			) : (
 				<Flex>
 					<P cfg={{ mr: 2 }}>{postcode}</P>
-					<Link onClick={() => showLookup(true)} underline>
+					<Link onClick={() => {
+						debugger;
+						showLookup(true)
+					}} underline>
 						{i18n.address.postcode.link}
 					</Link>
 				</Flex>

--- a/packages/layout/src/components/cards/common/views/address/Postcode.tsx
+++ b/packages/layout/src/components/cards/common/views/address/Postcode.tsx
@@ -130,7 +130,6 @@ const Postcode: React.FC<PostcodeProps> = ({
 				<Flex>
 					<P cfg={{ mr: 2 }}>{postcode}</P>
 					<Link onClick={() => {
-						debugger;
 						showLookup(true)
 					}} underline>
 						{i18n.address.postcode.link}

--- a/packages/layout/src/components/cards/inHouse/views/address/AutoComplete.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/address/AutoComplete.tsx
@@ -7,6 +7,7 @@ const AutoComplete: React.FC<AutoCompleteProps> = ({
 	onClick,
 	options,
 	loading,
+	initialValue,
 }) => {
 	const [submitLoading, setSubmitLoading] = useState(false);
 	const { send, i18n, current, onSaveAddress } = useInHouseAdminContext();
@@ -33,6 +34,7 @@ const AutoComplete: React.FC<AutoCompleteProps> = ({
 		<AutoCompleteForm
 			onClick={onClick}
 			options={options}
+			initialValue = {initialValue}
 			loading={loading}
 			onSubmit={onSubmit}
 			dropdown={i18n.address.auto.dropdown}

--- a/packages/layout/src/components/cards/inHouse/views/address/AutoComplete.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/address/AutoComplete.tsx
@@ -7,7 +7,7 @@ const AutoComplete: React.FC<AutoCompleteProps> = ({
 	onClick,
 	options,
 	loading,
-	initialValue,
+	selectedItem,
 }) => {
 	const [submitLoading, setSubmitLoading] = useState(false);
 	const { send, i18n, current, onSaveAddress } = useInHouseAdminContext();
@@ -34,7 +34,7 @@ const AutoComplete: React.FC<AutoCompleteProps> = ({
 		<AutoCompleteForm
 			onClick={onClick}
 			options={options}
-			initialValue = {initialValue}
+			selectedItem = {selectedItem}
 			loading={loading}
 			onSubmit={onSubmit}
 			dropdown={i18n.address.auto.dropdown}

--- a/packages/layout/src/components/cards/inHouse/views/address/index.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/address/index.tsx
@@ -44,7 +44,7 @@ const { loading, manual, postcode, lookup, options, initialValue } = state;
 							showLookup={(lookup: boolean) => setState({ lookup })}
 							setLoading={(loading: boolean) => setState({ loading })}
 							setOptions={(options: any[]) => setState({ options })}
-							setInitialValue={(initialValue:[key:string])=>setState({initialValue})}
+							setInitialValue={(initialValue:any)=>setState({initialValue})}
 							addressAPI={addressAPI}
 							i18n={i18n}
 						/>

--- a/packages/layout/src/components/cards/inHouse/views/address/index.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/address/index.tsx
@@ -18,9 +18,10 @@ export const AddressPage: React.FC = () => {
 		postcode: inHouseAdmin.address.postcode,
 		lookup: false,
 		options: [],
+		initialValue:{},
 	});
-	const { loading, manual, postcode, lookup, options } = state;
 
+const { loading, manual, postcode, lookup, options, initialValue } = state;
 	return (
 		<Content
 			type={cardType.inHouseAdmin}
@@ -43,6 +44,7 @@ export const AddressPage: React.FC = () => {
 							showLookup={(lookup: boolean) => setState({ lookup })}
 							setLoading={(loading: boolean) => setState({ loading })}
 							setOptions={(options: any[]) => setState({ options })}
+							setInitialValue={(initialValue:[key:string])=>setState({initialValue})}
 							addressAPI={addressAPI}
 							i18n={i18n}
 						/>
@@ -56,6 +58,7 @@ export const AddressPage: React.FC = () => {
 					<AutoComplete
 						loading={loading}
 						options={options}
+						initialValue={initialValue}
 						onClick={() => setState({ manual: true })}
 					/>
 				)}

--- a/packages/layout/src/components/cards/inHouse/views/address/index.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/address/index.tsx
@@ -18,10 +18,10 @@ export const AddressPage: React.FC = () => {
 		postcode: inHouseAdmin.address.postcode,
 		lookup: false,
 		options: [],
-		initialValue:{},
+		selectedItem:{},
 	});
 
-const { loading, manual, postcode, lookup, options, initialValue } = state;
+const { loading, manual, postcode, lookup, options, selectedItem } = state;
 	return (
 		<Content
 			type={cardType.inHouseAdmin}
@@ -44,7 +44,7 @@ const { loading, manual, postcode, lookup, options, initialValue } = state;
 							showLookup={(lookup: boolean) => setState({ lookup })}
 							setLoading={(loading: boolean) => setState({ loading })}
 							setOptions={(options: any[]) => setState({ options })}
-							setInitialValue={(initialValue:any)=>setState({initialValue})}
+							setSelectedItem={(selectedItem:any)=>setState({selectedItem})}
 							addressAPI={addressAPI}
 							i18n={i18n}
 						/>
@@ -58,7 +58,7 @@ const { loading, manual, postcode, lookup, options, initialValue } = state;
 					<AutoComplete
 						loading={loading}
 						options={options}
-						initialValue={initialValue}
+						selectedItem ={selectedItem}
 						onClick={() => setState({ manual: true })}
 					/>
 				)}

--- a/packages/layout/src/components/cards/trustee/views/address/AutoComplete.tsx
+++ b/packages/layout/src/components/cards/trustee/views/address/AutoComplete.tsx
@@ -6,6 +6,7 @@ import AutoCompleteForm from '../../../common/views/address/AutoCompleteForm';
 const AutoComplete: React.FC<AutoCompleteProps> = ({
 	onClick,
 	options,
+	initialValue,
 	loading,
 }) => {
 	const { send, i18n } = useTrusteeContext();
@@ -20,6 +21,7 @@ const AutoComplete: React.FC<AutoCompleteProps> = ({
 		<AutoCompleteForm
 			onClick={onClick}
 			options={options}
+			initialValue = {initialValue}
 			loading={loading}
 			onSubmit={onSubmit}
 			dropdown={i18n.address.auto.dropdown}

--- a/packages/layout/src/components/cards/trustee/views/address/AutoComplete.tsx
+++ b/packages/layout/src/components/cards/trustee/views/address/AutoComplete.tsx
@@ -6,7 +6,7 @@ import AutoCompleteForm from '../../../common/views/address/AutoCompleteForm';
 const AutoComplete: React.FC<AutoCompleteProps> = ({
 	onClick,
 	options,
-	initialValue,
+	selectedItem,
 	loading,
 }) => {
 	const { send, i18n } = useTrusteeContext();
@@ -21,7 +21,7 @@ const AutoComplete: React.FC<AutoCompleteProps> = ({
 		<AutoCompleteForm
 			onClick={onClick}
 			options={options}
-			initialValue = {initialValue}
+			selectedItem = {selectedItem}
 			loading={loading}
 			onSubmit={onSubmit}
 			dropdown={i18n.address.auto.dropdown}

--- a/packages/layout/src/components/cards/trustee/views/address/index.tsx
+++ b/packages/layout/src/components/cards/trustee/views/address/index.tsx
@@ -18,9 +18,9 @@ const AddressPage: React.FC = () => {
 		postcode: trustee.address.postcode,
 		lookup: false,
 		options: [],
-		intitialValue:{}
+		initialValue:{}
 	});
-	const { loading, manual, postcode, lookup, options,intitialValue } = state;
+	const { loading, manual, postcode, lookup, options,initialValue } = state;
 
 	return (
 		<Content type={cardType.trustee} title={i18n.address.title}>
@@ -44,7 +44,7 @@ const AddressPage: React.FC = () => {
 							showLookup={(lookup: boolean) => setState({ lookup })}
 							setLoading={(loading: boolean) => setState({ loading })}
 							setOptions={(options: any[]) => setState({ options })}
-							setInitialValue={(initialValue:[key:string])=>setState({initialValue})}
+							setInitialValue={(initialValue:any)=>setState({initialValue})}
 							addressAPI={addressAPI}
 							i18n={i18n}
 						/>
@@ -58,7 +58,7 @@ const AddressPage: React.FC = () => {
 					<AutoComplete
 						loading={loading}
 						options={options}
-						initialValue ={intitialValue}
+						initialValue ={initialValue}
 						onClick={() => setState({ manual: true })}
 					/>
 				)}

--- a/packages/layout/src/components/cards/trustee/views/address/index.tsx
+++ b/packages/layout/src/components/cards/trustee/views/address/index.tsx
@@ -18,8 +18,9 @@ const AddressPage: React.FC = () => {
 		postcode: trustee.address.postcode,
 		lookup: false,
 		options: [],
+		intitialValue:{}
 	});
-	const { loading, manual, postcode, lookup, options } = state;
+	const { loading, manual, postcode, lookup, options,intitialValue } = state;
 
 	return (
 		<Content type={cardType.trustee} title={i18n.address.title}>
@@ -43,6 +44,7 @@ const AddressPage: React.FC = () => {
 							showLookup={(lookup: boolean) => setState({ lookup })}
 							setLoading={(loading: boolean) => setState({ loading })}
 							setOptions={(options: any[]) => setState({ options })}
+							setInitialValue={(initialValue:[key:string])=>setState({initialValue})}
 							addressAPI={addressAPI}
 							i18n={i18n}
 						/>
@@ -56,6 +58,7 @@ const AddressPage: React.FC = () => {
 					<AutoComplete
 						loading={loading}
 						options={options}
+						initialValue ={intitialValue}
 						onClick={() => setState({ manual: true })}
 					/>
 				)}

--- a/packages/layout/src/components/cards/trustee/views/address/index.tsx
+++ b/packages/layout/src/components/cards/trustee/views/address/index.tsx
@@ -18,9 +18,9 @@ const AddressPage: React.FC = () => {
 		postcode: trustee.address.postcode,
 		lookup: false,
 		options: [],
-		initialValue:{}
+		selectedItem:{}
 	});
-	const { loading, manual, postcode, lookup, options,initialValue } = state;
+	const { loading, manual, postcode, lookup, options,selectedItem } = state;
 
 	return (
 		<Content type={cardType.trustee} title={i18n.address.title}>
@@ -44,7 +44,7 @@ const AddressPage: React.FC = () => {
 							showLookup={(lookup: boolean) => setState({ lookup })}
 							setLoading={(loading: boolean) => setState({ loading })}
 							setOptions={(options: any[]) => setState({ options })}
-							setInitialValue={(initialValue:any)=>setState({initialValue})}
+							setSelectedItem={(selectedItem:any)=>setState({selectedItem})}
 							addressAPI={addressAPI}
 							i18n={i18n}
 						/>
@@ -58,7 +58,7 @@ const AddressPage: React.FC = () => {
 					<AutoComplete
 						loading={loading}
 						options={options}
-						initialValue ={initialValue}
+						selectedItem ={selectedItem}
 						onClick={() => setState({ manual: true })}
 					/>
 				)}


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- updated the Adress lookup component to:
   - display addresses for the initial post code on loading
    - fixed the select box to display the first address line on each  post code search

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
