### PR TITLE
AB#82812 - For currency inputs, allow the initial entry of a pound si…

### DIFF
--- a/packages/forms/src/__tests__/currency.spec.tsx
+++ b/packages/forms/src/__tests__/currency.spec.tsx
@@ -7,6 +7,7 @@ import { fireEvent } from '@testing-library/react';
 import {
 	calculateCursorPosition,
 	getNumberOfCommas,
+	validateCurrency,
 } from '../elements/helpers';
 import { CheckDescribedByTag } from '../utils/aria-describedByTest';
 
@@ -51,6 +52,15 @@ describe('Currency', () => {
 
 			userEvent.type(getByTestId(testId), '123');
 			expect(getByTestId(testId)).toHaveValue('123');
+		});
+
+		test('Currency symbol can be typed as the first character only', async () => {
+			const { getByTestId } = formSetup({
+				render: currencyComponent,
+			});
+
+			userEvent.type(getByTestId(testId), '£10£0');
+			expect(getByTestId(testId)).toHaveValue('£100');
 		});
 
 		test('label renders with an id attribute', () => {
@@ -141,6 +151,16 @@ describe('Currency', () => {
 			});
 
 			userEvent.type(getByTestId(testId), '123456789.4');
+			fireEvent.blur(getByTestId(testId));
+			expect(getByTestId(testId)).toHaveValue('123,456,789.40');
+		});
+
+		test('value with currency symbol gets formatted correctly on onBlur event', async () => {
+			const { getByTestId } = formSetup({
+				render: currencyComponent,
+			});
+
+			userEvent.type(getByTestId(testId), '£123456789.4');
 			fireEvent.blur(getByTestId(testId));
 			expect(getByTestId(testId)).toHaveValue('123,456,789.40');
 		});
@@ -253,6 +273,33 @@ describe('Currency', () => {
 				expect(getByTestId(testId)).toHaveValue('45,000.00');
 			}, 100);
 			expect(validateExecuted).toEqual(true);
+		});
+	});
+
+	describe('testing helper function: validateCurrency', () => {
+		test('when value is too large, tooBig validation result is returned', () => {
+			expect(validateCurrency('1000', 0, 10)).toEqual('tooBig');
+		});
+		test('when value with thousand separators is too large, tooBig validation result is returned', () => {
+			expect(validateCurrency('1,000', 0, 10)).toEqual('tooBig');
+		});
+		test('when value with thousand separators and currency symbol is too large, tooBig validation result is returned', () => {
+			expect(validateCurrency('£1,000', 0, 10)).toEqual('tooBig');
+		});
+		test('when value is too small, tooSmall validation result is returned', () => {
+			expect(validateCurrency('1000', 10000, 15000)).toEqual('tooSmall');
+		});
+		test('when value with thousand separators is too small, tooSmall validation result is returned', () => {
+			expect(validateCurrency('1,000', 10000, 15000)).toEqual('tooSmall');
+		});
+		test('when value with thousand separators and currency symbol is too small, tooSmall validation result is returned', () => {
+			expect(validateCurrency('£1,000', 10000, 15000)).toEqual('tooSmall');
+		});
+		test('when value is undefined, empty validation result is returned', () => {
+			expect(validateCurrency(undefined, 0, 0)).toEqual('empty');
+		});
+		test('when value is null, empty validation result is returned', () => {
+			expect(validateCurrency(null, 0, 0)).toEqual('empty');
 		});
 	});
 

