### PR TITLE
Feature/bug 74818 year field allows 5+ zeros

### DIFF
--- a/packages/forms/src/elements/date/date.tsx
+++ b/packages/forms/src/elements/date/date.tsx
@@ -50,6 +50,7 @@ type DateInputFieldProps = {
 	disabled?: boolean;
 	readOnly?: boolean;
 	hideMonth?: boolean;
+	maxLength?: number;
 };
 const DateInputField: React.FC<DateInputFieldProps> = ({
 	small = true,
@@ -65,6 +66,7 @@ const DateInputField: React.FC<DateInputFieldProps> = ({
 	disabled,
 	readOnly,
 	hideMonth,
+	maxLength,
 }) => {
 	return (
 		<label className={small ? styles.inputSmall : styles.inputLarge}>
@@ -86,7 +88,7 @@ const DateInputField: React.FC<DateInputFieldProps> = ({
 				}}
 				meta={meta}
 				autoComplete="off"
-				maxLength="4"
+				maxLength={maxLength}
 			/>
 		</label>
 	);
@@ -196,6 +198,7 @@ export const InputDate: React.FC<InputDateComponentProps> = memo(
 						disabled={disabled}
 						readOnly={readOnly}
 						hideMonth={hideMonth}
+						maxLength={4}
 					/>
 				</Flex>
 			</StyledInputLabel>

--- a/packages/forms/src/elements/date/date.tsx
+++ b/packages/forms/src/elements/date/date.tsx
@@ -11,7 +11,7 @@ import styles from './date.module.scss';
 const handleChange = (onChange: Function, value: number) => ({
 	target,
 }: ChangeEvent<HTMLInputElement>) => {
-	const newValue = target.value.replace(/[^0-9]/g, '').trim();
+	const newValue = target.value.replace(/[^0-9]{4}/g, '').trim();
 	if (!newValue) return onChange('');
 	if (parseInt(newValue, 10) < value) {
 		return onChange(newValue);
@@ -86,6 +86,7 @@ const DateInputField: React.FC<DateInputFieldProps> = ({
 				}}
 				meta={meta}
 				autoComplete="off"
+				maxLength="4"
 			/>
 		</label>
 	);

--- a/packages/forms/src/elements/date/date.tsx
+++ b/packages/forms/src/elements/date/date.tsx
@@ -167,6 +167,7 @@ export const InputDate: React.FC<InputDateComponentProps> = memo(
 							meta={meta}
 							disabled={disabled}
 							readOnly={readOnly}
+							maxLength={2}
 						/>
 					)}
 					{!hideMonth && (
@@ -182,6 +183,7 @@ export const InputDate: React.FC<InputDateComponentProps> = memo(
 							meta={meta}
 							disabled={disabled}
 							readOnly={readOnly}
+							maxLength={2}
 						/>
 					)}
 					<DateInputField

--- a/packages/forms/src/elements/date/date.tsx
+++ b/packages/forms/src/elements/date/date.tsx
@@ -11,7 +11,7 @@ import styles from './date.module.scss';
 const handleChange = (onChange: Function, value: number) => ({
 	target,
 }: ChangeEvent<HTMLInputElement>) => {
-	const newValue = target.value.replace(/[^0-9]{4}/g, '').trim();
+	const newValue = target.value.replace(/[^0-9]/g, '').trim();
 	if (!newValue) return onChange('');
 	if (parseInt(newValue, 10) < value) {
 		return onChange(newValue);


### PR DESCRIPTION
#### Fixes [AB#74818](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/74818) AND [AB#69456](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/69456)

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Setting the max length of date input to 4 to resolve bug of user being able to enter more than 4 zeros e.g. `00000` into the year field.
- Setting the maxLength of date input to 2 for day and month field. Resolve bug of being able to type `031` and `012` respectively .


#### Reviewers should focus on:
- The year field on Date input
- The month field on Date input
- The day field on Date input

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
