### PR TITLE
adding font-weight '4' value to TypographyProps

### DIFF
--- a/packages/core/src/components/globals/globals.module.scss
+++ b/packages/core/src/components/globals/globals.module.scss
@@ -664,6 +664,10 @@
 	font-weight: $font-weight-3 !important;
 }
 
+.fontWeight-4 {
+	font-weight: $font-weight-4 !important;
+}
+
 /* line heights */
 
 .lineHeight-1 {
@@ -703,7 +707,6 @@
 .wordBreak-inherit {
 	word-break: inherit !important;
 }
-
 
 /* BACKGROUND */
 

--- a/packages/core/src/components/globals/globals.tsx
+++ b/packages/core/src/components/globals/globals.tsx
@@ -84,7 +84,7 @@ export type WordBreak =
 export type TypographyProps = Partial<{
 	fontSize: ValuesFullRange;
 	textAlign: 'left' | 'center' | 'right';
-	fontWeight: 1 | 2 | 3;
+	fontWeight: 1 | 2 | 3 | 4;
 	lineHeight: 1 | 2 | 3;
 	wordBreak: WordBreak;
 }>;

--- a/packages/theming/src/variables.scss
+++ b/packages/theming/src/variables.scss
@@ -61,6 +61,7 @@ $font-size-6: 45px;
 $font-weight-1: 300;
 $font-weight-2: 400;
 $font-weight-3: 600;
+$font-weight-4: 700;
 /**** BREAKPOINTS ****/
 $breakpoint-1: 48em;
 $breakpoint-2: 64em;


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Adding value of '4' to `TypographyProps` for displaying `font-weight: 700`

`fontWeight: 1 | 2 | 3 | 4;`

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
