### PR TITLE
#80620 - Add style classes that allow the styling of header tags.  Ma…

### DIFF
--- a/packages/core/src/components/typography/typography.module.scss
+++ b/packages/core/src/components/typography/typography.module.scss
@@ -1,6 +1,6 @@
 @import '@tpr/theming/lib/variables.scss';
 
-.h1 {
+@mixin styled-as-h1 {
 	font-family: $fonts-sans-serif;
 	font-weight: $font-weight-3;
 	font-size: $font-size-6;
@@ -9,7 +9,7 @@
 	color: $colors-neutral-8;
 }
 
-.h2 {
+@mixin styled-as-h2 {
 	font-family: $fonts-sans-serif;
 	font-weight: $font-weight-2;
 	font-size: $font-size-5;
@@ -17,7 +17,7 @@
 	line-height: $line-height-1;
 }
 
-.h3 {
+@mixin styled-as-h3 {
 	font-family: $fonts-sans-serif;
 	font-weight: $font-weight-1;
 	font-size: $font-size-4;
@@ -25,7 +25,7 @@
 	line-height: $line-height-1;
 }
 
-.h4 {
+@mixin styled-as-h4 {
 	font-family: $fonts-sans-serif;
 	font-weight: $font-weight-3;
 	font-size: $font-size-3;
@@ -33,7 +33,7 @@
 	line-height: $line-height-1;
 }
 
-.h5 {
+@mixin styled-as-h5 {
 	font-family: $fonts-sans-serif;
 	font-weight: $font-weight-2;
 	font-size: $font-size-2;
@@ -41,12 +41,60 @@
 	line-height: $line-height-1;
 }
 
-.h6 {
+@mixin styled-as-h6 {
 	font-family: $fonts-sans-serif;
 	font-weight: $font-weight-2;
-	font-size: $font-size-1;
+	font-size: $font-size-2;
 	letter-spacing: 0px;
 	line-height: $line-height-1;
+}
+
+.h1 {
+	@include styled-as-h1;
+}
+
+.h2 {
+	@include styled-as-h2;
+}
+
+.h3 {
+	@include styled-as-h3;
+}
+
+.h4 {
+	@include styled-as-h4;
+}
+
+.h5 {
+	@include styled-as-h5;
+}
+
+.h6 {
+	@include styled-as-h6;
+}
+
+.styledAsH1 {
+	@include styled-as-h1;
+}
+
+.styledAsH2 {
+	@include styled-as-h2;
+}
+
+.styledAsH3 {
+	@include styled-as-h3;
+}
+
+.styledAsH4 {
+	@include styled-as-h4;
+}
+
+.styledAsH5 {
+	@include styled-as-h5;
+}
+
+.styledAsH6 {
+	@include styled-as-h5;
 }
 
 .p {

--- a/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
+++ b/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { H3, Flex, Hr, Link } from '@tpr/core';
+import { H2, Flex, Hr, Link } from '@tpr/core';
 import { SidebarLinkProps, SidebarMenuProps } from './types';
 import StatusIcon from './StatusIcon';
 import styles from '../sidebar.module.scss';
@@ -55,9 +55,9 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 
 	return (
 		<Flex cfg={{ flexDirection: 'column' }} className={styles.sidebarMenu}>
-			<H3 cfg={{ fontWeight: 3, mt: 4, color: 'neutral.8', lineHeight: 6 }}>
+			<H2 cfg={{ fontWeight: 3, mt: 4, color: 'neutral.8', lineHeight: 6 }} className={styles.styledAsH3}>
 				{title}
-			</H3>
+			</H2>
 			<Hr cfg={{ my: 4 }} />
 			{links.map(
 				({ onClick = () => {}, active = () => false, ...link }, key) => (

--- a/packages/layout/src/components/sidebar/sidebar.module.scss
+++ b/packages/layout/src/components/sidebar/sidebar.module.scss
@@ -1,4 +1,5 @@
 @import '@tpr/theming/lib/variables.scss';
+@import '@tpr/core/lib/components/typography/typography.module.scss';
 
 .sidebar {
 	display: flex;


### PR DESCRIPTION
Add some style classes to allow overriding of header styles so that structurally a header can be at one level, but present like another.

Modify the sidebar so that the headers are H2 but continue to render as H3 like before.