### PR TITLE
Bugfix/85229 remove divs within legends

### DIFF
--- a/packages/forms/src/elements/date/date.tsx
+++ b/packages/forms/src/elements/date/date.tsx
@@ -7,7 +7,6 @@ import { Input } from '../input/input';
 import { FieldProps, FieldExtraProps } from '../../renderFields';
 import isEqual from 'lodash.isequal';
 import styles from './date.module.scss';
-import elements from '../elements.module.scss';
 import { SameMonthDateValidator } from './services/SameMonthDateValidator';
 
 const handleChange = (onChange: Function, value: number) => ({
@@ -160,7 +159,6 @@ export const InputDate: React.FC<InputDateComponentProps> = memo(
 				onFocus={input.onFocus}
 				onBlur={input.onBlur}
 				data-testid={`date-input-${testId}`}
-				className={elements.internalLegend}
 				cfg={Object.assign(
 					{ mt: 1, py: 1, alignItems: 'flex-start', flexDirection: 'column' },
 					cfg,

--- a/packages/forms/src/elements/elements.module.scss
+++ b/packages/forms/src/elements/elements.module.scss
@@ -2,9 +2,15 @@
 
 fieldset {
   padding: 0;
-
-	legend {
+	display: flex;
+	flex-direction: column;
+	
+	> legend {
 		float:left;   //position legend within the fieldset
+
+		+ * {
+			clear: left;
+		}		
 	}
 }
 

--- a/packages/forms/src/elements/elements.module.scss
+++ b/packages/forms/src/elements/elements.module.scss
@@ -2,10 +2,10 @@
 
 fieldset {
   padding: 0;
-}
 
-fieldset.internalLegend > legend {
-  float:left;   //position legend within the fieldset
+	legend {
+		float:left;   //position legend within the fieldset
+	}
 }
 
 .label {


### PR DESCRIPTION
Improve implementation of fieldset error styling:

- Make default for all fieldset / legends
- Clear float on legend's adjacent sibling
- Prevent adjacent sibling's top margin from collapsing