### PR TITLE
moving 'new Event' declaration into useEffect

### DIFF
--- a/packages/forms/src/elements/address/editAddress.tsx
+++ b/packages/forms/src/elements/address/editAddress.tsx
@@ -43,8 +43,6 @@ export const EditAddress: React.FC<EditAddressProps> = React.memo(
 	}) => {
 		const form = useForm();
 
-		const blurEvent = new Event('blur', { bubbles: true });
-
 		function isDirty() {
 			const selectedAddress = form.getFieldState('selectedAddress');
 			return selectedAddress && selectedAddress.dirty;
@@ -100,6 +98,7 @@ export const EditAddress: React.FC<EditAddressProps> = React.memo(
 		const address2ref = useRef(null);
 
 		useEffect(() => {
+			const blurEvent = new Event('blur', { bubbles: true });
 			// in some cases when 'value'=='initialValue',
 			// the input fields do not refresh the view and keep the previous values,
 			// dispatching a 'blur' event will refresh the view with the correct values.


### PR DESCRIPTION

#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

When running the Netlify checks, the build fails giving an error of `WebpackError: ReferenceError: Event is not defined.`
It seems to be due to the declaration of the Event being outside a function and gatsby doesn't handle it correctly.
Placing the declaration inside `useEffect`, should fix this error, because we use similar code in other components and it worked before without errors.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
