### PR TITLE
Sidebar status icons should have accessibility attributes

### DIFF
--- a/packages/icons/src/components/circle/circle.tsx
+++ b/packages/icons/src/components/circle/circle.tsx
@@ -4,7 +4,14 @@ import { SVG } from '../global';
 
 export const CheckedCircle: React.FC<SVGProps> = (props) => {
 	return (
-		<SVG testId="checked-circle" width="22" viewBox="0 0 22 22" {...props}>
+		<SVG
+			testId="checked-circle"
+			width="22"
+			viewBox="0 0 22 22"
+			role="img"
+			{...props}
+		>
+			<title>{props.ariaLabel}</title>
 			<circle cx="11" cy="11" r="11" />
 			<g transform="translate(5.665 5.915)">
 				<path
@@ -21,7 +28,14 @@ export const CheckedCircle: React.FC<SVGProps> = (props) => {
 
 export const ErrorCircle: React.FC<SVGProps> = (props) => {
 	return (
-		<SVG testId="error-circle" width="22" viewBox="0 0 22 22" {...props}>
+		<SVG
+			testId="error-circle"
+			width="22"
+			viewBox="0 0 22 22"
+			role="img"
+			{...props}
+		>
+			<title>{props.ariaLabel}</title>
 			<path
 				d="M241.259,11476.006a11,11,0,1,0,11,11A11,11,0,0,0,241.259,11476.006Zm1.181,17.4a1.6,1.6,0,0,1-1.172.416,1.642,1.642,0,0,1-1.19-.408,1.81,1.81,0,0,1-.009-2.311,1.671,1.671,0,0,1,1.2-.4,1.624,1.624,0,0,1,1.177.4,1.78,1.78,0,0,1,0,2.294Zm-.046-4.778h-2.234l-.467-8.439h3.168Z"
 				transform="translate(-230.259 -11476.006)"

--- a/packages/layout/src/components/__tests__/actuary.spec.tsx
+++ b/packages/layout/src/components/__tests__/actuary.spec.tsx
@@ -32,9 +32,9 @@ const actuary: Actuary = {
 
 describe('Actuary Card', () => {
 	describe('Preview', () => {
-		let component, findByText;
+		let component, findByText, findAllByText, findByTitle;
 		beforeEach(() => {
-			const { container, getByText } = render(
+			const { container, getByText, getAllByText, queryByTitle } = render(
 				<ActuaryCard
 					actuary={actuary}
 					complete={true}
@@ -48,6 +48,8 @@ describe('Actuary Card', () => {
 
 			component = container;
 			findByText = getByText;
+			findAllByText = getAllByText;
+			findByTitle = queryByTitle;
 		});
 
 		test('no Violations', async () => {
@@ -63,7 +65,8 @@ describe('Actuary Card', () => {
 		});
 
 		test('initial status is correct', () => {
-			expect(findByText('Confirmed')).toBeDefined();
+			expect(findAllByText('Confirmed').length).toEqual(2);
+			expect(findByTitle('Confirmed')).toBeDefined();
 			expect(findByText('Confirm details are correct.')).toBeDefined();
 		});
 

--- a/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
+++ b/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
@@ -33,9 +33,9 @@ const corporateGroup: CorporateGroup = {
 
 describe('Corporate Group Trustee Card', () => {
 	describe('Preview', () => {
-		let component, findByText;
+		let component, findByText, findAllByText, findByTitle;
 		beforeEach(() => {
-			const { container, getByText } = render(
+			const { container, getByText, getAllByText, queryByTitle } = render(
 				<CorporateGroupCard
 					corporateGroup={corporateGroup}
 					complete={true}
@@ -49,6 +49,8 @@ describe('Corporate Group Trustee Card', () => {
 
 			component = container;
 			findByText = getByText;
+			findAllByText = getAllByText;
+			findByTitle = queryByTitle;
 		});
 
 		test('no Violations', async () => {
@@ -66,7 +68,8 @@ describe('Corporate Group Trustee Card', () => {
 		});
 
 		test('initial status is correct', () => {
-			expect(findByText('Confirmed')).toBeDefined();
+			expect(findAllByText('Confirmed').length).toEqual(2);
+			expect(findByTitle('Confirmed')).toBeDefined();
 			expect(findByText('Confirm details are correct.')).toBeDefined();
 		});
 

--- a/packages/layout/src/components/__tests__/independentTrustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/independentTrustee.spec.tsx
@@ -28,9 +28,9 @@ const independentTrustee: IndependentTrustee = {
 
 describe('Professional / Independent Trustee Card', () => {
 	describe('Preview', () => {
-		let component, findByText;
+		let component, findByText, findAllByText, findByTitle;
 		beforeEach(() => {
-			const { container, getByText } = render(
+			const { container, getByText, getAllByText, queryByTitle } = render(
 				<IndependentTrusteeCard
 					independentTrustee={independentTrustee}
 					complete={true}
@@ -42,6 +42,8 @@ describe('Professional / Independent Trustee Card', () => {
 
 			component = container;
 			findByText = getByText;
+			findAllByText = getAllByText;
+			findByTitle = queryByTitle;
 		});
 
 		test('no Violations', async () => {
@@ -58,7 +60,8 @@ describe('Professional / Independent Trustee Card', () => {
 		});
 
 		test('initial status is correct', () => {
-			expect(findByText('Confirmed')).toBeDefined();
+			expect(findAllByText('Confirmed').length).toEqual(2);
+			expect(findByTitle('Confirmed')).toBeDefined();
 			expect(findByText('Confirm details are correct.')).toBeDefined();
 		});
 

--- a/packages/layout/src/components/__tests__/sidebar.spec.tsx
+++ b/packages/layout/src/components/__tests__/sidebar.spec.tsx
@@ -73,6 +73,8 @@ describe('Sidebar', () => {
 				matchPath={() => {}}
 				location={{}}
 				history={{ push: () => {} }}
+				sectionCompleteLabel="Section complete"
+				sectionIncompleteLabel="Section not complete"
 			/>,
 		);
 		const results = await axe(container);
@@ -88,6 +90,8 @@ describe('Sidebar', () => {
 				matchPath={() => {}}
 				location={{}}
 				history={{ push: () => {} }}
+				sectionCompleteLabel="Section complete"
+				sectionIncompleteLabel="Section not complete"
 			/>,
 		);
 		expect(getByText(title)).toBeInTheDocument();
@@ -103,6 +107,8 @@ describe('Sidebar', () => {
 				matchPath={() => {}}
 				location={{}}
 				history={{ push: () => {} }}
+				sectionCompleteLabel="Section complete"
+				sectionIncompleteLabel="Section not complete"
 			/>,
 		);
 
@@ -128,6 +134,8 @@ describe('Sidebar', () => {
 				matchPath={() => {}}
 				location={{}}
 				history={{ push: () => {} }}
+				sectionCompleteLabel="Section complete"
+				sectionIncompleteLabel="Section not complete"
 			/>,
 		);
 
@@ -145,6 +153,8 @@ describe('Sidebar', () => {
 				matchPath={() => {}}
 				location={{}}
 				history={{ push: () => {} }}
+				sectionCompleteLabel="Section complete"
+				sectionIncompleteLabel="Section not complete"
 			/>,
 		);
 
@@ -160,4 +170,44 @@ describe('Sidebar', () => {
 		expect(totalCompleted.length).toMatchInlineSnapshot(`3`);
 		expect(totalSections.length).toMatchInlineSnapshot(`8`);
 	});
+
+	test('each section status icon hass accessibility attributes', () => {
+		const title = 'Scheme return home';
+		const sectionCompleteLabel = 'Section complete';
+		const sectionIncompleteLabel = 'Section not complete';
+
+		const { getByText } = render(
+			<Sidebar
+				title={title}
+				sections={sections}
+				matchPath={() => {}}
+				location={{}}
+				history={{ push: () => {} }}
+				sectionCompleteLabel={sectionCompleteLabel}
+				sectionIncompleteLabel={sectionIncompleteLabel}
+			/>,
+		);
+
+		[...s1.links, ...s2.links, ...s3.links].map((link) => {
+			let statusIcon = getByText(link.name).nextSibling as HTMLElement;
+			expect(statusIcon).toHaveAttribute('role', 'img');
+			assertStatusIconHasAccessibilityAttributes(
+				statusIcon,
+				link.completed ? 'checked-circle' : 'error-circle',
+				link.completed ? sectionCompleteLabel : sectionIncompleteLabel,
+			);
+		});
+	});
 });
+
+const assertStatusIconHasAccessibilityAttributes = (
+	statusIcon: HTMLElement,
+	expectedTestId: string,
+	expectedLabel: string,
+) => {
+	expect(statusIcon).toHaveAttribute('data-testid', expectedTestId);
+	expect(statusIcon).toHaveAttribute('aria-label', expectedLabel);
+	expect(statusIcon.getElementsByTagName('title')[0].innerHTML).toEqual(
+		expectedLabel,
+	);
+};

--- a/packages/layout/src/components/__tests__/sidebar.spec.tsx
+++ b/packages/layout/src/components/__tests__/sidebar.spec.tsx
@@ -171,7 +171,7 @@ describe('Sidebar', () => {
 		expect(totalSections.length).toMatchInlineSnapshot(`8`);
 	});
 
-	test('each section status icon hass accessibility attributes', () => {
+	test('each section status icon has accessibility attributes', () => {
 		const title = 'Scheme return home';
 		const sectionCompleteLabel = 'Section complete';
 		const sectionIncompleteLabel = 'Section not complete';

--- a/packages/layout/src/components/__tests__/trustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/trustee.spec.tsx
@@ -31,9 +31,15 @@ const trustee: Trustee = {
 	emailAddress: 'fred.sandoors@trp.gov.uk',
 	effectiveDate: '1997-04-01T00:00:00',
 };
-let component, findByText, findByTestId;
+let component, findByText, findAllByText, findByTitle, findByTestId;
 beforeEach(async () => {
-	const { container, getByText, getByTestId } = render(
+	const {
+		container,
+		getByText,
+		getAllByText,
+		queryByTitle,
+		getByTestId,
+	} = render(
 		<TrusteeCard
 			onDetailsSave={noop}
 			onContactSave={noop}
@@ -53,6 +59,8 @@ beforeEach(async () => {
 	component = container;
 	findByText = getByText;
 	findByTestId = getByTestId;
+	findAllByText = getAllByText;
+	findByTitle = queryByTitle;
 });
 
 afterEach(() => {
@@ -74,7 +82,8 @@ describe('Trustee Preview', () => {
 	});
 
 	test('initial status is correct', () => {
-		expect(findByText('Confirmed')).toBeDefined();
+		expect(findAllByText('Confirmed').length).toEqual(2);
+		expect(findByTitle('Confirmed')).toBeDefined();
 		expect(findByText('Confirm details are correct.')).toBeDefined();
 	});
 

--- a/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
@@ -42,7 +42,7 @@ export const Reason: React.FC<ReasonProps> = ({
 					const leftScheme: boolean = reason === 'left_the_scheme';
 					return (
 						<form onSubmit={handleSubmit} data-testid={`remove-${type}-form`}>
-							<div className={showError && elementStyles.labelError}>
+							<div className={showError ? elementStyles.labelError : null}>
 								<fieldset>
 									<legend>
 										<H4 fontWeight="bold" mb={0}>

--- a/packages/layout/src/components/cards/components/card.tsx
+++ b/packages/layout/src/components/cards/components/card.tsx
@@ -75,7 +75,11 @@ export const Footer: React.FC = ({ children }) => {
 export const StatusMessage = ({ complete, icon: Icon, text }) => {
 	return (
 		<Flex cfg={{ alignItems: 'center' }} height="22px">
-			<Icon size={18} fill={complete ? '#207e3b' : '#d4351c'} />
+			<Icon
+				size={18}
+				fill={complete ? '#207e3b' : '#d4351c'}
+				ariaLabel={text}
+			/>
 			<P
 				cfg={{
 					ml: 1,

--- a/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
+++ b/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
@@ -9,6 +9,8 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 	links,
 	maintenanceMode,
 	collapsed,
+	sectionCompleteLabel,
+	sectionIncompleteLabel,
 }) => {
 	const collapsedClass = styles.nestedWrapper + ' ' + styles.collapsed;
 	const [classes, setClasses] = useState(styles.nestedWrapper);
@@ -45,7 +47,11 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 										{innerLink.name}
 									</Link>
 									{!maintenanceMode && !innerLink.hideIcon && (
-										<StatusIcon link={innerLink} />
+										<StatusIcon
+											link={innerLink}
+											sectionCompleteLabel={sectionCompleteLabel}
+											sectionIncompleteLabel={sectionIncompleteLabel}
+										/>
 									)}
 								</Flex>
 								{innerLink.links && generateSubmenu(innerLink.links)}
@@ -98,7 +104,11 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 										{link.name}
 									</Link>
 									{!maintenanceMode && !link.hideIcon && (
-										<StatusIcon link={link} />
+										<StatusIcon
+											link={link}
+											sectionCompleteLabel={sectionCompleteLabel}
+											sectionIncompleteLabel={sectionIncompleteLabel}
+										/>
 									)}
 								</Flex>
 								{link.links &&

--- a/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
+++ b/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
@@ -44,15 +44,23 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 										disabled={innerLink.disabled}
 										onClick={() => onClick(innerLink)}
 									>
-										{innerLink.name}
+										<Flex
+											cfg={{
+												flexDirection: 'row',
+												justifyContent: 'space-between',
+												alignItems: 'center',
+											}}
+										>
+											<span>{innerLink.name}</span>
+											{!maintenanceMode && !innerLink.hideIcon && (
+												<StatusIcon
+													link={innerLink}
+													sectionCompleteLabel={sectionCompleteLabel}
+													sectionIncompleteLabel={sectionIncompleteLabel}
+												/>
+											)}
+										</Flex>
 									</Link>
-									{!maintenanceMode && !innerLink.hideIcon && (
-										<StatusIcon
-											link={innerLink}
-											sectionCompleteLabel={sectionCompleteLabel}
-											sectionIncompleteLabel={sectionIncompleteLabel}
-										/>
-									)}
 								</Flex>
 								{innerLink.links && generateSubmenu(innerLink.links)}
 							</li>
@@ -101,15 +109,23 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 										disabled={link.disabled}
 										onClick={() => onClick(link)}
 									>
-										{link.name}
+										<Flex
+											cfg={{
+												flexDirection: 'row',
+												justifyContent: 'space-between',
+												alignItems: 'center',
+											}}
+										>
+											<span>{link.name}</span>
+											{!maintenanceMode && !link.hideIcon && (
+												<StatusIcon
+													link={link}
+													sectionCompleteLabel={sectionCompleteLabel}
+													sectionIncompleteLabel={sectionIncompleteLabel}
+												/>
+											)}
+										</Flex>
 									</Link>
-									{!maintenanceMode && !link.hideIcon && (
-										<StatusIcon
-											link={link}
-											sectionCompleteLabel={sectionCompleteLabel}
-											sectionIncompleteLabel={sectionIncompleteLabel}
-										/>
-									)}
 								</Flex>
 								{link.links &&
 									link.links.length > 0 &&

--- a/packages/layout/src/components/sidebar/components/StatusIcon.tsx
+++ b/packages/layout/src/components/sidebar/components/StatusIcon.tsx
@@ -1,12 +1,22 @@
 import React from 'react';
 import { CheckedCircle, ErrorCircle } from '@tpr/icons';
-import { SidebarLinkProps } from './types';
+import { StatusIconProps } from './types';
 
-const StatusIcon: React.FC<{ link: SidebarLinkProps }> = ({ link }) => {
+const StatusIcon: React.FC<StatusIconProps> = ({
+	link,
+	sectionCompleteLabel,
+	sectionIncompleteLabel,
+}) => {
 	return link.completed ? (
-		<CheckedCircle cfg={{ fill: 'success.1' }} />
+		<CheckedCircle
+			cfg={{ fill: 'success.1' }}
+			ariaLabel={sectionCompleteLabel}
+		/>
 	) : (
-		<ErrorCircle cfg={{ fill: link.disabled ? 'danger.1' : 'danger.2' }} />
+		<ErrorCircle
+			cfg={{ fill: link.disabled ? 'danger.1' : 'danger.2' }}
+			ariaLabel={sectionIncompleteLabel}
+		/>
 	);
 };
 

--- a/packages/layout/src/components/sidebar/components/types.ts
+++ b/packages/layout/src/components/sidebar/components/types.ts
@@ -27,4 +27,12 @@ export type SidebarMenuProps = {
 	links: SidebarLinkProps[];
 	maintenanceMode: boolean;
 	collapsed: boolean;
+	sectionCompleteLabel: string;
+	sectionIncompleteLabel: string;
+};
+
+export type StatusIconProps = {
+	link: SidebarLinkProps;
+	sectionCompleteLabel: string;
+	sectionIncompleteLabel: string;
 };

--- a/packages/layout/src/components/sidebar/sidebar.mdx
+++ b/packages/layout/src/components/sidebar/sidebar.mdx
@@ -90,6 +90,8 @@ import { Sidebar } from '@tpr/layout';
 				matchPath={matchPath}
 				location={location}
 				history={{ push: () => {} }}
+				sectionCompleteLabel="Section complete"
+				sectionIncompleteLabel="Section not complete"
 			/>
 		);
 	}}
@@ -235,6 +237,8 @@ import { Sidebar } from '@tpr/layout';
 				matchPath={matchPath}
 				location={location}
 				history={{ push: () => {} }}
+				sectionCompleteLabel="Section complete"
+				sectionIncompleteLabel="Section not complete"
 			/>
 		);
 	}}
@@ -293,6 +297,8 @@ import { Sidebar } from '@tpr/layout';
 				location={location}
 				history={{ push: () => {} }}
 				collapseNested={true}
+				sectionCompleteLabel="Section complete"
+				sectionIncompleteLabel="Section not complete"
 			/>
 		);
 	}}

--- a/packages/layout/src/components/sidebar/sidebar.module.scss
+++ b/packages/layout/src/components/sidebar/sidebar.module.scss
@@ -11,6 +11,7 @@
 
 	a {
 		text-decoration: none;
+		width: 100%;
 
 		&:hover {
 			color: $colors-neutral-a1 !important;
@@ -19,6 +20,13 @@
 
 		&:focus {
 			color: $colors-neutral-8 !important;
+		}
+
+		> div {
+			height: 100%;
+			> svg {
+				min-width: 22px;
+			}
 		}
 	}
 

--- a/packages/layout/src/components/sidebar/sidebar.tsx
+++ b/packages/layout/src/components/sidebar/sidebar.tsx
@@ -70,6 +70,8 @@ export type SidebarProps = {
 	/** import from react-router-dom */
 	history: any;
 	collapseNested?: boolean;
+	sectionCompleteLabel: string;
+	sectionIncompleteLabel: string;
 };
 
 export const Sidebar: React.FC<SidebarProps> = ({
@@ -81,6 +83,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
 	location,
 	history,
 	collapseNested = false,
+	sectionCompleteLabel,
+	sectionIncompleteLabel,
 }) => {
 	const routerProps = { matchPath, location, history };
 	const sections = useSectionsUpdater(originalSections, routerProps);
@@ -147,6 +151,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
 								links={item.links}
 								maintenanceMode={maintenanceMode}
 								collapsed={collapseNested}
+								sectionCompleteLabel={sectionCompleteLabel}
+								sectionIncompleteLabel={sectionIncompleteLabel}
 							/>
 						</li>
 					))}


### PR DESCRIPTION
#### Fixes [AB#82763](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/82763)

The sidebar and card status icons should have accessibility attributes such that screen reader users can understand the information being conveyed by the icons displayed.
