### PR TITLE
fixing error in Netlify about 'window not available'

### DIFF
--- a/packages/layout/src/components/sidebar/sidebar.mdx
+++ b/packages/layout/src/components/sidebar/sidebar.mdx
@@ -21,7 +21,9 @@ import { Sidebar } from '@tpr/layout';
 
 <Playground>
 	{() => {
-		const location = window.location;
+		const location = {
+			pathname: '/layout/sidebar',
+		};
 		const sections = [
 			{
 				title: 'Scheme details',
@@ -97,7 +99,9 @@ import { Sidebar } from '@tpr/layout';
 
 <Playground>
 	{() => {
-		const location = window.location;
+		const location = {
+			pathname: '/layout/sidebar',
+		};
 		const sections = [
 			{
 				title: 'Scheme details (DB)',
@@ -239,7 +243,9 @@ import { Sidebar } from '@tpr/layout';
 
 <Playground>
 	{() => {
-		const location = window.location;
+		const location = {
+			pathname: '/layout/sidebar',
+		};
 		const sections = [
 			{
 				title: 'Roles',


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

The Netlify checks fail giving the following error:
`"window" is not available during server side rendering.`
This is because when building the app, the window object is not defined.

Passing a static object instead of a reference to `window.location` in `sidebar.mdx` should fix this error.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
