### PR TITLE
fixing issue with 'validate' being passed as prop to the inner input …

### DIFF
--- a/packages/forms/src/__tests__/currency.spec.tsx
+++ b/packages/forms/src/__tests__/currency.spec.tsx
@@ -157,8 +157,9 @@ describe('Currency', () => {
 			expect(getByTestId(testId)).toHaveValue('');
 		});
 
-		test('receives null and then changes to number', () => {
+		test('receives null and then changes to number && custom validator', () => {
 			let val = null;
+			let validateExecuted = false;
 			const { getByTestId } = formSetup({
 				render: (
 					<FFInputCurrency
@@ -168,6 +169,7 @@ describe('Currency', () => {
 						maxInputLength={11}
 						decimalPlaces={2}
 						initialValue={val}
+						validate={() => (validateExecuted = true)}
 					/>
 				),
 			});
@@ -177,6 +179,7 @@ describe('Currency', () => {
 			setTimeout(() => {
 				expect(getByTestId(testId)).toHaveValue('45,000.00');
 			}, 100);
+			expect(validateExecuted).toEqual(true);
 		});
 	});
 });

--- a/packages/forms/src/elements/currency/currency.tsx
+++ b/packages/forms/src/elements/currency/currency.tsx
@@ -201,7 +201,9 @@ export const FFInputCurrency: React.FC<FieldProps> = (fieldProps) => {
 	return (
 		<Field
 			{...fieldProps}
-			render={(props) => <InputCurrency {...props} {...fieldProps} />}
+			render={(props) => (
+				<InputCurrency {...props} initialValue={fieldProps.initialValue} />
+			)}
 		/>
 	);
 };


### PR DESCRIPTION
…because all 'fieldprops' were passed to the InputCurrency component

#### Fixes #0000

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Because `InputCurrency` component received all `fieldprops`, `validate` was passed as prop to the inner input and this was causing an error. Now will only receive `initialValue` from the `fieldprops`.
Adding custom validator to tests.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
