### PR TITLE
FFInputCurrency implements initialValue

### DIFF
--- a/packages/forms/src/__tests__/currency.spec.tsx
+++ b/packages/forms/src/__tests__/currency.spec.tsx
@@ -121,4 +121,62 @@ describe('Currency', () => {
 			expect(label).toHaveAttribute('readonly');
 		});
 	});
+
+	describe('passing initial value', () => {
+		test('receives a number and applies the format', () => {
+			const { getByTestId } = formSetup({
+				render: (
+					<FFInputCurrency
+						label="Currency"
+						testId={testId}
+						name="currency"
+						maxInputLength={11}
+						decimalPlaces={2}
+						initialValue={35050}
+					/>
+				),
+			});
+			setTimeout(() => {
+				expect(getByTestId(testId)).toHaveValue('35,050.00');
+			}, 100);
+		});
+
+		test('receives null', () => {
+			const { getByTestId } = formSetup({
+				render: (
+					<FFInputCurrency
+						label="Currency"
+						testId={testId}
+						name="currency"
+						maxInputLength={11}
+						decimalPlaces={2}
+						initialValue={null}
+					/>
+				),
+			});
+			expect(getByTestId(testId)).toHaveValue('');
+		});
+
+		test('receives null and then changes to number', () => {
+			let val = null;
+			const { getByTestId } = formSetup({
+				render: (
+					<FFInputCurrency
+						label="Currency"
+						testId={testId}
+						name="currency"
+						maxInputLength={11}
+						decimalPlaces={2}
+						initialValue={val}
+					/>
+				),
+			});
+			setTimeout(() => {
+				val = 45000;
+			}, 100);
+			setTimeout(() => {
+				expect(getByTestId(testId)).toHaveValue('45,000.00');
+			}, 100);
+		});
+	});
 });

--- a/packages/forms/src/elements/currency/currency.mdx
+++ b/packages/forms/src/elements/currency/currency.mdx
@@ -220,7 +220,7 @@ Accepted config props: FlexProps, SpaceProps
 | decimalPlaces  | false    | number   | the number of decimal places used for formatting the value, default is 2                                 |
 | disabled       | false    | boolean  | Disable input field                                                                                      |
 | hint           | false    | string   | More detailed description about the field                                                                |
-| initialV       | false    | number   | Initial value for the input, will be automatically formatted                                             |
+| initialValue   | false    | number   | Initial value for the input, will be automatically formatted                                             |
 | label          | true     | string   | Input description                                                                                        |
 | maxInputLength | false    | number   | the max length for the input (including ',' and '.'), default is 16 + decimalPlaces (999,999,999,999.99) |
 | noLeftBorder   | false    | boolean  | disables the left border when detecting error                                                            |

--- a/packages/forms/src/elements/currency/currency.mdx
+++ b/packages/forms/src/elements/currency/currency.mdx
@@ -63,6 +63,10 @@ import { FFInputCurrency } from '@tpr/forms';
 							noLeftBorder={true}
 							optionalText={false}
 							callback={handleChange}
+							validate={(value) => {
+								if (validateCurrency(value, 0, null) === 'empty')
+									return 'Value cannot be empty';
+							}}
 						/>
 						<button
 							type="submit"
@@ -98,7 +102,7 @@ import { FFInputCurrency } from '@tpr/forms';
 							noLeftBorder={true}
 							optionalText={false}
 							callback={handleChange}
-							initialV={15000000}
+							initialValue={15000000}
 						/>
 						<button
 							type="submit"
@@ -138,7 +142,7 @@ import { FFInputCurrency, validateCurrency } from '@tpr/forms';
 							noLeftBorder={true}
 							optionalText={false}
 							callback={handleChange}
-							initialV={500}
+							initialValue={500}
 							validate={(value) =>
 								validateCurrency(value, 10e2, 999999999999.99)
 							}
@@ -181,7 +185,7 @@ import { FFInputCurrency, validateCurrency } from '@tpr/forms';
 							noLeftBorder={true}
 							optionalText={false}
 							callback={handleChange}
