### PR TITLE
fix menu link colour

### DIFF
--- a/packages/layout/src/components/cards/components/button.module.scss
+++ b/packages/layout/src/components/cards/components/button.module.scss
@@ -13,6 +13,10 @@
 	width: 100%;
 	height: $space-5;
 	min-height: $space-5;
+
+	p {
+		color: $colors-primary-3;
+	}
 }
 
 .button:hover {

--- a/packages/theming/src/resets.module.scss
+++ b/packages/theming/src/resets.module.scss
@@ -8,7 +8,6 @@
 // apply css resets for all elements within a div. We don't want to reset default docz styles.
 
 .bodyreset * {
-	color: #3d3d3d;
 	border: 0;
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
Fix the colour of trustee and service provider card menu links. Also fix default colour on playground pages.