### PR TITLE
#73390 If a number input specifies integers only, then don't allow th…

### DIFF
--- a/packages/forms/src/__tests__/number.spec.tsx
+++ b/packages/forms/src/__tests__/number.spec.tsx
@@ -144,4 +144,61 @@ describe('Number', () => {
 			expect(label).toHaveAttribute('readonly');
 		});
 	});
+
+	describe('When decimal places are zero', () => {
+		test('decimal point cannot be used', () => {
+			const { getByTestId } = formSetup({
+				render: (
+					<FFInputNumber
+						label="Number"
+						testId={testId}
+						name="number"
+						maxLength={3}
+						decimalPlaces={0}
+					/>
+				),
+			});
+
+			userEvent.type(getByTestId(testId), '1.2');
+			fireEvent.blur(getByTestId(testId));
+			expect(getByTestId(testId)).toHaveValue(12);
+		});
+	});
+	describe('When decimal places are not specified', () => {
+		test('decimal point cannot be used', () => {
+			const { getByTestId } = formSetup({
+				render: (
+					<FFInputNumber
+						label="Number"
+						testId={testId}
+						name="number"
+						maxLength={3}
+					/>
+				),
+			});
+
+			userEvent.type(getByTestId(testId), '1.2');
+			fireEvent.blur(getByTestId(testId));
+			expect(getByTestId(testId)).toHaveValue(12);
+		});
+	});
+	describe('When decimal places are non-zero', () => {
+		test('decimal point can be used', () => {
+			const { getByTestId } = formSetup({
+				render: (
+					<FFInputNumber
+						label="Number"
+						testId={testId}
+						name="number"
+						maxLength={3}
+						decimalPlaces={1}
+					/>
+				),
+			});
+
+			userEvent.type(getByTestId(testId), '1.2');
+			fireEvent.blur(getByTestId(testId));
+			expect(getByTestId(testId)).toHaveValue(1.2);
+		});
+	});
 });

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -67,7 +67,6 @@ const InputNumber: React.FC<InputNumberProps> = ({
 			// avoid entering the number 'E'
 			e.key.toLowerCase() === 'e' && e.preventDefault();
 			!validKeys.includes(e.key) && e.preventDefault();
-			// if zero decimal places, then decimal point is not allowed
 			e.key === '.' && !decimalPlaces && e.preventDefault();
 		}
 	};

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -67,6 +67,8 @@ const InputNumber: React.FC<InputNumberProps> = ({
 			// avoid entering the number 'E'
 			e.key.toLowerCase() === 'e' && e.preventDefault();
 			!validKeys.includes(e.key) && e.preventDefault();
+			// if zero decimal places, then decimal point is not allowed
+			e.key === '.' && !decimalPlaces && e.preventDefault();
 		}
 	};
 


### PR DESCRIPTION
Issue #73390 when a number input is an integer, don't allow the typing of a decimal place.