### PR TITLE
Provide a default initial value in the address lookup 

### DIFF
--- a/packages/forms/src/elements/address/addressLookup.tsx
+++ b/packages/forms/src/elements/address/addressLookup.tsx
@@ -39,7 +39,7 @@ enum AddressView {
 }
 
 export const AddressLookup: React.FC<AddressProps> = ({
-	initialValue,
+	initialValue = {},
 	loading,
 	setLoading,
 	testId,


### PR DESCRIPTION
Provide a default initial value in the address lookup so that the consuming component does not need to
