### PR TITLE
Link component can become anchor tag

### DIFF
--- a/packages/core/src/components/__tests__/buttons.spec.tsx
+++ b/packages/core/src/components/__tests__/buttons.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '../buttons/buttons';
+import { Button, Link } from '../buttons/buttons';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
@@ -121,5 +121,23 @@ describe('Buttons', () => {
 		expect(getByTestId('btn').className).toMatchInlineSnapshot(
 			`"button appearance-outlined intent-none size-medium"`,
 		);
+	});
+});
+
+
+describe('Links', () => {
+	test('Link with button appearance', () => {
+		const { getByTestId } = render(
+			<Link 
+				testId="link-anchor"
+				anchorTag={true}
+				buttonAppearance={true}
+				href="http://www.google.com"
+				target="_blank"
+			>Home</Link>
+		);
+		expect(getByTestId('link-anchor')).toBeDefined();
+		expect(getByTestId('link-anchor')).toHaveAttribute('href');
+		expect(getByTestId('link-anchor')).toHaveAttribute('target');
 	});
 });

--- a/packages/core/src/components/__tests__/buttons.spec.tsx
+++ b/packages/core/src/components/__tests__/buttons.spec.tsx
@@ -124,17 +124,18 @@ describe('Buttons', () => {
 	});
 });
 
