### PR TITLE
Bugfix/78750 blue bar for home link

### DIFF
--- a/packages/layout/src/components/sidebar/sidebar.tsx
+++ b/packages/layout/src/components/sidebar/sidebar.tsx
@@ -102,6 +102,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
 				className={styles.sidebarMenu}
 			>
 				<Link
+					underline={isHomePageActive}
 					cfg={{
 						fontWeight: 3,
 						color: 'primary.2',


### PR DESCRIPTION
#### Fixes [AB#78750](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/78750)

Adds underline to active home link

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
