### PR TITLE
Remove contact details from Insurer card

### DIFF
--- a/packages/forms/src/elements/elements.tsx
+++ b/packages/forms/src/elements/elements.tsx
@@ -62,7 +62,9 @@ export const InputElementHeading: React.FC<InputElementHeadingProps> = ({
 				</FormLabelText>
 			)}
 			{hint && (
-				<Span cfg={{ mb: 2 }} className={styles.hint}>{hint}</Span>
+				<Span cfg={{ mb: 2 }} className={styles.hint}>
+					{hint}
+				</Span>
 			)}
 			{meta && meta.touched && meta.error && (
 				<ErrorMessage>{meta.error}</ErrorMessage>

--- a/packages/forms/src/validation.ts
+++ b/packages/forms/src/validation.ts
@@ -29,10 +29,11 @@ export function validate(formFields: FieldProps[]) {
 				if (errorMessage) return merge(errors, errorObject);
 			}
 			// typof error is a string and there is no field value, assign error to errors
-			if (typeof error === 'string' &&
+			if (
+				typeof error === 'string' &&
 				(!fieldValue ||
-				(typeof fieldValue === 'string' && !fieldValue.trim()) ||
-				(Array.isArray(fieldValue) && !fieldValue.length))
+					(typeof fieldValue === 'string' && !fieldValue.trim()) ||
+					(Array.isArray(fieldValue) && !fieldValue.length))
 			) {
 				// construct object from string with errors
 				const errorObject = qs.parse(`${name}=${error}`, {

--- a/packages/layout/src/components/__tests__/insurer.spec.tsx
+++ b/packages/layout/src/components/__tests__/insurer.spec.tsx
@@ -25,8 +25,8 @@ const insurer: Insurer = {
 		county: 'West Sussex',
 		countryId: 2,
 	},
-	telephoneNumber: '01273 222 111',
-	emailAddress: 'john.wick@warnerbros.com',
+	telephoneNumber: '',
+	emailAddress: '',
 };
 
 describe('Insurer Preview', () => {

--- a/packages/layout/src/components/cards/insurer/i18n.ts
+++ b/packages/layout/src/components/cards/insurer/i18n.ts
@@ -5,7 +5,6 @@ export type InsurerI18nProps = {
 			two: string;
 			three: string;
 			four: string;
-			five: string;
 		};
 		statusText: {
 			confirmed: string;
@@ -68,8 +67,7 @@ export const i18n: InsurerI18nProps = {
 			one: 'Insurer administrator',
 			two: 'Remove',
 			three: 'Address',
-			four: 'Contact details',
-			five: 'Insurer reference number',
+			four: 'Insurer reference number',
 		},
 		statusText: {
 			confirmed: 'Confirmed',

--- a/packages/layout/src/components/cards/insurer/insurer.mdx
+++ b/packages/layout/src/components/cards/insurer/insurer.mdx
@@ -37,8 +37,6 @@ import { InsurerCard } from '@tpr/layout';
 			organisationReference: 123,
 			organisationName: 'Nike Inc.',
 			insurerCompanyReference: '12345678',
-			telephoneNumber: '01273 222 111',
-			emailAddress: 'john.wick@warnerbros.com',
 			address: {
 				addressLine1: 'Napier House',
 				addressLine2: 'Trafalgar Pl',
@@ -47,6 +45,8 @@ import { InsurerCard } from '@tpr/layout';
 				postcode: 'BN1 4DW',
 				county: 'West Sussex',
 			},
+			telephoneNumber: '',
+			emailAddress: '',
 		};
 		return (
 			<InsurerCard
@@ -64,12 +64,12 @@ import { InsurerCard } from '@tpr/layout';
 
 ### Props
 
-| Property         | Required | Type             | Description                                                                              |
-| ---------------- | -------- | ---------------- | ---------------------------------------------------------------------------------------- |
-| complete         | true     | boolean          | changes the state of the card when All details are correct                               |
-| i18n             | false    | InsurerI18nProps | allows to override specific text in the card                                             |
-| insurer          | true     | Insurer          | the Insurer object                                                                       |
+| Property         | Required | Type             | Description                                                                                  |
+| ---------------- | -------- | ---------------- | -------------------------------------------------------------------------------------------- |
+| complete         | true     | boolean          | changes the state of the card when All details are correct                                   |
+| i18n             | false    | InsurerI18nProps | allows to override specific text in the card                                                 |
+| insurer          | true     | Insurer          | the Insurer object                                                                           |
 | onCorrect        | true     | function         | actions for when the user clicks the "Confirm details are correct" checkbox                  |
-| onRemove         | true     | function         | actions for when the insurer is removed                                                  |
-| onSaveRef        | true     | function         | actions for when the insurer reference number is modified                                |
+| onRemove         | true     | function         | actions for when the insurer is removed                                                      |
+| onSaveRef        | true     | function         | actions for when the insurer reference number is modified                                    |
 | prevalidatedData | false    | boolean          | allows to ignore the state of the "Confirm details are correct" checkbox & shows "No issues" |

--- a/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
@@ -3,10 +3,6 @@ import { Checkbox } from '@tpr/forms';
 import { Flex, P, Hr, classNames } from '@tpr/core';
 import { UnderlinedButton } from '../../../components/button';
 import { useInsurerContext } from '../../context';
-import {
-	PhonePreview,
-	EmailPreview,
-} from '../../../common/views/preview/components';
 import styles from './preview.module.scss';
 
 export const Preview: React.FC<any> = () => {
@@ -42,23 +38,12 @@ export const Preview: React.FC<any> = () => {
 					</Flex>
 				</Flex>
 
-				{/* Contact details block: display only	 */}
+				{/* Insurer reference number */}
 				<Flex
 					cfg={{ width: 5, flex: '0 0 auto', flexDirection: 'column', pl: 4 }}
 				>
-					<UnderlinedButton>{i18n.preview.buttons.four}</UnderlinedButton>
-					<Flex cfg={{ my: 2, flexDirection: 'column' }}>
-						{insurer.telephoneNumber && (
-							<PhonePreview value={insurer.telephoneNumber} />
-						)}
-						{insurer.emailAddress && (
-							<EmailPreview value={insurer.emailAddress} />
-						)}
-					</Flex>
-
-					{/* Contact details block: display only	 */}
 					<UnderlinedButton isOpen={false} onClick={() => send('EDIT_INSURER')}>
-						{i18n.preview.buttons.five}
+						{i18n.preview.buttons.four}
 					</UnderlinedButton>
 					<Flex cfg={{ mt: 1, flexDirection: 'column' }}>
 						<P>{insurer.insurerCompanyReference}</P>


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Insurer card should not display the contact details section (email & phone), however these info might still be included in the API.
https://dev.azure.com/thepensionsregulator/TPR/_workitems/edit/78312/

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
