### PR TITLE
Bug - radio button hint overflow in IE

### DIFF
--- a/packages/forms/src/elements/radio/radio.module.scss
+++ b/packages/forms/src/elements/radio/radio.module.scss
@@ -37,5 +37,6 @@
 	font-size: $font-size-2;
 	font-weight: $font-weight-2;
 	margin-top: $space-2;
-	margin-left: 55px;
+	padding-left: 55px;
+	max-width: 100%;
 }

--- a/packages/forms/src/elements/radio/radio.tsx
+++ b/packages/forms/src/elements/radio/radio.tsx
@@ -65,10 +65,6 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
 	);
 };
 
-// export interface FFRadioButtonProps extends FieldProps {
-// 	callback?: Function;
-// }
-
 export const FFRadioButton: React.FC<FieldProps> = (fieldProps) => {
 	const handleChange = (input: any, value: any) => {
 		input.onChange(value);

--- a/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
@@ -3,7 +3,10 @@ import { Checkbox } from '@tpr/forms';
 import { Flex, P, Hr, classNames } from '@tpr/core';
 import { UnderlinedButton } from '../../../components/button';
 import { useActuaryContext } from '../../context';
-import { PhonePreview, EmailPreview } from '../../../common/views/preview/components';
+import {
+	PhonePreview,
+	EmailPreview,
+} from '../../../common/views/preview/components';
 import styles from './preview.module.scss';
 
 export const Preview: React.FC<any> = () => {
@@ -50,8 +53,12 @@ export const Preview: React.FC<any> = () => {
 						{i18n.preview.buttons.four}
 					</UnderlinedButton>
 					<Flex cfg={{ my: 2, flexDirection: 'column' }}>
-						{actuary.telephoneNumber && <PhonePreview value={actuary.telephoneNumber} />}
-						{actuary.emailAddress && <EmailPreview value={actuary.emailAddress} />}
+						{actuary.telephoneNumber && (
+							<PhonePreview value={actuary.telephoneNumber} />
+						)}
+						{actuary.emailAddress && (
+							<EmailPreview value={actuary.emailAddress} />
+						)}
 					</Flex>
 				</Flex>
 			</Flex>

--- a/packages/layout/src/components/cards/common/views/preview/components/emailPreview.tsx
+++ b/packages/layout/src/components/cards/common/views/preview/components/emailPreview.tsx
@@ -2,18 +2,17 @@ import React from 'react';
 import { H4, P } from '@tpr/core';
 
 interface EmailPreviewProps {
-  label?:string,
-  value: string
+	label?: string;
+	value: string;
 }
 
-export const EmailPreview:React.FC<EmailPreviewProps> = React.memo(({
-  label = 'Email',
-  value
-}) => {
-  return (
-    <>
-      <H4 cfg={{ lineHeight: 3 }}>{label}</H4>
-      <P cfg={{ wordBreak: 'all' }}>{value}</P>
-    </>
-  )
-});
+export const EmailPreview: React.FC<EmailPreviewProps> = React.memo(
+	({ label = 'Email', value }) => {
+		return (
+			<>
+				<H4 cfg={{ lineHeight: 3 }}>{label}</H4>
+				<P cfg={{ wordBreak: 'all' }}>{value}</P>
+			</>
+		);
+	},
+);

--- a/packages/layout/src/components/cards/common/views/preview/components/phonePreview.tsx
+++ b/packages/layout/src/components/cards/common/views/preview/components/phonePreview.tsx
@@ -2,18 +2,17 @@ import React from 'react';
 import { H4, P } from '@tpr/core';
 
 interface PhonePreviewProps {
-  label?:string,
-  value: string
+	label?: string;
+	value: string;
 }
 
-export const PhonePreview:React.FC<PhonePreviewProps> = React.memo(({
-  label = 'Phone',
-  value
-}) => {
-  return (
-    <>
-      <H4 cfg={{ lineHeight: 3 }}>{label}</H4>
-      <P x-ms-format-detection="none">{value}</P>
-    </>
-  )
-});
+export const PhonePreview: React.FC<PhonePreviewProps> = React.memo(
+	({ label = 'Phone', value }) => {
+		return (
+			<>
+				<H4 cfg={{ lineHeight: 3 }}>{label}</H4>
+				<P x-ms-format-detection="none">{value}</P>
+			</>
+		);
+	},
+);

--- a/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
@@ -3,7 +3,10 @@ import { Checkbox } from '@tpr/forms';
 import { Flex, P, Hr, classNames } from '@tpr/core';
 import { UnderlinedButton } from '../../../components/button';
 import { useCorporateGroupContext } from '../../context';
-import { PhonePreview, EmailPreview } from '../../../common/views/preview/components';
+import {
+	PhonePreview,
+	EmailPreview,
+} from '../../../common/views/preview/components';
 import styles from './preview.module.scss';
 
 export const Preview: React.FC<any> = () => {
@@ -70,8 +73,12 @@ export const Preview: React.FC<any> = () => {
 								? `${corporateGroup.title} ${corporateGroup.firstName} ${corporateGroup.lastName}`
 								: `${corporateGroup.firstName} ${corporateGroup.lastName}`}
 						</P>
-						{corporateGroup.telephoneNumber && <PhonePreview value={corporateGroup.telephoneNumber} />}
-						{corporateGroup.emailAddress && <EmailPreview value={corporateGroup.emailAddress} />}
+						{corporateGroup.telephoneNumber && (
+							<PhonePreview value={corporateGroup.telephoneNumber} />
+						)}
+						{corporateGroup.emailAddress && (
+							<EmailPreview value={corporateGroup.emailAddress} />
+						)}
 					</Flex>
 				</Flex>
 			</Flex>

--- a/packages/layout/src/components/cards/inHouse/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/preview/preview.tsx
@@ -3,7 +3,10 @@ import { Checkbox } from '@tpr/forms';
 import { Flex, P, Hr, classNames } from '@tpr/core';
 import { UnderlinedButton } from '../../../components/button';
 import { useInHouseAdminContext } from '../../context';
-import { PhonePreview, EmailPreview } from '../../../common/views/preview/components';
+import {
+	PhonePreview,
+	EmailPreview,
+} from '../../../common/views/preview/components';
 import styles from './preview.module.scss';
 
 export const Preview: React.FC<any> = () => {
@@ -53,8 +56,12 @@ export const Preview: React.FC<any> = () => {
 						{i18n.preview.buttons.four}
 					</UnderlinedButton>
 					<Flex cfg={{ my: 2, flexDirection: 'column' }}>
-						{inHouseAdmin.telephoneNumber && <PhonePreview value={inHouseAdmin.telephoneNumber} />}
-						{inHouseAdmin.emailAddress && <EmailPreview value={inHouseAdmin.emailAddress} />}
+						{inHouseAdmin.telephoneNumber && (
+							<PhonePreview value={inHouseAdmin.telephoneNumber} />
+						)}
+						{inHouseAdmin.emailAddress && (
+							<EmailPreview value={inHouseAdmin.emailAddress} />
+						)}
 					</Flex>
 				</Flex>
 			</Flex>

--- a/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
@@ -3,7 +3,10 @@ import { Checkbox } from '@tpr/forms';
 import { Flex, P, Hr, classNames } from '@tpr/core';
 import { UnderlinedButton } from '../../../components/button';
 import { useInsurerContext } from '../../context';
-import { PhonePreview, EmailPreview } from '../../../common/views/preview/components';
+import {
+	PhonePreview,
+	EmailPreview,
+} from '../../../common/views/preview/components';
 import styles from './preview.module.scss';
 
 export const Preview: React.FC<any> = () => {
@@ -45,8 +48,12 @@ export const Preview: React.FC<any> = () => {
 				>
 					<UnderlinedButton>{i18n.preview.buttons.four}</UnderlinedButton>
 					<Flex cfg={{ my: 2, flexDirection: 'column' }}>
-						{insurer.telephoneNumber && <PhonePreview value={insurer.telephoneNumber} />}
-						{insurer.emailAddress && <EmailPreview value={insurer.emailAddress} />}
+						{insurer.telephoneNumber && (
+							<PhonePreview value={insurer.telephoneNumber} />
+						)}
+						{insurer.emailAddress && (
+							<EmailPreview value={insurer.emailAddress} />
+						)}
 					</Flex>
 
 					{/* Contact details block: display only	 */}

--- a/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
@@ -4,7 +4,10 @@ import { useTrusteeContext } from '../../context';
 import { UnderlinedButton } from '../../../components/button';
 import { Checkbox } from '@tpr/forms';
 import { capitalize } from '../../../../../utils';
-import { PhonePreview, EmailPreview } from '../../../common/views/preview/components';
+import {
+	PhonePreview,
+	EmailPreview,
+} from '../../../common/views/preview/components';
 import styles from './preview.module.scss';
 
 export const Preview: React.FC = () => {
@@ -50,8 +53,12 @@ export const Preview: React.FC = () => {
 						{i18n.preview.buttons.four}
 					</UnderlinedButton>
 					<Flex cfg={{ mt: 1, flexDirection: 'column' }}>
-						{trustee.telephoneNumber && <PhonePreview value={trustee.telephoneNumber} />}
-						{trustee.emailAddress && <EmailPreview value={trustee.emailAddress} />}
+						{trustee.telephoneNumber && (
+							<PhonePreview value={trustee.telephoneNumber} />
+						)}
+						{trustee.emailAddress && (
+							<EmailPreview value={trustee.emailAddress} />
+						)}
 					</Flex>
 				</Flex>
 			</Flex>


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

Fixing bug on `FFRadioButton` in IE where the `hint` text goes beyond the container's width.
https://dev.azure.com/thepensionsregulator/TPR/_workitems/edit/62030/

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