-							initialV={0}
+							initialValue={0}
 							validate={(value) => {
 								if (validateCurrency(value, null, 999999999999.99) === 'tooBig')
 									return 'Value cannot be greater than 999,999,999,999.99';

--- a/packages/forms/src/elements/currency/currency.tsx
+++ b/packages/forms/src/elements/currency/currency.tsx
@@ -26,161 +26,169 @@ interface InputCurrencyProps extends FieldRenderProps<number>, FieldExtraProps {
 	initialV?: number;
 }
 
-const InputCurrency: React.FC<InputCurrencyProps> = ({
-	label,
-	hint,
-	input,
-	testId,
-	meta,
-	required,
-	placeholder,
-	readOnly,
-	inputWidth: width,
-	cfg,
-	after,
-	before,
-	callback,
-	decimalPlaces = 2,
-	noLeftBorder,
-	optionalText,
-	maxInputLength = 16 + decimalPlaces,
-	initialV,
-	...props
-}) => {
-	const digits = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.'];
+const InputCurrency: React.FC<InputCurrencyProps> = React.memo(
+	({
+		label,
+		hint,
+		input,
+		testId,
+		meta,
+		required,
+		placeholder,
+		readOnly,
+		inputWidth: width,
+		cfg,
+		after,
+		before,
+		callback,
+		decimalPlaces = 2,
+		noLeftBorder,
+		optionalText,
+		maxInputLength = 16 + decimalPlaces,
+		initialV,
+		...props
+	}) => {
+		const digits = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.'];
 
-	// e.g. format: 999,999,999,999.00
+		// e.g. format: 999,999,999,999.00
 
-	const [inputValue, setInputValue] = useState<string>('');
-	const [dot, setDot] = useState<boolean>(false);
-	const [firstLoad, setFirstLoad] = useState<boolean>(true);
+		const [inputValue, setInputValue] = useState<string>('');
+		const [dot, setDot] = useState<boolean>(false);
 
-	const formatWithCommas = (value: string): string => {
-		const numString: string = value.replace(/,/g, '');
-		let numFormatted: string = '';
-		// if number is integer
-		if (!containsDecimals(value)) {
-			// numString = "123456"
-			numFormatted = format(numString);
-			// numFormatted = "123,456"
-			const numWithDecimals: string = fixToDecimals(numString, decimalPlaces);
-			setInputValue(numFormatted + '.' + numWithDecimals.slice(-decimalPlaces));
-		}
-		// if number has decimals
-		else {
-			// numString = "123456.77"
-			numFormatted = formatWithDecimals(numString, decimalPlaces);
-			// numFormatted = "123,456.77"
-			setInputValue(numFormatted);
-		}
-		return numFormatted;
-	};
-
-	const keyPressedIsNotAllowed = (e: any): boolean => {
-		if (!digits.includes(e.key) && !validKeys.includes(e.key)) return true;
-		return false;
-	};
-
-	const handleKeyDown = (e: any) => {
-		// managing e.ctrlKey we allow to use the key combinations Ctrl+C, Ctrl+V, Ctrl+X
-		if (!(e.ctrlKey === true)) {
-			// typing '.' when already exists one in the value
-			if (e.key === '.') {
-				dot ? e.preventDefault() : setDot(true);
-				return true;
+		const formatWithCommas = (value: string): string => {
+			const numString: string = value.replace(/,/g, '');
+			let numFormatted: string = '';
+			// if number is integer
+			if (!containsDecimals(value)) {
+				// numString = "123456"
+				numFormatted = format(numString);
+				// numFormatted = "123,456"
+				const numWithDecimals: string = fixToDecimals(numString, decimalPlaces);
+				setInputValue(
+					numFormatted + '.' + numWithDecimals.slice(-decimalPlaces),
+				);
 			}
-			keyPressedIsNotAllowed(e) && e.preventDefault();
-		}
-	};
+			// if number has decimals
+			else {
+				// numString = "123456.77"
+				numFormatted = formatWithDecimals(numString, decimalPlaces);
+				// numFormatted = "123,456.77"
+				setInputValue(numFormatted);
+			}
+			return numFormatted;
+		};
 
-	const valueLengthValid = (value: string): boolean => {
-		// if the length of the new value (after formatting) is greater than maxInputLength => returns false
-		if (value) {
-			const newValue = getFinalValueWithFormat(value, decimalPlaces);
-			if (newValue.length > maxInputLength) return false;
-		}
-		return true;
-	};
+		const keyPressedIsNotAllowed = (e: any): boolean => {
+			if (!digits.includes(e.key) && !validKeys.includes(e.key)) return true;
+			return false;
+		};
 
-	const handleOnChange = (e: ChangeEvent<HTMLInputElement>): void => {
-		// if the new value.length is greater than the maxLength
-		if (!valueLengthValid(e.target.value)) {
-			e.target.value = inputValue;
-		} else {
-			if (String(e.target.value)[e.target.value.length - 1] == '.') {
-				input.onChange(e.target.value);
+		const handleKeyDown = (e: any) => {
+			// managing e.ctrlKey we allow to use the key combinations Ctrl+C, Ctrl+V, Ctrl+X
+			if (!(e.ctrlKey === true)) {
+				// typing '.' when already exists one in the value
+				if (e.key === '.') {
+					dot ? e.preventDefault() : setDot(true);
+					return true;
+				}
+				keyPressedIsNotAllowed(e) && e.preventDefault();
+			}
+		};
+
+		const valueLengthValid = (value: string): boolean => {
+			// if the length of the new value (after formatting) is greater than maxInputLength => returns false
+			if (value) {
+				const newValue = getFinalValueWithFormat(value, decimalPlaces);
+				if (newValue.length > maxInputLength) return false;
+			}
+			return true;
+		};
+
+		const handleOnChange = (e: ChangeEvent<HTMLInputElement>): void => {
+			// if the new value.length is greater than the maxLength
+			if (!valueLengthValid(e.target.value)) {
+				e.target.value = inputValue;
 			} else {
-				input.onChange(e.target.value && formatWithCommas(e.target.value));
+				if (String(e.target.value)[e.target.value.length - 1] == '.') {
+					input.onChange(e.target.value);
+				} else {
+					input.onChange(e.target.value && formatWithCommas(e.target.value));
+				}
+				if (!containsDecimals(e.target.value)) setDot(false);
+				e.target.value === '' && setInputValue('');
 			}
-			if (!containsDecimals(e.target.value)) setDot(false);
-			e.target.value === '' && setInputValue('');
-		}
-		if (callback) {
-			const numericValue = Number(
-				adaptValueToFormat(e.target.value.replace(/,/g, ''), decimalPlaces),
-			);
-			e.target.value === ''
-				? callback(null)
-				: callback(Number(numericValue.toFixed(decimalPlaces)));
-		}
-	};
+			if (callback) {
+				const numericValue = Number(
+					adaptValueToFormat(e.target.value.replace(/,/g, ''), decimalPlaces),
+				);
+				e.target.value === ''
+					? callback(null)
+					: callback(Number(numericValue.toFixed(decimalPlaces)));
+			}
+		};
 
-	const handleBlur = (e: any): void => {
-		input.onBlur(e);
-		e.target.value =
-			getNumDecimalPlaces(inputValue) < decimalPlaces
-				? appendMissingZeros(inputValue.replace(/,/g, ''), decimalPlaces)
-				: inputValue;
-		input.onChange(e);
-	};
+		const handleBlur = (e: any): void => {
+			input.onBlur(e);
+			e.target.value =
+				getNumDecimalPlaces(inputValue) < decimalPlaces
+					? appendMissingZeros(inputValue.replace(/,/g, ''), decimalPlaces)
+					: inputValue;
+			input.onChange(e);
+		};
 
-	const innerInput = useRef(null);
-
-	useEffect(() => {
-		// if "initialV" is specified, it needs to trigger manually the onBlur event to apply the format
-		const myEvent = new Event('blur', { bubbles: true });
-		if (initialV !== undefined && initialV !== null) {
-			const newInitialValue = formatWithCommas(initialV.toFixed(decimalPlaces));
+		const formatInitialValue = (value: number) => {
+			const newInitialValue = formatWithCommas(value.toFixed(decimalPlaces));
 			setInputValue(newInitialValue);
 			innerInput.current.value = newInitialValue;
-			setFirstLoad(false);
-			innerInput.current.dispatchEvent(myEvent);
-		}
-	}, [firstLoad]);
+		};
 
-	return (
-		<StyledInputLabel
-			isError={meta && meta.touched && meta.error}
-			cfg={Object.assign({ flexDirection: 'column', mt: 1 }, cfg)}
-			noLeftBorder={noLeftBorder}
-		>
-			<InputElementHeading
-				label={label}
-				required={optionalText !== undefined ? !optionalText : required}
-				hint={hint}
-				meta={meta}
-			/>
-			<Input
-				parentRef={innerInput}
-				type="text"
-				width={width}
-				testId={testId}
-				label={label}
-				touched={meta && meta.touched && meta.error}
-				placeholder={placeholder}
-				readOnly={readOnly}
-				decimalPlaces={decimalPlaces}
-				{...input}
-				onKeyDown={handleKeyDown}
-				onChange={handleOnChange}
-				onBlur={handleBlur}
-				after={after}
-				before={before}
-				{...props}
-			/>
-		</StyledInputLabel>
-	);
-};
+		const innerInput = useRef(null);
+
+		useEffect(() => {
+			if (initialV !== undefined && initialV !== null) {
+				const myEvent = new Event('blur', { bubbles: true });
+				formatInitialValue(initialV);
+
+				setTimeout(() => {
+					innerInput.current.dispatchEvent(myEvent);
+				}, 50);
+			}
+		}, [initialV]);
+
+		return (
+			<StyledInputLabel
+				isError={meta && meta.touched && meta.error}
+				cfg={Object.assign({ flexDirection: 'column', mt: 1 }, cfg)}
+				noLeftBorder={noLeftBorder}
+			>
+				<InputElementHeading
+					label={label}
+					required={optionalText !== undefined ? !optionalText : required}
+					hint={hint}
+					meta={meta}
+				/>
+				<Input
+					parentRef={innerInput}
+					type="text"
+					width={width}
+					testId={testId}
+					label={label}
+					touched={meta && meta.touched && meta.error}
+					placeholder={placeholder}
+					readOnly={readOnly}
+					decimalPlaces={decimalPlaces}
+					{...input}
+					onKeyDown={handleKeyDown}
+					onChange={handleOnChange}
+					onBlur={handleBlur}
+					after={after}
+					before={before}
+					{...props}
+				/>
+			</StyledInputLabel>
+		);
+	},
+);
 
 export const FFInputCurrency: React.FC<FieldProps> = (fieldProps) => {
 	return <Field {...fieldProps} component={InputCurrency} />;

--- a/packages/forms/src/elements/currency/currency.tsx
+++ b/packages/forms/src/elements/currency/currency.tsx
@@ -147,6 +147,11 @@ const InputCurrency: React.FC<InputCurrencyProps> = React.memo(
 			if (initialValue !== undefined && initialValue !== null) {
 				const myEvent = new Event('blur', { bubbles: true });
 				formatInitialValue(initialValue);
+				/*
+					When initialValue changes from null to a numeric value there is a situation where the format 
+					is not correctly applied because somehow the blur event triggers before the value is formatted. 
+					Delaying minimally the execution of the blur event solves this problem.
+				*/
 				setTimeout(() => {
 					innerInput.current.dispatchEvent(myEvent);
 				}, 50);

--- a/packages/forms/src/elements/currency/currency.tsx
+++ b/packages/forms/src/elements/currency/currency.tsx
@@ -23,7 +23,6 @@ interface InputCurrencyProps extends FieldRenderProps<number>, FieldExtraProps {
 	noLeftBorder?: boolean;
 	optionalText?: boolean;
 	maxInputLength?: number;
-	initialV?: number;
 }
 
 const InputCurrency: React.FC<InputCurrencyProps> = React.memo(
@@ -45,7 +44,7 @@ const InputCurrency: React.FC<InputCurrencyProps> = React.memo(
 		noLeftBorder,
 		optionalText,
 		maxInputLength = 16 + decimalPlaces,
-		initialV,
+		initialValue,
 		...props
 	}) => {
 		const digits = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.'];
@@ -145,15 +144,18 @@ const InputCurrency: React.FC<InputCurrencyProps> = React.memo(
 		const innerInput = useRef(null);
 
 		useEffect(() => {
-			if (initialV !== undefined && initialV !== null) {
+			if (initialValue !== undefined && initialValue !== null) {
 				const myEvent = new Event('blur', { bubbles: true });
-				formatInitialValue(initialV);
-
+				formatInitialValue(initialValue);
 				setTimeout(() => {
 					innerInput.current.dispatchEvent(myEvent);
 				}, 50);
+			} else {
+				setInputValue('');
+				innerInput.current.value = null;
+				input.onChange(null);
 			}
-		}, [initialV]);
+		}, [initialValue]);
 
 		return (
 			<StyledInputLabel
@@ -191,5 +193,10 @@ const InputCurrency: React.FC<InputCurrencyProps> = React.memo(
 );
 
 export const FFInputCurrency: React.FC<FieldProps> = (fieldProps) => {
-	return <Field {...fieldProps} component={InputCurrency} />;
+	return (
+		<Field
+			{...fieldProps}
+			render={(props) => <InputCurrency {...props} {...fieldProps} />}
+		/>
+	);
 };


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [x] Includes tests
- [x] Update documentation

- passing the **react-final-form** prop `initialValue` to the `FFInputCurrency` component to be consistent with the other components and also to avoid errors when used in a `Form` component that receives the `initialValues` prop. 
In **react-final-form**, when `initialValues` is updated, it modifies all the form fields values, except for those implementing `initialValue`, and the FFInputCurrency was not doing it.
- When `initialValue` changes from `null` to a numeric value there is a situation where the format is not correctly applied because somehow the `blur` event triggers before the value is formatted. Delaying minimally the execution of the `blur` event solves this problem. That's the reason why there is a `setTimeout` inside the `useEffect` when `initialValue !== null`.

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

Using this new update will require changing all places where `initialV` is used and change it for `initialValue`.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
