### PR TITLE
Fixing bug in FFInputNumber in IE

### DIFF
--- a/packages/forms/src/elements/currency/currency.tsx
+++ b/packages/forms/src/elements/currency/currency.tsx
@@ -82,12 +82,15 @@ const InputCurrency: React.FC<InputCurrencyProps> = ({
 	};
 
 	const handleKeyDown = (e: any) => {
-		// typing '.' when already exists one in the value
-		if (e.key === '.') {
-			dot ? e.preventDefault() : setDot(true);
-			return true;
+		// managing e.ctrlKey we allow to use the key combinations Ctrl+C, Ctrl+V, Ctrl+X
+		if (!(e.ctrlKey === true)) {
+			// typing '.' when already exists one in the value
+			if (e.key === '.') {
+				dot ? e.preventDefault() : setDot(true);
+				return true;
+			}
+			keyPressedIsNotAllowed(e) && e.preventDefault();
 		}
-		keyPressedIsNotAllowed(e) && e.preventDefault();
 	};
 
 	const valueLengthValid = (value: string): boolean => {

--- a/packages/forms/src/elements/helpers.ts
+++ b/packages/forms/src/elements/helpers.ts
@@ -135,8 +135,8 @@ export const validateCurrency = (
 	*/
 	if (value !== undefined && value !== null) {
 		const numericValue = Number(value.toString().replace(/,/g, ''));
-		if (min && numericValue < min) return 'tooSmall';
-		if (max && numericValue > max) return 'tooBig';
+		if ((min !== null) && numericValue < min) return 'tooSmall';
+		if ((max !== null) && numericValue > max) return 'tooBig';
 		return undefined;
 	}
 	return 'empty';

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -3,7 +3,7 @@ import { Field, FieldRenderProps } from 'react-final-form';
 import { StyledInputLabel, InputElementHeading } from '../elements';
 import { FieldProps, FieldExtraProps } from '../../renderFields';
 import { Input } from '../input/input';
-import { adaptValueToFormat, fixToDecimals } from '../helpers';
+import { adaptValueToFormat, fixToDecimals, validKeys as vk } from '../helpers';
 
 interface InputNumberProps extends FieldRenderProps<number>, FieldExtraProps {
 	after?: string;
@@ -37,6 +37,23 @@ const InputNumber: React.FC<InputNumberProps> = ({
 	maxIntDigits,
 	...props
 }) => {
+	const digits = [
+		'0',
+		'1',
+		'2',
+		'3',
+		'4',
+		'5',
+		'6',
+		'7',
+		'8',
+		'9',
+		'.',
+		'-',
+		'+',
+	];
+	const validKeys = [...vk, ...digits];
+
 	const [prevValue, setPrevValue] = useState<string | null>(null);
 
 	const reachedMaxIntDigits = (value: string): boolean => {
@@ -45,8 +62,12 @@ const InputNumber: React.FC<InputNumberProps> = ({
 	};
 
 	const handleKeyDown = (e: any): void => {
-		// avoid entering the number 'E'
-		e.key.toLowerCase() === 'e' && e.preventDefault();
+		// managing e.ctrlKey we allow to use the key combinations Ctrl+C, Ctrl+V, Ctrl+X
+		if (!(e.ctrlKey === true)) {
+			// avoid entering the number 'E'
+			e.key.toLowerCase() === 'e' && e.preventDefault();
+			!validKeys.includes(e.key) && e.preventDefault();
+		}
 	};
 
 	const valueLengthValid = (value: string): boolean => {


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

IE doesn't implements correctly the functionality of an input with `type="number"`, allowing all type of characters being typed in, and only after the `onBlur` event happens it cleans the input if the value is not correct.
With this fix, we control that the `onChange` event will occur only if a valid key is typed in.
And will also allow the use of combination keys like `ctrl+c`, `ctrl+x` and `ctrl+v` in `FFinputNumber` and `FFinputCurrency`.


#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
