### PR TITLE
Fix export statement so that it can be consumed downstream #65336

### DIFF
--- a/packages/forms/src/elements/address/addressComparer.ts
+++ b/packages/forms/src/elements/address/addressComparer.ts
@@ -1,6 +1,6 @@
 import { Address } from './address';
 
-class AddressComparer {
+export class AddressComparer {
 	constructor() {}
 	public areEqual(address1: Address, address2: Address): boolean {
 		// Use == because an address is the same address if it's undefined on one side and null or empty string on the other


### PR DESCRIPTION
#### Related to [AB#65336](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/65336)

WebApps-Shared needs to import this class, and tests fail without the extra export keyword.