### PR TITLE
FFInputDate: monthYearOnly

### DIFF
--- a/packages/forms/src/__tests__/date.spec.tsx
+++ b/packages/forms/src/__tests__/date.spec.tsx
@@ -147,10 +147,10 @@ describe('Date input', () => {
 		}
 	`);
 		expect(formState.errors).toMatchInlineSnapshot(`
-Object {
-  "date-1": "This is a required field",
-}
-`);
+		Object {
+		  "date-1": "This is a required field",
+		}
+	`);
 		expect(handleSubmit).toBeCalledTimes(0);
 	});
 
@@ -185,5 +185,50 @@ Object {
 		expect(dd).toHaveAttribute('readonly');
 		expect(mm).toHaveAttribute('readonly');
 		expect(yyyy).toHaveAttribute('readonly');
+	});
+
+	test('using the monthYearOnly prop', () => {
+		const fields: FieldProps[] = [
+			{
+				name: 'month-year-only',
+				label: 'month-year-only',
+				hint: 'For example, 11 2007',
+				type: 'date',
+				required: true,
+				monthYearOnly: true,
+			},
+		];
+		const handleSubmit = jest.fn();
+		const { container, form } = formSetup({
+			render: renderFields(fields),
+			validate: validate(fields),
+			onSubmit: handleSubmit,
+		});
+
+		const dd = container.querySelector(
+			'input[aria-label="dd-month-year-only"]',
+		);
+		const mm = container.querySelector(
+			'input[aria-label="mm-month-year-only"]',
+		);
+		const yyyy = container.querySelector(
+			'input[aria-label="yyyy-month-year-only"]',
+		);
+
+		expect(dd).toBe(null);
+		expect(mm).toBeDefined();
+		expect(yyyy).toBeDefined();
+
+		const submit = container.querySelector('button[type="submit"]');
+
+		userEvent.type(mm, '10');
+		userEvent.type(yyyy, '2020');
+
+		userEvent.click(submit);
+
+		expect(handleSubmit).toBeCalledTimes(1);
+		expect(form.getState().values).toEqual({
+			'month-year-only': '2020-10-01',
+		});
 	});
 });

--- a/packages/forms/src/__tests__/date.spec.tsx
+++ b/packages/forms/src/__tests__/date.spec.tsx
@@ -45,13 +45,13 @@ describe('Date input', () => {
 		});
 
 		const dd = container.querySelector(
-			'input[aria-label="dd-passport-expiry"]',
+			'input[aria-label="passport-expiry: Day"]',
 		);
 		const mm = container.querySelector(
-			'input[aria-label="mm-passport-expiry"]',
+			'input[aria-label="passport-expiry: Month"]',
 		);
 		const yyyy = container.querySelector(
-			'input[aria-label="yyyy-passport-expiry"]',
+			'input[aria-label="passport-expiry: Month"]',
 		);
 
 		const submit = container.querySelector('button[type="submit"]');
@@ -84,18 +84,18 @@ describe('Date input', () => {
 		});
 
 		const dd = container.querySelector(
-			'input[aria-label="dd-passport-expiry"]',
+			'input[aria-label="passport-expiry: Day"]',
 		);
 		const mm = container.querySelector(
-			'input[aria-label="mm-passport-expiry"]',
+			'input[aria-label="passport-expiry: Month"]',
 		);
 		const yyyy = container.querySelector(
-			'input[aria-label="yyyy-passport-expiry"]',
+			'input[aria-label="passport-expiry: Year"]',
 		);
 
-		expect(dd).toHaveAttribute('aria-label', 'dd-passport-expiry');
-		expect(mm).toHaveAttribute('aria-label', 'mm-passport-expiry');
-		expect(yyyy).toHaveAttribute('aria-label', 'yyyy-passport-expiry');
+		expect(dd).toHaveAttribute('aria-label', 'passport-expiry: Day');
+		expect(mm).toHaveAttribute('aria-label', 'passport-expiry: Month');
+		expect(yyyy).toHaveAttribute('aria-label', 'passport-expiry: Year');
 		expect(dd).toHaveAttribute('type', 'string');
 		expect(mm).toHaveAttribute('type', 'string');
 		expect(yyyy).toHaveAttribute('type', 'string');
