### PR TITLE
Bug 71087: Use separate error messages for reasons and dates on "remove" trustee cards.

### DIFF
--- a/packages/forms/src/elements/elements.module.scss
+++ b/packages/forms/src/elements/elements.module.scss
@@ -32,4 +32,5 @@
 	font-weight: $font-weight-3;
 	margin-bottom: $space-2;
 	max-width: 100%;
+	white-space: pre-line;
 }

--- a/packages/layout/src/components/__tests__/trustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/trustee.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { cleanup, render } from '@testing-library/react';
 import { TrusteeCard } from '../cards/trustee/trustee';
 import { axe } from 'jest-axe';
 import { Trustee } from '../cards/trustee/context';
@@ -255,33 +255,8 @@ describe('Trustee Contact Details', () => {
 });
 
 describe('Trustee Remove', () => {
-	test('is accessible', async () => {
-		const { container, getByText } = render(
-			<TrusteeCard
-				onDetailsSave={noop}
-				onContactSave={noop}
-				onAddressSave={noop}
-				onRemove={noop}
-				onCorrect={(_value) => {}}
-				addressAPI={{
-					get: (_endpont) => Promise.resolve(),
-					limit: 100,
-				}}
-				complete={true}
-				trustee={trustee}
-				testId={trustee.schemeRoleId}
-			/>,
-		);
-
-		getByText('Remove').click();
-
-		const results = await axe(container);
-		expect(results).toHaveNoViolations();
-	});
-});
-
-describe('Trustee Remove', () => {
-	test('displays correct validation messages', async () => {
+	let component, findByText, findByTestId;
+	beforeEach(async () => {
 		const { container, getByText, getByTestId } = render(
 			<TrusteeCard
 				onDetailsSave={noop}
@@ -299,19 +274,36 @@ describe('Trustee Remove', () => {
 			/>,
 		);
 
-		getByText('Remove').click();
-		getByText('Continue').click();
-		const msg1 = getByText('Select a reason for removing the trustee.');
+		component = container;
+		findByText = getByText;
+		findByTestId = getByTestId;
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	test('is accessible', async () => {
+		findByText('Remove').click();
+
+		const results = await axe(component);
+		expect(results).toHaveNoViolations();
+	});
+
+	test('displays correct validation messages', async () => {
+		findByText('Remove').click();
+		findByText('Continue').click();
+		const msg1 = findByText('Select a reason for removing the trustee.');
 		expect(msg1).toBeDefined();
 		expect(msg1.className.includes('errorMessage')).toBeTruthy();
 
-		getByTestId('leftTheScheme').click();
-		getByText('Continue').click();
-		const msg2 = getByText('Enter the date the trustee left the scheme.');
+		findByTestId('leftTheScheme').click();
+		findByText('Continue').click();
+		const msg2 = findByText('Enter the date the trustee left the scheme.');
 		expect(msg2).toBeDefined();
 		expect(msg2.className.includes('errorMessage')).toBeTruthy();
 
-		const results = await axe(container);
+		const results = await axe(component);
 		expect(results).toHaveNoViolations();
 	});
 });

--- a/packages/layout/src/components/__tests__/trustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/trustee.spec.tsx
@@ -31,156 +31,80 @@ const trustee: Trustee = {
 	emailAddress: 'fred.sandoors@trp.gov.uk',
 	effectiveDate: '1997-04-01T00:00:00',
 };
+let component, findByText, findByTestId;
+beforeEach(async () => {
+	const { container, getByText, getByTestId } = render(
+		<TrusteeCard
+			onDetailsSave={noop}
+			onContactSave={noop}
+			onAddressSave={noop}
+			onRemove={noop}
+			onCorrect={(_value) => {}}
+			addressAPI={{
+				get: (_endpont) => Promise.resolve(),
+				limit: 100,
+			}}
+			complete={true}
+			trustee={trustee}
+			testId={trustee.schemeRoleId}
+		/>,
+	);
+
+	component = container;
+	findByText = getByText;
+	findByTestId = getByTestId;
+});
+
+afterEach(() => {
+	cleanup();
+});
 
 describe('Trustee Preview', () => {
 	test('is accessible', async () => {
-		const { container } = render(
-			<TrusteeCard
-				onDetailsSave={noop}
-				onContactSave={noop}
-				onAddressSave={noop}
-				onRemove={noop}
-				onCorrect={(_value) => {}}
-				addressAPI={{
-					get: (_endpont) => Promise.resolve(),
-					limit: 100,
-				}}
-				complete={true}
-				trustee={trustee}
-				testId={trustee.schemeRoleId}
-			/>,
-		);
-
-		const results = await axe(container);
+		const results = await axe(component);
 		expect(results).toHaveNoViolations();
 	});
 
 	test('buttons renders correctly', () => {
-		const { getByText } = render(
-			<TrusteeCard
-				onDetailsSave={noop}
-				onContactSave={noop}
-				onAddressSave={noop}
-				onRemove={noop}
-				onCorrect={(_value) => {}}
-				addressAPI={{
-					get: (_endpont) => Promise.resolve(),
-					limit: 100,
-				}}
-				complete={true}
-				trustee={trustee}
-				testId={trustee.schemeRoleId}
-			/>,
-		);
-
 		// Buttons are visible
-
-		expect(getByText('Trustee')).toBeDefined();
-		expect(getByText('Correspondence address')).toBeDefined();
-		expect(getByText('Contact details')).toBeDefined();
-		expect(getByText('Remove')).toBeDefined();
+		expect(findByText('Trustee')).toBeDefined();
+		expect(findByText('Correspondence address')).toBeDefined();
+		expect(findByText('Contact details')).toBeDefined();
+		expect(findByText('Remove')).toBeDefined();
 	});
 
 	test('initial status is correct', () => {
-		const { getByText } = render(
-			<TrusteeCard
-				onDetailsSave={noop}
-				onContactSave={noop}
-				onAddressSave={noop}
-				onRemove={noop}
-				onCorrect={(_value) => {}}
-				addressAPI={{
-					get: (_endpont) => Promise.resolve(),
-					limit: 100,
-				}}
-				complete={true}
-				trustee={trustee}
-				testId={trustee.schemeRoleId}
-			/>,
-		);
-
-		expect(getByText('Confirmed')).toBeDefined();
-		expect(getByText('Confirm details are correct.')).toBeDefined();
+		expect(findByText('Confirmed')).toBeDefined();
+		expect(findByText('Confirm details are correct.')).toBeDefined();
 	});
 
 	test('address shows up correctly', () => {
-		const { getByText } = render(
-			<TrusteeCard
-				onDetailsSave={noop}
-				onContactSave={noop}
-				onAddressSave={noop}
-				onRemove={noop}
-				onCorrect={(_value) => {}}
-				addressAPI={{
-					get: (_endpont) => Promise.resolve(),
-					limit: 100,
-				}}
-				complete={true}
-				trustee={trustee}
-				testId={trustee.schemeRoleId}
-			/>,
-		);
-
-		expect(getByText(trustee.addressLine1)).toBeDefined();
-		expect(getByText(trustee.addressLine2)).toBeDefined();
-		expect(getByText(trustee.addressLine3)).toBeDefined();
-		expect(getByText(trustee.postTown)).toBeDefined();
-		expect(getByText(trustee.postcode)).toBeDefined();
+		expect(findByText(trustee.addressLine1)).toBeDefined();
+		expect(findByText(trustee.addressLine2)).toBeDefined();
+		expect(findByText(trustee.addressLine3)).toBeDefined();
+		expect(findByText(trustee.postTown)).toBeDefined();
+		expect(findByText(trustee.postcode)).toBeDefined();
 	});
 
 	test('contact details shows up correctly', () => {
-		const { getByText } = render(
-			<TrusteeCard
-				onDetailsSave={noop}
-				onContactSave={noop}
-				onAddressSave={noop}
-				onRemove={noop}
-				onCorrect={(_value) => {}}
-				addressAPI={{
-					get: (_endpont) => Promise.resolve(),
-					limit: 100,
-				}}
-				complete={true}
-				trustee={trustee}
-				testId={trustee.schemeRoleId}
-			/>,
-		);
-
-		expect(getByText('Phone')).toBeDefined();
-		expect(getByText(trustee.telephoneNumber)).toBeDefined();
-		expect(getByText('Email')).toBeDefined();
-		expect(getByText(trustee.emailAddress)).toBeDefined();
+		expect(findByText('Phone')).toBeDefined();
+		expect(findByText(trustee.telephoneNumber)).toBeDefined();
+		expect(findByText('Email')).toBeDefined();
+		expect(findByText(trustee.emailAddress)).toBeDefined();
 	});
 });
 
 describe('Trustee Name', () => {
 	test('is accessible', async () => {
-		const { container, getByText, getByTestId } = render(
-			<TrusteeCard
-				onDetailsSave={noop}
-				onContactSave={noop}
-				onAddressSave={noop}
-				onRemove={noop}
-				onCorrect={(_value) => {}}
-				addressAPI={{
-					get: (_endpont) => Promise.resolve(),
-					limit: 100,
-				}}
-				complete={true}
-				trustee={trustee}
-				testId={trustee.schemeRoleId}
-			/>,
-		);
-
-		getByText('Trustee').click();
-		const results = await axe(container);
+		findByText('Trustee').click();
+		const results = await axe(component);
 		expect(results).toHaveNoViolations();
 
-		expect(getByTestId('trustee-name-form')).not.toBe(null);
+		expect(findByTestId('trustee-name-form')).not.toBe(null);
 
-		var titleHtmlElement = getByText('Title (optional)') as HTMLElement;
-		var firstNameHtmlElement = getByText('First name') as HTMLElement;
-		var lastNameHtmlElement = getByText('Last name') as HTMLElement;
+		var titleHtmlElement = findByText('Title (optional)') as HTMLElement;
+		var firstNameHtmlElement = findByText('First name') as HTMLElement;
+		var lastNameHtmlElement = findByText('Last name') as HTMLElement;
 
 		expect(titleHtmlElement).toBeDefined();
 		expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
@@ -197,92 +121,30 @@ describe('Trustee Name', () => {
 			'maxlength',
 			'70',
 		);
-		expect(getByText('Continue')).toBeDefined();
+		expect(findByText('Continue')).toBeDefined();
 	});
 });
 
 describe('Trustee Type', () => {
 	test('is accessible', async () => {
-		const { container, getByText } = render(
-			<TrusteeCard
-				onDetailsSave={noop}
-				onContactSave={noop}
-				onAddressSave={noop}
-				onRemove={noop}
-				onCorrect={(_value) => {}}
-				addressAPI={{
-					get: (_endpont) => Promise.resolve(),
-					limit: 100,
-				}}
-				complete={true}
-				trustee={trustee}
-				testId={trustee.schemeRoleId}
-			/>,
-		);
+		findByText(/Trustee/).click();
+		findByText(/Continue/).click();
 
-		getByText(/Trustee/).click();
-		getByText(/Continue/).click();
-
-		const results = await axe(container);
+		const results = await axe(component);
 		expect(results).toHaveNoViolations();
 	});
 });
 
 describe('Trustee Contact Details', () => {
 	test('is accessible', async () => {
-		const { container, getByText } = render(
-			<TrusteeCard
-				onDetailsSave={noop}
-				onContactSave={noop}
-				onAddressSave={noop}
-				onRemove={noop}
-				onCorrect={(_value) => {}}
-				addressAPI={{
-					get: (_endpont) => Promise.resolve(),
-					limit: 100,
-				}}
-				complete={true}
-				trustee={trustee}
-				testId={trustee.schemeRoleId}
-			/>,
-		);
+		findByText('Contact details').click();
 
-		getByText('Contact details').click();
-
-		const results = await axe(container);
+		const results = await axe(component);
 		expect(results).toHaveNoViolations();
 	});
 });
 
 describe('Trustee Remove', () => {
-	let component, findByText, findByTestId;
-	beforeEach(async () => {
-		const { container, getByText, getByTestId } = render(
-			<TrusteeCard
-				onDetailsSave={noop}
-				onContactSave={noop}
-				onAddressSave={noop}
-				onRemove={noop}
-				onCorrect={(_value) => {}}
-				addressAPI={{
-					get: (_endpont) => Promise.resolve(),
-					limit: 100,
-				}}
-				complete={true}
-				trustee={trustee}
-				testId={trustee.schemeRoleId}
-			/>,
-		);
-
-		component = container;
-		findByText = getByText;
-		findByTestId = getByTestId;
-	});
-
-	afterEach(() => {
-		cleanup();
-	});
-
 	test('is accessible', async () => {
 		findByText('Remove').click();
 
@@ -310,58 +172,24 @@ describe('Trustee Remove', () => {
 
 describe('Trustee correspondence address', () => {
 	test('Change address is accessible', async () => {
-		const { container, getByText } = render(
-			<TrusteeCard
-				onDetailsSave={noop}
-				onContactSave={noop}
-				onAddressSave={noop}
-				onRemove={noop}
-				onCorrect={(_value) => {}}
-				addressAPI={{
-					get: (_endpont) => Promise.resolve(),
-					limit: 100,
-				}}
-				complete={true}
-				trustee={trustee}
-				testId={trustee.schemeRoleId}
-			/>,
-		);
+		findByText('Correspondence address').click();
+		findByText(/I need to change the address/).click();
 
-		getByText('Correspondence address').click();
-		getByText(/I need to change the address/).click();
-
-		const results = await axe(container);
+		const results = await axe(component);
 
 		expect(results).toHaveNoViolations();
-		expect(getByText('Find address')).toBeInTheDocument();
-		expect(getByText('Cancel')).toBeInTheDocument();
+		expect(findByText('Find address')).toBeInTheDocument();
+		expect(findByText('Cancel')).toBeInTheDocument();
 	});
 
 	test('Cancel change address returns to preview', async () => {
-		const { container, getByText } = render(
-			<TrusteeCard
-				onDetailsSave={noop}
-				onContactSave={noop}
-				onAddressSave={noop}
-				onRemove={noop}
-				onCorrect={(_value) => {}}
-				addressAPI={{
-					get: (_endpont) => Promise.resolve(),
-					limit: 100,
-				}}
-				complete={true}
-				trustee={trustee}
-				testId={trustee.schemeRoleId}
-			/>,
-		);
+		findByText('Correspondence address').click();
+		findByText(/I need to change the address/).click();
+		findByText(/Cancel/).click();
 
-		getByText('Correspondence address').click();
-		getByText(/I need to change the address/).click();
-		getByText(/Cancel/).click();
-
-		const results = await axe(container);
+		const results = await axe(component);
 
 		expect(results).toHaveNoViolations();
-		expect(getByText('Correspondence address')).toBeInTheDocument();
+		expect(findByText('Correspondence address')).toBeInTheDocument();
 	});
 });

--- a/packages/layout/src/components/__tests__/trustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/trustee.spec.tsx
@@ -280,6 +280,42 @@ describe('Trustee Remove', () => {
 	});
 });
 
+describe('Trustee Remove', () => {
+	test('displays correct validation messages', async () => {
+		const { container, getByText, getByTestId } = render(
+			<TrusteeCard
+				onDetailsSave={noop}
+				onContactSave={noop}
+				onAddressSave={noop}
+				onRemove={noop}
+				onCorrect={(_value) => {}}
+				addressAPI={{
+					get: (_endpont) => Promise.resolve(),
+					limit: 100,
+				}}
+				complete={true}
+				trustee={trustee}
+				testId={trustee.schemeRoleId}
+			/>,
+		);
+
+		getByText('Remove').click();
+		getByText('Continue').click();
+		const msg1 = getByText('Select a reason for removing the trustee.');
+		expect(msg1).toBeDefined();
+		expect(msg1.className.includes('errorMessage')).toBeTruthy();
+
+		getByTestId('leftTheScheme').click();
+		getByText('Continue').click();
+		const msg2 = getByText('Enter the date the trustee left the scheme.');
+		expect(msg2).toBeDefined();
+		expect(msg2.className.includes('errorMessage')).toBeTruthy();
+
+		const results = await axe(container);
+		expect(results).toHaveNoViolations();
+	});
+});
+
 describe('Trustee correspondence address', () => {
 	test('Change address is accessible', async () => {
 		const { container, getByText } = render(

--- a/packages/layout/src/components/cards/common/interfaces.ts
+++ b/packages/layout/src/components/cards/common/interfaces.ts
@@ -102,6 +102,7 @@ export interface I18nRemoveReason {
 	};
 	errors?: {
 		pristine?: string;
+		pristineDate?: string;
 		dateAddedBeforeEffectiveDate?: string;
 		dateAddedInTheFuture?: string;
 	};

--- a/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
@@ -10,6 +10,7 @@ import {
 	RemoveReasonProps,
 } from '../../../../common/interfaces';
 import styles from './reason.module.scss';
+import elementStyles from '@tpr/forms/lib/elements/elements.module.scss';
 
 interface ReasonProps {
 	type: cardType;
@@ -28,9 +29,6 @@ export const Reason: React.FC<ReasonProps> = ({
 }) => {
 	return (
 		<Content type={type} title={i18nRemoveReason.title}>
-			<H4 fontWeight="bold" mb={0}>
-				{i18nRemoveReason.subtitle}
-			</H4>
 			<Form
 				onSubmit={onSubmit}
 				initialValues={{
@@ -39,31 +37,42 @@ export const Reason: React.FC<ReasonProps> = ({
 				}}
 			>
 				{({ handleSubmit, submitError, form }) => {
-					const leftScheme =
-						form.getState().values.reason === 'left_the_scheme';
+					const reason = form.getState().values.reason;
+					const hasError: boolean = !!submitError && !reason;
+					const leftScheme: boolean = reason === 'left_the_scheme';
 					return (
 						<form onSubmit={handleSubmit} data-testid={`remove-${type}-form`}>
-							<FFRadioButton
-								name="reason"
-								type="radio"
-								label={i18nRemoveReason.fields.leftTheScheme.label}
-								value="left_the_scheme"
-								cfg={{ my: 4 }}
-							/>
-							{leftScheme && (
-								<div className={styles.dateWrapper}>
-									{renderFields(dateField)}
-								</div>
-							)}
-							<FFRadioButton
-								name="reason"
-								type="radio"
-								label={i18nRemoveReason.fields.neverPartOfTheScheme.label}
-								value="not_part_of_scheme"
-							/>
-							{submitError && (
-								<P cfg={{ color: 'danger.2', mt: 5 }}>{submitError}</P>
-							)}
+							<div className={hasError && elementStyles.labelError}>
+								<H4 fontWeight="bold" mb={0}>
+									{i18nRemoveReason.subtitle}
+								</H4>
+								<FFRadioButton
+									name="reason"
+									type="radio"
+									label={i18nRemoveReason.fields.leftTheScheme.label}
+									value="left_the_scheme"
+									cfg={{ my: 4 }}
+								/>
+								{leftScheme && (
+									<div className={styles.dateWrapper}>
+										{renderFields(dateField)}
+									</div>
+								)}
+								<FFRadioButton
+									name="reason"
+									type="radio"
+									label={i18nRemoveReason.fields.neverPartOfTheScheme.label}
+									value="not_part_of_scheme"
+								/>
+								{hasError && (
+									<P
+										cfg={{ color: 'danger.2', mt: 5 }}
+										className={elementStyles.errorMessage}
+									>
+										{submitError}
+									</P>
+								)}
+							</div>
 							<Footer>
 								<ArrowButton
 									appearance="secondary"

--- a/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
@@ -38,11 +38,11 @@ export const Reason: React.FC<ReasonProps> = ({
 			>
 				{({ handleSubmit, submitError, form }) => {
 					const reason = form.getState().values.reason;
-					const hasError: boolean = !!submitError && !reason;
+					const showError: boolean = !!submitError && !reason;
 					const leftScheme: boolean = reason === 'left_the_scheme';
 					return (
 						<form onSubmit={handleSubmit} data-testid={`remove-${type}-form`}>
-							<div className={hasError && elementStyles.labelError}>
+							<div className={showError && elementStyles.labelError}>
 								<H4 fontWeight="bold" mb={0}>
 									{i18nRemoveReason.subtitle}
 								</H4>
@@ -64,7 +64,7 @@ export const Reason: React.FC<ReasonProps> = ({
 									label={i18nRemoveReason.fields.neverPartOfTheScheme.label}
 									value="not_part_of_scheme"
 								/>
-								{hasError && (
+								{showError && (
 									<P
 										cfg={{ color: 'danger.2', mt: 5 }}
 										className={elementStyles.errorMessage}

--- a/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
@@ -49,6 +49,7 @@ export const Reason: React.FC<ReasonProps> = ({
 								<FFRadioButton
 									name="reason"
 									type="radio"
+									testId="leftTheScheme"
 									label={i18nRemoveReason.fields.leftTheScheme.label}
 									value="left_the_scheme"
 									cfg={{ my: 4 }}

--- a/packages/layout/src/components/cards/corporateGroup/i18n.ts
+++ b/packages/layout/src/components/cards/corporateGroup/i18n.ts
@@ -180,9 +180,9 @@ export const i18n: CorporateGroupI18nProps = {
 				},
 			},
 			errors: {
-				pristine: 'Please select one of the options.',
+				pristine: 'Select a reason for removing the trustee.',
 				pristineDate:
-					'Please fill in the date fields.',
+					'Enter the date the trustee left the scheme.',
 				dateAddedBeforeEffectiveDate:
 					'Date must be after the Trustee was added.',
 				dateAddedInTheFuture: 'Date cannot be in the future.',

--- a/packages/layout/src/components/cards/corporateGroup/i18n.ts
+++ b/packages/layout/src/components/cards/corporateGroup/i18n.ts
@@ -181,8 +181,7 @@ export const i18n: CorporateGroupI18nProps = {
 			},
 			errors: {
 				pristine: 'Select a reason for removing the trustee.',
-				pristineDate:
-					'Enter the date the trustee left the scheme.',
+				pristineDate: 'Enter the date the trustee left the scheme.',
 				dateAddedBeforeEffectiveDate:
 					'Date must be after the Trustee was added.',
 				dateAddedInTheFuture: 'Date cannot be in the future.',

--- a/packages/layout/src/components/cards/corporateGroup/i18n.ts
+++ b/packages/layout/src/components/cards/corporateGroup/i18n.ts
@@ -180,7 +180,9 @@ export const i18n: CorporateGroupI18nProps = {
 				},
 			},
 			errors: {
-				pristine: 'Please select one of the options',
+				pristine: 'Please select one of the options.',
+				pristineDate:
+					'Please fill in the date fields.',
 				dateAddedBeforeEffectiveDate:
 					'Date must be after the Trustee was added.',
 				dateAddedInTheFuture: 'Date cannot be in the future.',

--- a/packages/layout/src/components/cards/corporateGroup/views/remove/reason/reason.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/remove/reason/reason.tsx
@@ -20,7 +20,7 @@ export const ReasonRemove: React.FC = () => {
 			required: true,
 			validate: (value) => {
 				if (!value) {
-					return i18n.remove.reason.errors.pristine;
+					return i18n.remove.reason.errors.pristineDate;
 				} else if (
 					isBefore(
 						toDate(new Date(value)),

--- a/packages/layout/src/components/cards/independentTrustee/i18n.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/i18n.tsx
@@ -107,9 +107,9 @@ export const i18n: IndependentTrusteeI18nProps = {
 				},
 			},
 			errors: {
-				pristine: 'Please select one of the options.',
+				pristine: 'Select a reason for removing the trustee.',
 				pristineDate:
-					'Please fill in the date fields.',
+					'Enter the date the trustee left the scheme.',
 				dateAddedBeforeEffectiveDate:
 					'Date must be after the Trustee was added.',
 				dateAddedInTheFuture: 'Date cannot be in the future.',

--- a/packages/layout/src/components/cards/independentTrustee/i18n.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/i18n.tsx
@@ -108,8 +108,7 @@ export const i18n: IndependentTrusteeI18nProps = {
 			},
 			errors: {
 				pristine: 'Select a reason for removing the trustee.',
-				pristineDate:
-					'Enter the date the trustee left the scheme.',
+				pristineDate: 'Enter the date the trustee left the scheme.',
 				dateAddedBeforeEffectiveDate:
 					'Date must be after the Trustee was added.',
 				dateAddedInTheFuture: 'Date cannot be in the future.',

--- a/packages/layout/src/components/cards/independentTrustee/i18n.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/i18n.tsx
@@ -107,7 +107,9 @@ export const i18n: IndependentTrusteeI18nProps = {
 				},
 			},
 			errors: {
-				pristine: 'Please select one of the options',
+				pristine: 'Please select one of the options.',
+				pristineDate:
+					'Please fill in the date fields.',
 				dateAddedBeforeEffectiveDate:
 					'Date must be after the Trustee was added.',
 				dateAddedInTheFuture: 'Date cannot be in the future.',

--- a/packages/layout/src/components/cards/independentTrustee/views/remove/reason/reason.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/views/remove/reason/reason.tsx
@@ -20,7 +20,7 @@ export const ReasonRemove: React.FC = () => {
 			required: true,
 			validate: (value) => {
 				if (!value) {
-					return i18n.remove.reason.errors.pristine;
+					return i18n.remove.reason.errors.pristineDate;
 				} else if (
 					isBefore(
 						toDate(new Date(value)),

--- a/packages/layout/src/components/cards/trustee/i18n.ts
+++ b/packages/layout/src/components/cards/trustee/i18n.ts
@@ -181,8 +181,7 @@ export const i18n: TrusteeI18nProps = {
 			},
 			errors: {
 				pristine: 'Select a reason for removing the trustee.',
-				pristineDate:
-					'Enter the date the trustee left the scheme.',
+				pristineDate: 'Enter the date the trustee left the scheme.',
 				dateAddedBeforeEffectiveDate:
 					'Date must be after the Trustee was added.',
 				dateAddedInTheFuture: 'Date cannot be in the future.',

--- a/packages/layout/src/components/cards/trustee/i18n.ts
+++ b/packages/layout/src/components/cards/trustee/i18n.ts
@@ -181,7 +181,9 @@ export const i18n: TrusteeI18nProps = {
 			},
 			errors: {
 				pristine:
-					'Please select one of the options and fill in required fields.',
+					'Please select one of the options.',
+				pristineDate:
+					'Leaving date is required.',
 				dateAddedBeforeEffectiveDate:
 					'Date must be after the Trustee was added.',
 				dateAddedInTheFuture: 'Date cannot be in the future.',

--- a/packages/layout/src/components/cards/trustee/i18n.ts
+++ b/packages/layout/src/components/cards/trustee/i18n.ts
@@ -180,10 +180,9 @@ export const i18n: TrusteeI18nProps = {
 				},
 			},
 			errors: {
-				pristine:
-					'Please select one of the options.',
+				pristine: 'Select a reason for removing the trustee.',
 				pristineDate:
-					'Please fill in the date fields.',
+					'Enter the date the trustee left the scheme.',
 				dateAddedBeforeEffectiveDate:
 					'Date must be after the Trustee was added.',
 				dateAddedInTheFuture: 'Date cannot be in the future.',

--- a/packages/layout/src/components/cards/trustee/i18n.ts
+++ b/packages/layout/src/components/cards/trustee/i18n.ts
@@ -183,7 +183,7 @@ export const i18n: TrusteeI18nProps = {
 				pristine:
 					'Please select one of the options.',
 				pristineDate:
-					'Leaving date is required.',
+					'Please fill in the date fields.',
 				dateAddedBeforeEffectiveDate:
 					'Date must be after the Trustee was added.',
 				dateAddedInTheFuture: 'Date cannot be in the future.',

--- a/packages/layout/src/components/cards/trustee/views/remove/reason/reason.tsx
+++ b/packages/layout/src/components/cards/trustee/views/remove/reason/reason.tsx
@@ -20,7 +20,7 @@ const RemoveReason: React.FC = () => {
 			required: true,
 			validate: (value) => {
 				if (!value) {
-					return i18n.remove.reason.errors.pristine;
+					return i18n.remove.reason.errors.pristineDate;
 				} else if (
 					isBefore(
 						toDate(new Date(value)),


### PR DESCRIPTION
Use separate error messages for reasons and dates on "remove" trustee cards. Add standard error styling when no values have been given.