### PR TITLE
adding the option of displaying a Button with 'white' or 'black' background

### DIFF
--- a/packages/core/src/components/buttons/buttons.mdx
+++ b/packages/core/src/components/buttons/buttons.mdx
@@ -78,24 +78,32 @@ import { Button } from '@tpr/core';
 ### Primary appearance with intent
 
 <Playground>
-	<Button cfg={{ mr: 3 }} intent="none">
-		Click me
-	</Button>
-	<Button cfg={{ mr: 3 }} intent="success">
-		Click me
-	</Button>
-	<Button cfg={{ mr: 3 }} intent="warning">
-		Click me
-	</Button>
-	<Button cfg={{ mr: 3 }} intent="danger">
-		Click me
-	</Button>
-	<Button cfg={{ mr: 3 }} intent="special">
-		Click me
-	</Button>
-	<Button cfg={{ mr: 3 }} disabled>
-		Click me
-	</Button>
+	<div style={{ background: '#e1e1e1' }}>
+		<Button cfg={{ mr: 3, my: 3 }} intent="none">
+			Click me
+		</Button>
+		<Button cfg={{ mr: 3 }} intent="success">
+			Click me
+		</Button>
+		<Button cfg={{ mr: 3 }} intent="warning">
+			Click me
+		</Button>
+		<Button cfg={{ mr: 3 }} intent="danger">
+			Click me
+		</Button>
+		<Button cfg={{ mr: 3 }} intent="special">
+			Click me
+		</Button>
+		<Button cfg={{ mr: 3 }} intent="white">
+			Click me
+		</Button>
+		<Button cfg={{ mr: 3 }} intent="black">
+			Click me
+		</Button>
+		<Button cfg={{ mr: 3 }} disabled>
+			Click me
+		</Button>
+	</div>
 </Playground>
 
 ### Outlined appearance with intent
@@ -114,6 +122,9 @@ import { Button } from '@tpr/core';
 		Click me
 	</Button>
 	<Button cfg={{ mr: 3 }} appearance="outlined" intent="special">
+		Click me
+	</Button>
+	<Button cfg={{ mr: 3 }} appearance="outlined" intent="black">
 		Click me
 	</Button>
 	<Button cfg={{ mr: 3 }} appearance="outlined" disabled>

--- a/packages/core/src/components/buttons/buttons.module.scss
+++ b/packages/core/src/components/buttons/buttons.module.scss
@@ -27,6 +27,14 @@
 	border: 2px solid $colors-primary-3;
 	background: transparent !important;
 	border-radius: 6px;
+
+	&.intent-black {
+		color: $black;
+
+		&:hover {
+			color: $white !important;
+		}
+	}
 }
 
 .appearance-outlined:disabled {
@@ -41,56 +49,76 @@
 	}
 }
 
-/* 'none' | 'success' | 'warning' | 'danger'; */
+/* 'none' | 'success' | 'warning' | 'danger' | 'special' | 'white'; */
 
 .intent-none {
 	background: $colors-primary-3;
 	border-color: $colors-primary-3;
-}
 
-.intent-none:hover {
-	background: $colors-primary-3 !important;
-	color: white;
+	&:hover {
+		background: $colors-primary-3 !important;
+		color: white;
+	}
 }
 
 .intent-success {
 	background: $colors-success-1;
 	border-color: $colors-success-1;
-}
 
-.intent-success:hover {
-	background: $colors-success-1 !important;
-	color: white;
+	&:hover {
+		background: $colors-success-1 !important;
+		color: white;
+	}
 }
 
 .intent-warning {
 	background: $colors-warning-1;
 	border-color: $colors-warning-1;
-}
 
-.intent-warning:hover {
-	background: $colors-warning-1 !important;
-	color: white;
+	&:hover {
+		background: $colors-warning-1 !important;
+		color: white;
+	}
 }
 
 .intent-danger {
 	background: $colors-danger-2;
 	border-color: $colors-danger-2;
-}
 
-.intent-danger:hover {
-	background: $colors-danger-2 !important;
-	color: white;
+	&:hover {
+		background: $colors-danger-2 !important;
+		color: white;
+	}
 }
 
 .intent-special {
 	background: $colors-primary-a2;
 	border-color: $colors-primary-a2;
+
+	&:hover {
+		background: $colors-primary-a2 !important;
+		color: white;
+	}
 }
 
-.intent-special:hover {
-	background: $colors-primary-a2 !important;
-	color: white;
+.intent-white {
+	background: $white;
+	color: $colors-neutral-8;
+	border-color: $colors-neutral-8;
+
+	&:hover {
+		background: $white !important;
+	}
+}
+
+.intent-black {
+	background: $black;
+	color: $colors-neutral-1;
+	border-color: $black;
+
+	&:hover {
+		background: $black !important;
+	}
 }
 
 /* 'small' | 'medium' | 'large'; */

--- a/packages/core/src/components/buttons/buttons.tsx
+++ b/packages/core/src/components/buttons/buttons.tsx
@@ -14,7 +14,7 @@ export type ButtonProps = {
 	className?: string;
 	cfg?: SpaceProps;
 	appearance?: 'primary' | 'outlined';
-	intent?: 'none' | 'success' | 'warning' | 'danger' | 'special';
+	intent?: 'none' | 'success' | 'warning' | 'danger' | 'special' | 'white';
 	size?: 'small' | 'medium' | 'large';
 	before?: any;
 	after?: any;


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- `white` & `black` added as values for the `intent` prop in order to change the background color of a `Button` element

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