-
 describe('Links', () => {
 	test('Link with button appearance', () => {
 		const { getByTestId } = render(
-			<Link 
+			<Link
 				testId="link-anchor"
 				anchorTag={true}
 				buttonAppearance={true}
 				href="http://www.google.com"
 				target="_blank"
-			>Home</Link>
+			>
+				Home
+			</Link>,
 		);
 		expect(getByTestId('link-anchor')).toBeDefined();
 		expect(getByTestId('link-anchor')).toHaveAttribute('href');

--- a/packages/core/src/components/buttons/buttons.module.scss
+++ b/packages/core/src/components/buttons/buttons.module.scss
@@ -146,3 +146,15 @@
 .link-underline {
 	text-decoration: underline;
 }
+
+.link-button-small {
+	line-height: 40px;
+}
+
+.link-button-medium {
+	line-height: 50px;
+}
+
+.link-button-large {
+	line-height: 60px;
+}

--- a/packages/core/src/components/buttons/buttons.module.scss
+++ b/packages/core/src/components/buttons/buttons.module.scss
@@ -158,3 +158,10 @@
 .link-button-large {
 	line-height: 60px;
 }
+
+.linkArrowBtn {
+	display: inline-flex;
+	flex-direction: row-reverse;
+	justify-content: center;
+	align-items: center;
+}

--- a/packages/core/src/components/buttons/buttons.tsx
+++ b/packages/core/src/components/buttons/buttons.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import styles from './buttons.module.scss';
 import {
 	SpaceProps,
 	ColorProps,
 	TypographyProps,
 	LayoutProps,
+	Flex,
 } from '../globals/globals';
 import { useClassNames } from '../../hooks/use-class-names';
+import { ArrowRight } from '@tpr/icons';
+import styles from './buttons.module.scss';
 
 export type ButtonProps = {
 	className?: string;
@@ -75,8 +77,8 @@ export type LinkProps = {
 	appearance?: 'primary' | 'outlined';
 	intent?: 'none' | 'success' | 'warning' | 'danger' | 'special';
 	btnSize?: 'small' | 'medium' | 'large';
-	pointsTo?: 'left' | 'up' | 'right' | 'down';
-	iconColor?: ColorProps['fill'];
+	arrowBtn?: boolean;
+	arrowColor?: ColorProps['fill'];
 	[key: string]: any;
 };
 export const Link: React.FC<LinkProps> = ({
@@ -89,8 +91,8 @@ export const Link: React.FC<LinkProps> = ({
 	appearance = 'primary',
 	intent = 'none',
 	btnSize = 'medium',
-	pointsTo = 'left',
-	iconColor = 'white',
+	arrowBtn,
+	arrowColor = 'white',
 	children,
 	...props
 }) => {
@@ -100,6 +102,7 @@ export const Link: React.FC<LinkProps> = ({
 		styles[`intent-${intent}`],
 		styles[`size-${btnSize}`],
 		buttonAppearance && styles[`link-button-${btnSize}`],
+		arrowBtn && styles.linkArrowBtn,
 		className,
 	])
 	: useClassNames(globalStyles, [
@@ -116,6 +119,7 @@ export const Link: React.FC<LinkProps> = ({
 			className: classNames,
 			...props,
 		},
+		arrowBtn && <Flex><ArrowRight fill={arrowColor} /></Flex>,
 		children,
 	);
 };

--- a/packages/core/src/components/buttons/buttons.tsx
+++ b/packages/core/src/components/buttons/buttons.tsx
@@ -96,30 +96,35 @@ export const Link: React.FC<LinkProps> = ({
 	children,
 	...props
 }) => {
-	const classNames = buttonAppearance ? useClassNames(globalStyles, [
-		styles.button,
-		styles[`appearance-${appearance}`],
-		styles[`intent-${intent}`],
-		styles[`size-${btnSize}`],
-		buttonAppearance && styles[`link-button-${btnSize}`],
-		arrowBtn && styles.linkArrowBtn,
-		className,
-	])
-	: useClassNames(globalStyles, [
-		styles.link,
-		{ [styles['link-underline']]: underline },
-		className,
-	]);
+	const classNames = buttonAppearance
+		? useClassNames(globalStyles, [
+				styles.button,
+				styles[`appearance-${appearance}`],
+				styles[`intent-${intent}`],
+				styles[`size-${btnSize}`],
+				buttonAppearance && styles[`link-button-${btnSize}`],
+				arrowBtn && styles.linkArrowBtn,
+				className,
+		  ])
+		: useClassNames(globalStyles, [
+				styles.link,
+				{ [styles['link-underline']]: underline },
+				className,
+		  ]);
 
 	return React.createElement(
-		anchorTag ? 'a' :	'button',
+		anchorTag ? 'a' : 'button',
 		{
 			type: anchorTag ? null : 'button',
 			'data-testid': testId,
 			className: classNames,
 			...props,
 		},
-		arrowBtn && <Flex><ArrowRight fill={arrowColor} /></Flex>,
+		arrowBtn && (
+			<Flex>
+				<ArrowRight fill={arrowColor} />
+			</Flex>
+		),
 		children,
 	);
 };

--- a/packages/core/src/components/buttons/buttons.tsx
+++ b/packages/core/src/components/buttons/buttons.tsx
@@ -70,6 +70,11 @@ export type LinkProps = {
 	className?: string;
 	underline?: boolean;
 	testId?: string;
+	anchorTag?: boolean;
+	buttonAppearance?: boolean;
+	appearance?: 'primary' | 'outlined';
+	intent?: 'none' | 'success' | 'warning' | 'danger' | 'special';
+	size?: 'small' | 'medium' | 'large';
 	[key: string]: any;
 };
 export const Link: React.FC<LinkProps> = ({
@@ -77,19 +82,32 @@ export const Link: React.FC<LinkProps> = ({
 	underline = false,
 	className,
 	testId,
+	anchorTag,
+	buttonAppearance,
+	appearance = 'primary',
+	intent = 'none',
+	size = 'medium',
 	children,
 	...props
 }) => {
-	const classNames = useClassNames(globalStyles, [
+	const classNames = buttonAppearance ? useClassNames(globalStyles, [
+		styles.button,
+		styles[`appearance-${appearance}`],
+		styles[`intent-${intent}`],
+		styles[`size-${size}`],
+		buttonAppearance && styles[`link-button-${size}`],
+		className,
+	])
+	: useClassNames(globalStyles, [
 		styles.link,
 		{ [styles['link-underline']]: underline },
 		className,
 	]);
 
 	return React.createElement(
-		'button',
+		anchorTag ? 'a' :	'button',
 		{
-			type: 'button',
+			type: anchorTag ? null : 'button',
 			'data-testid': testId,
 			className: classNames,
 			...props,

--- a/packages/core/src/components/buttons/buttons.tsx
+++ b/packages/core/src/components/buttons/buttons.tsx
@@ -74,7 +74,9 @@ export type LinkProps = {
 	buttonAppearance?: boolean;
 	appearance?: 'primary' | 'outlined';
 	intent?: 'none' | 'success' | 'warning' | 'danger' | 'special';
-	size?: 'small' | 'medium' | 'large';
+	btnSize?: 'small' | 'medium' | 'large';
+	pointsTo?: 'left' | 'up' | 'right' | 'down';
+	iconColor?: ColorProps['fill'];
 	[key: string]: any;
 };
 export const Link: React.FC<LinkProps> = ({
@@ -86,7 +88,9 @@ export const Link: React.FC<LinkProps> = ({
 	buttonAppearance,
 	appearance = 'primary',
 	intent = 'none',
-	size = 'medium',
+	btnSize = 'medium',
+	pointsTo = 'left',
+	iconColor = 'white',
 	children,
 	...props
 }) => {
@@ -94,8 +98,8 @@ export const Link: React.FC<LinkProps> = ({
 		styles.button,
 		styles[`appearance-${appearance}`],
 		styles[`intent-${intent}`],
-		styles[`size-${size}`],
-		buttonAppearance && styles[`link-button-${size}`],
+		styles[`size-${btnSize}`],
+		buttonAppearance && styles[`link-button-${btnSize}`],
 		className,
 	])
 	: useClassNames(globalStyles, [

--- a/packages/core/src/components/buttons/buttons.tsx
+++ b/packages/core/src/components/buttons/buttons.tsx
@@ -7,7 +7,7 @@ import {
 	Flex,
 } from '../globals/globals';
 import { useClassNames } from '../../hooks/use-class-names';
-import { ArrowRight } from '@tpr/icons';
+import { ArrowRight } from './icons';
 import styles from './buttons.module.scss';
 
 export type ButtonProps = {

--- a/packages/core/src/components/buttons/icons.tsx
+++ b/packages/core/src/components/buttons/icons.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { SpaceProps, ColorProps } from '../globals/globals';
+import { useClassNames } from '../../hooks/use-class-names';
+
+type SVGProps = Partial<{
+	/** space props */
+	cfg: SpaceProps | ColorProps;
+	/** svg fill colour */
+	fill: string;
+	/** svg stroke colour */
+	stroke: string;
+	/** width and height of the icon */
+	width: string;
+	/** svg class name */
+	className: string;
+	/** svg viewBox */
+	viewBox: string;
+	/** test id for testing */
+	testId: string;
+	/** for accessibility */
+	role: string;
+	ariaLabel: string;
+}>;
+
+export const SVG: React.FC<SVGProps> = ({
+	cfg,
+	fill = '',
+	stroke = '',
+	width = '24',
+	className,
+	viewBox = '0 0 24 24',
+	testId,
+	role,
+	ariaLabel,
+	children,
+}) => {
+	const classNames = useClassNames(cfg, [className]);
+	return (
+		<svg
+			width={width}
+			height={width}
+			fill={fill}
+			stroke={stroke}
+			viewBox={viewBox}
+			xmlns="http://www.w3.org/2000/svg"
+			className={classNames}
+			xmlnsXlink="http://www.w3.org/1999/xlink"
+			data-testid={testId}
+			role={role}
+			aria-label={ariaLabel}
+		>
+			{children}
+		</svg>
+	);
+};
+
+export const ArrowRight: React.FC<SVGProps> = (props) => {
+	return (
+		<SVG testId="arrow-down" {...props}>
+			<path d="M0 0h24v24H0V0z" fill="none" />
+			<path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z" />
+		</SVG>
+	);
+};

--- a/packages/core/src/components/buttons/link.mdx
+++ b/packages/core/src/components/buttons/link.mdx
@@ -73,7 +73,7 @@ Using the anchorTag prop will create an `<a>` element, therefore the "disabled" 
 		cfg={{ mr: 3 }}
 		anchorTag={true}
 		buttonAppearance={true}
-		size="large"
+		btnSize="large"
 		href="http://www.google.com"
 		target="_blank"
 	>
@@ -83,7 +83,7 @@ Using the anchorTag prop will create an `<a>` element, therefore the "disabled" 
 		cfg={{ mr: 3 }}
 		anchorTag={true}
 		buttonAppearance={true}
-		size="medium"
+		btnSize="medium"
 		intent="warning"
 		href="http://www.google.com"
 		target="_blank"
@@ -94,7 +94,7 @@ Using the anchorTag prop will create an `<a>` element, therefore the "disabled" 
 		cfg={{ mr: 3 }}
 		anchorTag={true}
 		buttonAppearance={true}
-		size="small"
+		btnSize="small"
 		intent="danger"
 		href="http://www.google.com"
 		target="_blank"

--- a/packages/core/src/components/buttons/link.mdx
+++ b/packages/core/src/components/buttons/link.mdx
@@ -103,6 +103,47 @@ Using the anchorTag prop will create an `<a>` element, therefore the "disabled" 
 	</Link>
 </Playground>
 
+### Anchor tag with ArrowButton appearance
+
+<Playground>
+	<Link
+		cfg={{ mr: 3 }}
+		anchorTag={true}
+		buttonAppearance={true}
+		btnSize="large"
+		href="http://www.google.com"
+		target="_blank"
+		arrowBtn={true}
+	>
+		Home
+	</Link>
+	<Link
+		cfg={{ mr: 3, color: 'black' }}
+		anchorTag={true}
+		buttonAppearance={true}
+		arrowBtn={true}
+		arrowColor="black"
+		btnSize="medium"
+		intent="warning"
+		href="http://www.google.com"
+		target="_blank"
+	>
+		Home
+	</Link>
+	<Link
+		cfg={{ mr: 3 }}
+		anchorTag={true}
+		buttonAppearance={true}
+		arrowBtn={true}
+		btnSize="small"
+		intent="danger"
+		href="http://www.google.com"
+		target="_blank"
+	>
+		Home
+	</Link>
+</Playground>
+
 ## API
 
 ```

--- a/packages/core/src/components/buttons/link.mdx
+++ b/packages/core/src/components/buttons/link.mdx
@@ -51,6 +51,58 @@ import { Link } from '@tpr/core';
 	<Link cfg={{ mr: 3, color: 'success.1' }}>Log out</Link>
 </Playground>
 
+### Anchor tag
+
+Using the anchorTag prop will create an `<a>` element, therefore the "disabled" prop will have no offect
+
+<Playground>
+	<Link
+		cfg={{ mr: 3 }}
+		anchorTag={true}
+		href="http://www.google.com"
+		target="_blank"
+	>
+		Home
+	</Link>
+</Playground>
+
+### Anchor tag with button appearance
+
+<Playground>
+	<Link
+		cfg={{ mr: 3 }}
+		anchorTag={true}
+		buttonAppearance={true}
+		size="large"
+		href="http://www.google.com"
+		target="_blank"
+	>
+		Home
+	</Link>
+	<Link
+		cfg={{ mr: 3 }}
+		anchorTag={true}
+		buttonAppearance={true}
+		size="medium"
+		intent="warning"
+		href="http://www.google.com"
+		target="_blank"
+	>
+		Home
+	</Link>
+	<Link
+		cfg={{ mr: 3 }}
+		anchorTag={true}
+		buttonAppearance={true}
+		size="small"
+		intent="danger"
+		href="http://www.google.com"
+		target="_blank"
+	>
+		Home
+	</Link>
+</Playground>
+
 ## API
 
 ```


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Adding props to `Link` component in order to:

- render an anchor tag `<a>` that can receive `href, target`, etc.
- make it look as a `Button` component while being an anchor tag.
- make it look as an `ArrowButton` component (currently just pointing to the right)

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
