### PR TITLE
fix for headings overlapping in cards AB#59432

### DIFF
--- a/packages/layout/src/components/cards/cards.module.scss
+++ b/packages/layout/src/components/cards/cards.module.scss
@@ -12,7 +12,7 @@
 	display: flex;
 	flex-direction: row;
 	flex: 0 0 auto;
-	height: 100px;
+	min-height: 100px;
 	padding: 40px 40px 0 40px;
 	border-left: 5px solid;
 	border-color: $colors-danger-2;
@@ -30,6 +30,5 @@
 }
 
 .extraPB {
-	padding-bottom: 40px;
-	height: 140px;
+	padding-bottom: 16px;
 }

--- a/packages/layout/src/components/cards/components/button.module.scss
+++ b/packages/layout/src/components/cards/components/button.module.scss
@@ -11,7 +11,6 @@
 	border-bottom-color: $colors-primary-3;
 	padding: 0 0 4px 2px;
 	width: 100%;
-	height: $space-5;
 	min-height: $space-5;
 
 	p {
@@ -41,12 +40,5 @@
 	border-bottom-color: $colors-neutral-7;
 	padding: 0 0 4px 2px;
 	width: 100%;
-	height: $space-5;
-
-	// IE ignores the height property if the height of the sibling and parent elements are not specified too.
-	// in order to make it a fixed height of $space-5 we use min-height and max-height
-	@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-		min-height: $space-5;
-		max-height: $space-5;
-	}
+	min-height: $space-5;
 }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

https://dev.azure.com/thepensionsregulator/TPR/_workitems/edit/59432/
Removing `height` from some styles in order to allow the containers to expand when the content does not fit in one line.
In some cases need to keep `min-height` for a correct display in IE.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
