### PR TITLE
AB#78750 add check to see if homepage is active

### DIFF
--- a/packages/layout/src/components/sidebar/sidebar.tsx
+++ b/packages/layout/src/components/sidebar/sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Flex, Link, P, flatten } from '@tpr/core';
 import { callAllEventHandlers } from '../../utils';
 import SidebarMenu from './components/SidebarMenu';
@@ -85,6 +85,15 @@ export const Sidebar: React.FC<SidebarProps> = ({
 	const routerProps = { matchPath, location, history };
 	const sections = useSectionsUpdater(originalSections, routerProps);
 	const [totalSections, totalCompleted] = useCalculateProgress(sections);
+	const [isHomePageActive, setIsHomePageActive] = useState(false);
+
+	useEffect(() => {
+		const match = matchPath(location.pathname, {
+			path: titlePath,
+			exact: true,
+		});
+		match ? setIsHomePageActive(true) : setIsHomePageActive(false);
+	}, [location.pathname]);
 
 	return (
 		<div className={styles.sidebar}>
@@ -100,6 +109,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
 						fontSize: 4,
 					}}
 					onClick={() => history.push(titlePath)}
+					className={isHomePageActive ? styles.activeLink : ''}
 				>
 					{title}
 				</Link>


### PR DESCRIPTION
#### Fixes [AB#78750](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/78750)

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Adds a blue bar next to the home link when the home link is active

#### Reviewers should focus on:

- Sidebar component

#### Screenshot

![image](https://user-images.githubusercontent.com/25232112/104443672-a2cd1b80-558e-11eb-9583-4d098f027f32.png)

