### PR TITLE
Check commit messages for an Azure DevOps work item reference AB#82568

### DIFF
--- a/Confirm-CommitMessage.ps1
+++ b/Confirm-CommitMessage.ps1
@@ -1,0 +1,9 @@
+$path = Resolve-Path($PSScriptRoot)
+While (!(Test-Path -Path (Join-Path -Path $path -ChildPath ".git") -PathType Container)) {
+    $path = Resolve-Path(Join-Path -Path $path -ChildPath "..")
+    If (($path).Path.Length -eq 3) { Break }
+}
+If (Test-Path "$path\.git" -PathType Container) {
+    If (!((Get-Content "$path/.git/COMMIT_EDITMSG") -Match "AB#\d")) { Write-Warning "Commit aborted. Your commit message must include a Azure DevOps work item reference, eg AB#12345"; Exit 1 } else { Exit 0 }
+} 
+Else { Exit 0 }

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
 	},
 	"husky": {
 		"hooks": {
+      "commit-msg": "pwsh ./Confirm-CommitMessage.ps1",
 			"pre-commit": "yarn format"
 		}
 	}


### PR DESCRIPTION
#### Part of [AB#82568](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/82568)

Displays a warning and aborts the commit if the reference to a work item is forgotten.

![image](https://user-images.githubusercontent.com/1260550/107682536-5ca3ce80-6c98-11eb-8859-e23080dcbdfc.png)