--- a/packages/forms/src/elements/currency/currency.tsx
+++ b/packages/forms/src/elements/currency/currency.tsx
@@ -59,7 +59,21 @@ const InputCurrency: React.FC<InputCurrencyProps> = React.memo(
 		i18n = currencyFieldI18nDefaults,
 		...props
 	}) => {
-		const digits = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.'];
+		const currencySymbol = '£';
+		const digits = [
+			'0',
+			'1',
+			'2',
+			'3',
+			'4',
+			'5',
+			'6',
+			'7',
+			'8',
+			'9',
+			'.',
+			currencySymbol,
+		];
 
 		// e.g. format: 999,999,999,999.00
 
@@ -70,12 +84,20 @@ const InputCurrency: React.FC<InputCurrencyProps> = React.memo(
 		const [delKey, setDelKey] = useState<boolean>(false);
 
 		const formatWithCommas = (value: string): string => {
-			const numString: string = value.replace(/,/g, '');
+			const hasCurrencySymbol = value && value[0] === currencySymbol;
+
+			const numString: string = value
+				.replace(/,/g, '')
+				.replace(currencySymbol, '');
+
+			if (numString === '') return value;
+
 			let numFormatted: string = '';
 			// if number is integer
 			if (!containsDecimals(value)) {
 				// numString = "123456"
-				numFormatted = format(numString);
+				numFormatted =
+					(hasCurrencySymbol ? currencySymbol : '') + format(numString);
 				// numFormatted = "123,456"
 				const numWithDecimals: string = fixToDecimals(numString, decimalPlaces);
 				setFormattedInputValue(
@@ -85,7 +107,9 @@ const InputCurrency: React.FC<InputCurrencyProps> = React.memo(
 			// if number has decimals
 			else {
 				// numString = "123456.77"
-				numFormatted = formatWithDecimals(numString, decimalPlaces);
+				numFormatted =
+					(hasCurrencySymbol ? currencySymbol : '') +
+					formatWithDecimals(numString, decimalPlaces);
 				// numFormatted = "123,456.77"
 				setFormattedInputValue(numFormatted);
 			}
@@ -103,6 +127,10 @@ const InputCurrency: React.FC<InputCurrencyProps> = React.memo(
 				// typing '.' when already exists one in the value
 				if (e.key === '.') {
 					dot ? e.preventDefault() : setDot(true);
+					return true;
+				}
+				if (e.key === currencySymbol) {
+					if (e.target.value.length !== 0) e.preventDefault();
 					return true;
 				}
 				keyPressedIsNotAllowed(e) && e.preventDefault();
@@ -167,8 +195,11 @@ const InputCurrency: React.FC<InputCurrencyProps> = React.memo(
 			input.onBlur(e);
 			e.target.value =
 				getNumDecimalPlaces(formattedInputValue) < decimalPlaces
-					? appendMissingZeros(inputValue.replace(/,/g, ''), decimalPlaces)
-					: formattedInputValue;
+					? appendMissingZeros(
+							inputValue.replace(/,/g, '').replace(currencySymbol, ''),
+							decimalPlaces,
+					  )
+					: formattedInputValue.replace(currencySymbol, '');
 			setInputValue(e.target.value);
 			input.onChange(e);
 		};

--- a/packages/forms/src/elements/helpers.ts
+++ b/packages/forms/src/elements/helpers.ts
@@ -1,5 +1,7 @@
 import { ChangeEvent } from 'react';
 
+const currencySymbol = '£';
+
 export const validKeys = [
 	'Backspace',
 	'Enter',
@@ -95,10 +97,12 @@ export const getFinalValueWithFormat = (
 	value: string,
 	decimals: number,
 ): string => {
-	const newValueWithNoCommas = value.replace(/,/g, '');
-	if (firstDotPosition(newValueWithNoCommas) === -1) {
+	const newValueWithNoCommasOrCurrencySymbol = value
+		.replace(/,/g, '')
+		.replace(currencySymbol, '');
+	if (firstDotPosition(newValueWithNoCommasOrCurrencySymbol) === -1) {
 		// if the value doesn't contain decimals, we return the value with the required format
-		const newValueWithDecimals = newValueWithNoCommas.concat(
+		const newValueWithDecimals = newValueWithNoCommasOrCurrencySymbol.concat(
 			'.',
 			new Array(decimals).fill('0').join(''),
 		);
@@ -136,7 +140,9 @@ export const validateCurrency = (
 						'empty' when the field is empty
 	*/
 	if (value !== undefined && value !== null) {
-		const numericValue = Number(value.toString().replace(/,/g, ''));
+		const numericValue = Number(
+			value.toString().replace(/,/g, '').replace(currencySymbol, ''),
+		);
 		if (min !== null && numericValue < min) return 'tooSmall';
 		if (max !== null && numericValue > max) return 'tooBig';
 		return undefined;


### PR DESCRIPTION
[AB#82812](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/82812) - Accessible currency data entry - potentially confusing disallowed entry of the currency symbol

For currency inputs, allow the initial entry of a pound sign, which will be auto-formatted away once the thousand separators and decimal place formatting occurs on blur.  This avoids any accessibility issues with users trying to enter the £ symbol into the currency field (which is an input type="text" field and so would have the standard expectation of allowing the entry of a pound sign).  

We would expect standard usage of the currency text box to include a £ label to the left of the field, which would indicate to sighted users that entry of the £ sign is not required.  However, if using a screen reader, users which would not necessarily have that context conveyed and may still try to enter the £ sign.  This fix resolves that issue.