@@ -173,13 +173,13 @@ describe('Date input', () => {
 		});
 
 		const dd = container.querySelector(
-			'input[aria-label="dd-passport-expiry"]',
+			'input[aria-label="passport-expiry: Day"]',
 		);
 		const mm = container.querySelector(
-			'input[aria-label="mm-passport-expiry"]',
+			'input[aria-label="passport-expiry: Month"]',
 		);
 		const yyyy = container.querySelector(
-			'input[aria-label="yyyy-passport-expiry"]',
+			'input[aria-label="passport-expiry: Year"]',
 		);
 
 		expect(dd).toHaveAttribute('readonly');
@@ -187,7 +187,7 @@ describe('Date input', () => {
 		expect(yyyy).toHaveAttribute('readonly');
 	});
 
-	test('using the monthYearOnly prop', () => {
+	test('using the hideDay prop', () => {
 		const fields: FieldProps[] = [
 			{
 				name: 'month-year-only',
@@ -195,7 +195,7 @@ describe('Date input', () => {
 				hint: 'For example, 11 2007',
 				type: 'date',
 				required: true,
-				monthYearOnly: true,
+				hideDay: true,
 			},
 		];
 		const handleSubmit = jest.fn();
@@ -206,13 +206,13 @@ describe('Date input', () => {
 		});
 
 		const dd = container.querySelector(
-			'input[aria-label="dd-month-year-only"]',
+			'input[aria-label="month-year-only: Day"]',
 		);
 		const mm = container.querySelector(
-			'input[aria-label="mm-month-year-only"]',
+			'input[aria-label="month-year-only: Month"]',
 		);
 		const yyyy = container.querySelector(
-			'input[aria-label="yyyy-month-year-only"]',
+			'input[aria-label="month-year-only: Year"]',
 		);
 
 		expect(dd).toBe(null);
@@ -229,6 +229,51 @@ describe('Date input', () => {
 		expect(handleSubmit).toBeCalledTimes(1);
 		expect(form.getState().values).toEqual({
 			'month-year-only': '2020-10-01',
+		});
+	});
+
+	test('using the hideDay & hideMonth props', () => {
+		const fields: FieldProps[] = [
+			{
+				name: 'month-year-only',
+				label: 'month-year-only',
+				hint: 'For example, 11 2007',
+				type: 'date',
+				required: true,
+				hideDay: true,
+				hideMonth: true,
+			},
+		];
+		const handleSubmit = jest.fn();
+		const { container, form } = formSetup({
+			render: renderFields(fields),
+			validate: validate(fields),
+			onSubmit: handleSubmit,
+		});
+
+		const dd = container.querySelector(
+			'input[aria-label="month-year-only: Day"]',
+		);
+		const mm = container.querySelector(
+			'input[aria-label="month-year-only: Month"]',
+		);
+		const yyyy = container.querySelector(
+			'input[aria-label="month-year-only: Year"]',
+		);
+
+		expect(dd).toBe(null);
+		expect(mm).toBe(null);
+		expect(yyyy).toBeDefined();
+
+		const submit = container.querySelector('button[type="submit"]');
+
+		userEvent.type(yyyy, '2020');
+
+		userEvent.click(submit);
+
+		expect(handleSubmit).toBeCalledTimes(1);
+		expect(form.getState().values).toEqual({
+			'month-year-only': '2020-01-01',
 		});
 	});
 });

--- a/packages/forms/src/elements/date/date.mdx
+++ b/packages/forms/src/elements/date/date.mdx
@@ -72,6 +72,39 @@ import { FFInputDate } from '@tpr/forms';
 	}}
 </Playground>
 
+### only displaying Month & Year, with the monthYearOnly prop
+
+<Playground>
+	{() => {
+		const fields = [
+			{
+				type: 'date',
+				name: 'passport-issued',
+				label: 'When was your passport issued?',
+				hint: 'For example, 11 2007',
+				error: 'The date your passport was issued must be in the past',
+				monthYearOnly: true,
+			},
+		];
+		return (
+			<Form
+				onSubmit={(val) => console.log(val)}
+				initialValues={{ 'passport-issued': null }}
+				validate={validate(fields)}
+			>
+				{({ handleSubmit }) => (
+					<form onSubmit={handleSubmit} style={{ padding: 10 }}>
+						{renderFields(fields)}
+						<button type="submit" style={{ display: 'none' }}>
+							Submit
+						</button>
+					</form>
+				)}
+			</Form>
+		);
+	}}
+</Playground>
+
 ## API
 
 ```
@@ -80,11 +113,12 @@ Accepted config props: FlexProps, SpaceProps
 
 ### Props
 
-| Property | Required | Type    | Description                                    |
-| -------- | -------- | ------- | --------------------------------------------   |
-| cfg      | false    | object  | FlexProps & SpaceProps                         |
-| disabled | false    | boolean | Disable date field                             |
-| testId   | false    | string  | data attribute for testers                     |
-| label    | true     | string  | Date field description                         |
-| hint     | false    | string  | More detailed description about the date field |
-| readOnly | false    | boolean | Sets whether the field is read only            |
+| Property      | Required | Type    | Description                                     |
+| ------------- | -------- | ------- | ----------------------------------------------- |
+| cfg           | false    | object  | FlexProps & SpaceProps                          |
+| disabled      | false    | boolean | Disable date field                              |
+| testId        | false    | string  | data attribute for testers                      |
+| label         | true     | string  | Date field description                          |
+| hint          | false    | string  | More detailed description about the date field  |
+| monthYearOnly | false    | boolean | hides the Day input and only shows Month & Year |
+| readOnly      | false    | boolean | Sets whether the field is read only             |

--- a/packages/forms/src/elements/date/date.mdx
+++ b/packages/forms/src/elements/date/date.mdx
@@ -129,7 +129,9 @@ import { FFInputDate } from '@tpr/forms';
 				{({ handleSubmit }) => (
 					<form onSubmit={handleSubmit} style={{ padding: 10 }}>
 						{renderFields(fields)}
-						<button type="submit">Submit</button>
+						<button type="submit" style={{ display: 'none' }}>
+							Submit
+						</button>
 					</form>
 				)}
 			</Form>

--- a/packages/forms/src/elements/date/date.mdx
+++ b/packages/forms/src/elements/date/date.mdx
@@ -47,7 +47,7 @@ import { FFInputDate } from '@tpr/forms';
 		const fields = [
 			{
 				type: 'date',
-				name: 'passport-issued',
+				name: 'passport-issued1',
 				label: 'When was your passport issued?',
 				hint: 'For example, 12 11 2007',
 				error: 'The date your passport was issued must be in the past',
@@ -56,7 +56,7 @@ import { FFInputDate } from '@tpr/forms';
 		return (
 			<Form
 				onSubmit={(val) => console.log(val)}
-				initialValues={{ 'passport-issued': null }}
+				initialValues={{ 'passport-issued1': null }}
 				validate={validate(fields)}
 			>
 				{({ handleSubmit }) => (
@@ -72,24 +72,24 @@ import { FFInputDate } from '@tpr/forms';
 	}}
 </Playground>
 
-### only displaying Month & Year, with the monthYearOnly prop
+### hiding Day and only displaying Month & Year
 
 <Playground>
 	{() => {
 		const fields = [
 			{
 				type: 'date',
-				name: 'passport-issued',
+				name: 'passport-issued2',
 				label: 'When was your passport issued?',
 				hint: 'For example, 11 2007',
 				error: 'The date your passport was issued must be in the past',
-				monthYearOnly: true,
+				hideDay: true,
 			},
 		];
 		return (
 			<Form
 				onSubmit={(val) => console.log(val)}
-				initialValues={{ 'passport-issued': null }}
+				initialValues={{ 'passport-issued2': null }}
 				validate={validate(fields)}
 			>
 				{({ handleSubmit }) => (
@@ -98,6 +98,38 @@ import { FFInputDate } from '@tpr/forms';
 						<button type="submit" style={{ display: 'none' }}>
 							Submit
 						</button>
+					</form>
+				)}
+			</Form>
+		);
+	}}
+</Playground>
+
+### hiding Day & Month and only displaying Year
+
+<Playground>
+	{() => {
+		const fields = [
+			{
+				type: 'date',
+				name: 'passport-issued3',
+				label: 'When was your passport issued?',
+				hint: 'For example, 2007',
+				error: 'The year your passport was issued must be in the past',
+				hideDay: true,
+				hideMonth: true,
+			},
+		];
+		return (
+			<Form
+				onSubmit={(val) => console.log(val)}
+				initialValues={{ 'passport-issued3': null }}
+				validate={validate(fields)}
+			>
+				{({ handleSubmit }) => (
+					<form onSubmit={handleSubmit} style={{ padding: 10 }}>
+						{renderFields(fields)}
+						<button type="submit">Submit</button>
 					</form>
 				)}
 			</Form>
@@ -113,12 +145,13 @@ Accepted config props: FlexProps, SpaceProps
 
 ### Props
 
-| Property      | Required | Type    | Description                                     |
-| ------------- | -------- | ------- | ----------------------------------------------- |
-| cfg           | false    | object  | FlexProps & SpaceProps                          |
-| disabled      | false    | boolean | Disable date field                              |
-| testId        | false    | string  | data attribute for testers                      |
-| label         | true     | string  | Date field description                          |
-| hint          | false    | string  | More detailed description about the date field  |
-| monthYearOnly | false    | boolean | hides the Day input and only shows Month & Year |
-| readOnly      | false    | boolean | Sets whether the field is read only             |
+| Property  | Required | Type    | Description                                                          |
+| --------- | -------- | ------- | -------------------------------------------------------------------- |
+| cfg       | false    | object  | FlexProps & SpaceProps                                               |
+| disabled  | false    | boolean | Disable date field                                                   |
+| testId    | false    | string  | data attribute for testers                                           |
+| label     | true     | string  | Date field description                                               |
+| hint      | false    | string  | More detailed description about the date field                       |
+| hideDay   | false    | boolean | hides the Day input and assigns a default value of 1 for the day     |
+| hideMonth | false    | boolean | hides the Month input and assigns a default value of 1 for the month |
+| readOnly  | false    | boolean | Sets whether the field is read only                                  |

--- a/packages/forms/src/elements/date/date.tsx
+++ b/packages/forms/src/elements/date/date.tsx
@@ -49,6 +49,7 @@ type DateInputFieldProps = {
 	label: string;
 	disabled?: boolean;
 	readOnly?: boolean;
+	hideMonth?: boolean;
 };
 const DateInputField: React.FC<DateInputFieldProps> = ({
 	small = true,
@@ -63,6 +64,7 @@ const DateInputField: React.FC<DateInputFieldProps> = ({
 	meta,
 	disabled,
 	readOnly,
+	hideMonth,
 }) => {
 	return (
 		<label className={small ? styles.inputSmall : styles.inputLarge}>
@@ -78,7 +80,7 @@ const DateInputField: React.FC<DateInputFieldProps> = ({
 				onChange={handleChange(updateFn, maxInt)}
 				onBlur={(evt: ChangeEvent<HTMLInputElement>) => {
 					if (!evt.target.value || evt.target.value === '0') {
-						setMonth('');
+						!hideMonth && setMonth('');
 						onBlur();
 					}
 				}}
@@ -91,7 +93,8 @@ const DateInputField: React.FC<DateInputFieldProps> = ({
 
 type InputDateProps = FieldRenderProps<string> & FieldExtraProps;
 interface InputDateComponentProps extends InputDateProps {
-	monthYearOnly?: boolean;
+	hideDay?: boolean;
+	hideMonth?: boolean;
 }
 export const InputDate: React.FC<InputDateComponentProps> = memo(
 	({
@@ -104,7 +107,8 @@ export const InputDate: React.FC<InputDateComponentProps> = memo(
 		cfg,
 		disabled,
 		readOnly,
-		monthYearOnly,
+		hideDay,
+		hideMonth,
 	}) => {
 		// react-final-form types says it's a string, incorrect, it's a date object.
 		const { dd, mm, yyyy } = transformDate(meta.initial);
@@ -114,7 +118,7 @@ export const InputDate: React.FC<InputDateComponentProps> = memo(
 		);
 
 		useEffect(() => {
-			setState({ dd: monthYearOnly ? 1 : dd, mm: mm, yyyy: yyyy });
+			setState({ dd: hideDay ? 1 : dd, mm: hideMonth ? 1 : mm, yyyy: yyyy });
 		}, [dd, mm, yyyy]);
 
 		useEffect(() => {
@@ -147,10 +151,10 @@ export const InputDate: React.FC<InputDateComponentProps> = memo(
 					meta={meta}
 				/>
 				<Flex>
-					{!monthYearOnly && (
+					{!hideDay && (
 						<DateInputField
 							label="Day"
-							ariaLabel={`dd-${label}`}
+							ariaLabel={`${label}: Day`}
 							testId={`dd-${testId}`}
 							value={day}
 							updateFn={(dd: number) => setState({ dd })}
@@ -162,23 +166,25 @@ export const InputDate: React.FC<InputDateComponentProps> = memo(
 							readOnly={readOnly}
 						/>
 					)}
-					<DateInputField
-						label="Month"
-						ariaLabel={`mm-${label}`}
-						testId={`mm-${testId}`}
-						value={month}
-						updateFn={(mm: number) => setState({ mm })}
-						maxInt={13}
-						setMonth={(mm: number) => setState({ mm })}
-						onBlur={input.onBlur}
-						meta={meta}
-						disabled={disabled}
-						readOnly={readOnly}
-					/>
+					{!hideMonth && (
+						<DateInputField
+							label="Month"
+							ariaLabel={`${label}: Month`}
+							testId={`mm-${testId}`}
+							value={month}
+							updateFn={(mm: number) => setState({ mm })}
+							maxInt={13}
+							setMonth={(mm: number) => setState({ mm })}
+							onBlur={input.onBlur}
+							meta={meta}
+							disabled={disabled}
+							readOnly={readOnly}
+						/>
+					)}
 					<DateInputField
 						label="Year"
 						small={false}
-						ariaLabel={`yyyy-${label}`}
+						ariaLabel={`${label}: Year`}
 						testId={`yyyy-${testId}`}
 						value={year}
 						updateFn={(yyyy: number) => setState({ yyyy })}
@@ -188,6 +194,7 @@ export const InputDate: React.FC<InputDateComponentProps> = memo(
 						meta={meta}
 						disabled={disabled}
 						readOnly={readOnly}
+						hideMonth={hideMonth}
 					/>
 				</Flex>
 			</StyledInputLabel>

--- a/packages/forms/src/elements/date/date.tsx
+++ b/packages/forms/src/elements/date/date.tsx
@@ -90,7 +90,10 @@ const DateInputField: React.FC<DateInputFieldProps> = ({
 };
 
 type InputDateProps = FieldRenderProps<string> & FieldExtraProps;
-export const InputDate: React.FC<InputDateProps> = memo(
+interface InputDateComponentProps extends InputDateProps {
+	monthYearOnly?: boolean;
+}
+export const InputDate: React.FC<InputDateComponentProps> = memo(
 	({
 		label,
 		hint,
@@ -101,6 +104,7 @@ export const InputDate: React.FC<InputDateProps> = memo(
 		cfg,
 		disabled,
 		readOnly,
+		monthYearOnly,
 	}) => {
 		// react-final-form types says it's a string, incorrect, it's a date object.
 		const { dd, mm, yyyy } = transformDate(meta.initial);
@@ -110,7 +114,7 @@ export const InputDate: React.FC<InputDateProps> = memo(
 		);
 
 		useEffect(() => {
-			setState({ dd: dd, mm: mm, yyyy: yyyy });
+			setState({ dd: monthYearOnly ? 1 : dd, mm: mm, yyyy: yyyy });
 		}, [dd, mm, yyyy]);
 
 		useEffect(() => {
@@ -143,19 +147,21 @@ export const InputDate: React.FC<InputDateProps> = memo(
 					meta={meta}
 				/>
 				<Flex>
-					<DateInputField
-						label="Day"
-						ariaLabel={`dd-${label}`}
-						testId={`dd-${testId}`}
-						value={day}
-						updateFn={(dd: number) => setState({ dd })}
-						maxInt={32}
-						setMonth={(mm: number) => setState({ mm })}
-						onBlur={input.onBlur}
-						meta={meta}
-						disabled={disabled}
-						readOnly={readOnly}
-					/>
+					{!monthYearOnly && (
+						<DateInputField
+							label="Day"
+							ariaLabel={`dd-${label}`}
+							testId={`dd-${testId}`}
+							value={day}
+							updateFn={(dd: number) => setState({ dd })}
+							maxInt={32}
+							setMonth={(mm: number) => setState({ mm })}
+							onBlur={input.onBlur}
+							meta={meta}
+							disabled={disabled}
+							readOnly={readOnly}
+						/>
+					)}
 					<DateInputField
 						label="Month"
 						ariaLabel={`mm-${label}`}


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Adding `monthYearOnly` prop to `FFInputDate` for cases where the `Day` field is not required.
Will set the default value for the Day input to "01".

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
