### PR TITLE
Add id attributes to form field labels so that the ids can be used in aria-describedby attributes on other, related, form elements.

### DIFF
--- a/packages/core/src/__tests__/utils.spec.ts
+++ b/packages/core/src/__tests__/utils.spec.ts
@@ -1,4 +1,4 @@
-import { classNames, filterProps } from '../utils';
+import { classNames, filterProps, toKebabCase } from '../utils';
 // import { matchClassName } from '../utils';
 
 describe('classNames', () => {
@@ -61,5 +61,13 @@ describe('filterProps', () => {
 	test('filterProps will pass on truthy names', () => {
 		const result: any = filterProps({ 'some-other-style-name': true });
 		expect(result['some-other-style-name']).toBeTruthy();
+	});
+});
+
+describe('toKebabCase', () => {
+	test('turns strings into kebab case', () => {
+		expect(toKebabCase('ThisIsMyText')).toEqual('this-is-my-text');
+		expect(toKebabCase('This Is My Text')).toEqual('this-is-my-text');
+		expect(toKebabCase('ThisIsMy Text')).toEqual('this-is-my-text');
 	});
 });

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -81,3 +81,15 @@ export const filterProps = (allProps: { [key: string]: any } = {}) => {
 		return acc;
 	}, {});
 };
+
+export const toKebabCase = (string: string) => {
+	return (
+		string &&
+		string
+			.match(
+				/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g,
+			)
+			.map((x) => x.toLowerCase())
+			.join('-')
+	);
+};

--- a/packages/forms/src/__tests__/currency.spec.tsx
+++ b/packages/forms/src/__tests__/currency.spec.tsx
@@ -33,6 +33,17 @@ describe('Currency', () => {
 			userEvent.type(getByTestId(testId), '123');
 			expect(getByTestId(testId)).toHaveValue('123');
 		});
+
+		test('label renders with an id attribute', () => {
+			const { getByText } = formSetup({
+				render: currencyComponent,
+			});
+
+			const label = getByText(/Currency/);
+
+			expect(label).toBeDefined();
+			expect(label).toHaveAttribute('id', 'currency-label');
+		});
 	});
 
 	describe('formatting integers', () => {

--- a/packages/forms/src/__tests__/number.spec.tsx
+++ b/packages/forms/src/__tests__/number.spec.tsx
@@ -38,6 +38,17 @@ describe('Number', () => {
 			userEvent.type(getByTestId(testId), '123');
 			expect(getByTestId(testId)).toHaveValue(123);
 		});
+
+		test('label renders with an id attribute', () => {
+			const { getByText } = formSetup({
+				render: numberComponent,
+			});
+
+			const label = getByText(/Number/);
+
+			expect(label).toBeDefined();
+			expect(label).toHaveAttribute('id', 'number-label');
+		});
 	});
 
 	describe('formatting values with decimal places specified on onBlur event', () => {

--- a/packages/forms/src/__tests__/text.spec.tsx
+++ b/packages/forms/src/__tests__/text.spec.tsx
@@ -19,14 +19,15 @@ describe('Text input', () => {
 	});
 
 	test('renders label', () => {
-		const { queryByTestId } = formSetup({
+		const { getByText } = formSetup({
 			render: (
 				<FFInputText label="Name" testId="text-input" name="name" type="text" />
 			),
 		});
 
-		const label = queryByTestId('text-input');
+		const label = getByText(/Name/);
 		expect(label).toBeInTheDocument();
+		expect(label).toHaveAttribute('id', 'name-label');
 	});
 
 	test('renders label with title optional', () => {

--- a/packages/forms/src/elements/currency/currency.tsx
+++ b/packages/forms/src/elements/currency/currency.tsx
@@ -203,6 +203,7 @@ const InputCurrency: React.FC<InputCurrencyProps> = React.memo(
 					required={optionalText !== undefined ? !optionalText : required}
 					hint={hint}
 					meta={meta}
+					inputName={input.name}
 				/>
 				<Input
 					parentRef={innerInput}

--- a/packages/forms/src/elements/elements.tsx
+++ b/packages/forms/src/elements/elements.tsx
@@ -1,5 +1,11 @@
 import React, { createElement } from 'react';
-import { SpaceProps, FlexProps, useClassNames, Span } from '@tpr/core';
+import {
+	SpaceProps,
+	FlexProps,
+	useClassNames,
+	Span,
+	toKebabCase,
+} from '@tpr/core';
 import styles from './elements.module.scss';
 
 interface StyledInputLabelProps {
@@ -36,15 +42,18 @@ export const StyledInputLabel: React.FC<StyledInputLabelProps> = ({
 
 interface FormLabelTextProps {
 	element?: 'div' | 'legend' | 'label' | null;
+	id?: string;
 }
 
-export const FormLabelText: React.FC<FormLabelTextProps> = ({ 	
+export const FormLabelText: React.FC<FormLabelTextProps> = ({
 	element = 'div',
-	children 
-}) => { 
+	id = null,
+	children,
+}) => {
 	return createElement(
 		element,
 		{
+			id: id,
 			className: styles.labelText,
 		},
 		children,
@@ -61,6 +70,7 @@ type InputElementHeadingProps = {
 	required?: boolean;
 	hint?: string;
 	meta?: any;
+	inputName?: string;
 };
 export const InputElementHeading: React.FC<InputElementHeadingProps> = ({
 	element = 'div',
@@ -68,11 +78,15 @@ export const InputElementHeading: React.FC<InputElementHeadingProps> = ({
 	required,
 	hint,
 	meta,
+	inputName,
 }) => {
 	return (
 		<>
 			{label && (
-				<FormLabelText element={element}>
+				<FormLabelText
+					element={element}
+					id={inputName ? `${toKebabCase(inputName + 'Label')}` : null}
+				>
 					{label} {!required && '(optional)'}
 				</FormLabelText>
 			)}

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -125,6 +125,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 				required={optionalText !== undefined ? !optionalText : required}
 				hint={hint}
 				meta={meta}
+				inputName={input.name}
 			/>
 			<Input
 				type="number"

--- a/packages/forms/src/elements/text/text.tsx
+++ b/packages/forms/src/elements/text/text.tsx
@@ -46,6 +46,7 @@ const InputText: React.FC<InputTextProps> = React.forwardRef(
 					required={required}
 					hint={hint}
 					meta={meta}
+					inputName={input.name}
 				/>
 				<Input
 					parentRef={ref}


### PR DESCRIPTION
[AB#84274](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/84274) - Add id attributes to form field labels so that the ids can be used in aria-describedby attributes on other, related, form elements.