### PR TITLE
AB#84266 Enhanced label components to optionally render fieldset and legend elements

### DIFF
--- a/packages/forms/src/elements/date/date.tsx
+++ b/packages/forms/src/elements/date/date.tsx
@@ -155,7 +155,7 @@ export const InputDate: React.FC<InputDateComponentProps> = memo(
 		return (
 			<StyledInputLabel
 				isError={meta && meta.touched && meta.error}
-				element="div"
+				element="fieldset"
 				onFocus={input.onFocus}
 				onBlur={input.onBlur}
 				data-testid={`date-input-${testId}`}
@@ -164,12 +164,13 @@ export const InputDate: React.FC<InputDateComponentProps> = memo(
 					cfg,
 				)}
 			>
-				<InputElementHeading
-					label={label}
-					required={required}
-					hint={hint}
-					meta={meta}
-				/>
+					<InputElementHeading
+						element='legend'
+						label={label}
+						required={required}
+						hint={hint}
+						meta={meta}
+					/>
 				<Flex>
 					{!hideDay && (
 						<DateInputField

--- a/packages/forms/src/elements/elements.tsx
+++ b/packages/forms/src/elements/elements.tsx
@@ -3,7 +3,7 @@ import { SpaceProps, FlexProps, useClassNames, Span } from '@tpr/core';
 import styles from './elements.module.scss';
 
 interface StyledInputLabelProps {
-	element?: 'label' | 'div';
+	element?: 'label' | 'div' | 'fieldset';
 	isError?: boolean;
 	className?: string;
 	cfg?: FlexProps | SpaceProps;
@@ -34,21 +34,36 @@ export const StyledInputLabel: React.FC<StyledInputLabelProps> = ({
 	);
 };
 
-export const FormLabelText: React.FC = ({ children }) => (
-	<div className={styles.labelText}>{children}</div>
-);
+interface FormLabelTextProps {
+	element?: 'div' | 'legend' | 'label' | null;
+}
+
+export const FormLabelText: React.FC<FormLabelTextProps> = ({ 	
+	element = 'div',
+	children 
+}) => { 
+	return createElement(
+		element,
+		{
+			className: styles.labelText,
+		},
+		children,
+	);
+};
 
 export const ErrorMessage: React.FC = ({ children }) => (
 	<div className={styles.errorMessage}>{children}</div>
 );
 
 type InputElementHeadingProps = {
+	element?: 'div' | 'legend' | null;
 	label?: string;
 	required?: boolean;
 	hint?: string;
 	meta?: any;
 };
 export const InputElementHeading: React.FC<InputElementHeadingProps> = ({
+	element = 'div',
 	label,
 	required,
 	hint,
@@ -57,7 +72,7 @@ export const InputElementHeading: React.FC<InputElementHeadingProps> = ({
 	return (
 		<>
 			{label && (
-				<FormLabelText>
+				<FormLabelText element={element}>
 					{label} {!required && '(optional)'}
 				</FormLabelText>
 			)}


### PR DESCRIPTION
Enhanced `StyledInputLabel` component to optionally render as a `<fieldset>` element; `InputElementHeading` optionally as a `<legend>`; and `FormLabelText` optionally as a `<legend>` or `<label>`. Without explicitly setting the element property on these components, they continue to render as they currently do.

Refactored ,`FFInputDate` to render as a `fieldset` with `legend`.

