### PR TITLE
Keyboard focus clarification for alerts

### DIFF
--- a/packages/icons/src/components/circle/circle.tsx
+++ b/packages/icons/src/components/circle/circle.tsx
@@ -43,3 +43,21 @@ export const ErrorCircle: React.FC<SVGProps> = (props) => {
 		</SVG>
 	);
 };
+
+export const WarningCircle: React.FC<SVGProps> = (props) => {
+	return (
+		<SVG
+			testId="warning-circle"
+			width="22"
+			viewBox="0 0 22 22"
+			role="img"
+			{...props}
+		>
+			<title>{props.ariaLabel}</title>
+			<path
+				d="M241.259,11476.006a11,11,0,1,0,11,11A11,11,0,0,0,241.259,11476.006Zm1.181,17.4a1.6,1.6,0,0,1-1.172.416,1.642,1.642,0,0,1-1.19-.408,1.81,1.81,0,0,1-.009-2.311,1.671,1.671,0,0,1,1.2-.4,1.624,1.624,0,0,1,1.177.4,1.78,1.78,0,0,1,0,2.294Zm-.046-4.778h-2.234l-.467-8.439h3.168Z"
+				transform="translate(-230.259 -11476.006)"
+			/>
+		</SVG>
+	);
+};

--- a/packages/icons/src/index.mdx
+++ b/packages/icons/src/index.mdx
@@ -13,6 +13,7 @@ import {
 	UnfoldMore,
 	CheckedCircle,
 	ErrorCircle,
+	WarningCircle,
 	ArrowUp,
 	ArrowDown,
 	ArrowLeft,
@@ -41,6 +42,7 @@ import { CheckboxChecked, CheckboxBlank, UnfoldMore } from '@tpr/icons';
 | UnfoldMore             |
 | CheckedCircle          |
 | ErrorCircle            |
+| WarningCircle          |
 | ArrowUp                |
 | ArrowDown              |
 | ArrowLeft              |
@@ -79,6 +81,12 @@ import { CheckboxChecked, CheckboxBlank, UnfoldMore } from '@tpr/icons';
 
 <Playground>
 	<ErrorCircle fill="#a91717" />
+</Playground>
+
+## Warning Circle
+
+<Playground>
+	<WarningCircle fill="#0b0030" />
 </Playground>
 
 ## Arrow Up

--- a/packages/layout/src/components/__tests__/warningbox.spec.tsx
+++ b/packages/layout/src/components/__tests__/warningbox.spec.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { P } from '@tpr/core';
+import { WarningBox } from '../warning/warning';
+
+describe('WarningBox', () => {
+	test('Renders with expected text and role', () => {
+		// Arrange
+		const warningBoxText = 'This is the warning text';
+		const warningLabelText = 'warning-label-text';
+
+		// Act
+		const { getByRole, getByTitle } = render(
+			<WarningBox warningLabel={warningLabelText}>
+				<P>{warningBoxText}</P>
+			</WarningBox>,
+		);
+
+		let warningBox = getByRole('alert');
+
+		// Assert
+		expect(warningBox).toBeDefined();
+		expect(warningBox).toHaveTextContent(warningBoxText);
+		expect(getByTitle(warningLabelText)).toBeDefined();
+	});
+});

--- a/packages/layout/src/components/cards/common/views/remove/confirm/confirm.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/confirm/confirm.tsx
@@ -17,6 +17,7 @@ interface ConfirmProps {
 	handleRemove: () => void;
 	handleCancel: () => void;
 	loading: boolean;
+	warningLabel?: string;
 }
 
 const Confirm: React.FC<ConfirmProps> = ({
@@ -31,12 +32,13 @@ const Confirm: React.FC<ConfirmProps> = ({
 	handleRemove,
 	handleCancel,
 	loading,
+	warningLabel = 'Warning',
 }) => {
 	return (
 		<Content type={cardType} typeName={cardTypeName} breadcrumbs={breadcrumbs}>
 			<H3 cfg={{ mt: 3, fontWeight: 2 }}>{removeTitle}</H3>
 			<Hr cfg={{ my: 4 }} />
-			<WarningBox>
+			<WarningBox warningLabel={warningLabel}>
 				<P>{removeMessage1}</P>
 				{removeMessage2 && <P cfg={{ mt: 3 }}>{removeMessage2}</P>}
 				<Flex cfg={{ mt: 3 }}>

--- a/packages/layout/src/components/cards/common/views/remove/confirm/confirm.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/confirm/confirm.tsx
@@ -39,20 +39,22 @@ const Confirm: React.FC<ConfirmProps> = ({
 			<H3 cfg={{ mt: 3, fontWeight: 2 }}>{removeTitle}</H3>
 			<Hr cfg={{ my: 4 }} />
 			<WarningBox warningLabel={warningLabel}>
-				<P>{removeMessage1}</P>
-				{removeMessage2 && <P cfg={{ mt: 3 }}>{removeMessage2}</P>}
-				<Flex cfg={{ mt: 3 }}>
-					<ArrowButton
-						intent="warning"
-						pointsTo="right"
-						iconSide="right"
-						title={removeBtnTitle}
-						onClick={handleRemove}
-						disabled={loading}
-					/>
-					<Link cfg={{ m: 3 }} underline onClick={handleCancel}>
-						{cancelBtnTitle}
-					</Link>
+				<Flex cfg={{ flexDirection: 'column' }}>
+					<P>{removeMessage1}</P>
+					{removeMessage2 && <P cfg={{ mt: 3 }}>{removeMessage2}</P>}
+					<Flex cfg={{ mt: 3 }}>
+						<ArrowButton
+							intent="warning"
+							pointsTo="right"
+							iconSide="right"
+							title={removeBtnTitle}
+							onClick={handleRemove}
+							disabled={loading}
+						/>
+						<Link cfg={{ m: 3 }} underline onClick={handleCancel}>
+							{cancelBtnTitle}
+						</Link>
+					</Flex>
 				</Flex>
 			</WarningBox>
 		</Content>

--- a/packages/layout/src/components/cards/common/views/remove/confirm/confirm.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/confirm/confirm.tsx
@@ -32,7 +32,7 @@ const Confirm: React.FC<ConfirmProps> = ({
 	handleRemove,
 	handleCancel,
 	loading,
-	warningLabel = 'Warning',
+	warningLabel,
 }) => {
 	return (
 		<Content type={cardType} typeName={cardTypeName} breadcrumbs={breadcrumbs}>

--- a/packages/layout/src/components/cards/components/removedBox.tsx
+++ b/packages/layout/src/components/cards/components/removedBox.tsx
@@ -8,7 +8,7 @@ interface RemovedBoxProps {
 
 const RemovedBox: React.FC<RemovedBoxProps> = ({ type }) => {
 	return (
-		<div className={styles.confirmationBox}>
+		<div role="alert" className={styles.confirmationBox}>
 			<Flex
 				cfg={{
 					flex: '0 0 auto',

--- a/packages/layout/src/components/warning/warning.mdx
+++ b/packages/layout/src/components/warning/warning.mdx
@@ -7,6 +7,8 @@ route: /layout/warning
 import { Props } from 'docz';
 import { Playground } from '@playground';
 import { WarningBox } from './warning';
+import { useState } from 'react'; 
+import { Button } from '@tpr/core';
 
 # Warning Box
 
@@ -19,10 +21,21 @@ import { WarningBox } from '@tpr/layout';
 ```
 
 <Playground>
-	<WarningBox>
-		Lorem ipsum dolor sit, amet consectetur adipisicing elit. Molestias
-		voluptatibus quaerat consequatur deleniti nobis explicabo eius.
-	</WarningBox>
+	{() => {
+		const [toggleWarning, setToggleWarning] = useState(false);
+		
+		return (
+			<>
+			<Button
+				onClick={() => setToggleWarning(!toggleWarning)}>
+				Toggle warning
+			</Button>
+			{(toggleWarning && <WarningBox>
+			Lorem ipsum dolor sit, amet consectetur adipisicing elit. Molestias
+			voluptatibus quaerat consequatur deleniti nobis explicabo eius.
+		</WarningBox>)}
+		</>)
+	}}
 </Playground>
 
 ## API

--- a/packages/layout/src/components/warning/warning.mdx
+++ b/packages/layout/src/components/warning/warning.mdx
@@ -21,6 +21,21 @@ import { WarningBox } from '@tpr/layout';
 ```
 
 <Playground>
+	<WarningBox>
+			Lorem ipsum dolor sit, amet consectetur adipisicing elit. Molestias
+			voluptatibus quaerat consequatur deleniti nobis explicabo eius.
+		</WarningBox>
+</Playground>
+
+## Accessibility
+
+The warning box has the role type of 'alert' so if it is toggled into view then assistive technology will immediately alert the user of it's presence.
+
+```js
+import { WarningBox } from '@tpr/layout';
+```
+
+<Playground>
 	{() => {
 		const [toggleWarning, setToggleWarning] = useState(false);
 		
@@ -38,10 +53,15 @@ import { WarningBox } from '@tpr/layout';
 	}}
 </Playground>
 
+
 ## API
 
 ```
 Accepted config props: SpaceProps, FlexProps
 ```
 
-<Props of={WarningBox} />
+### Props
+
+| Property         | Required | Type              | Description                                                                                                |
+| ---------------- | -------- | ----------------- | ---------------------------------------------------------------------------------------------------------- |
+| warningLabel     | false    | boolean           | Optionally overrides the default title text on the svg image (the exclamation mark) within the warning box |

--- a/packages/layout/src/components/warning/warning.module.scss
+++ b/packages/layout/src/components/warning/warning.module.scss
@@ -2,5 +2,5 @@
 
 .warning {
 	border: 4px solid $colors-danger-2;
-	outline: 4px solid $colors-warning-1;
+	// outline: 4px solid $colors-warning-1;
 }

--- a/packages/layout/src/components/warning/warning.module.scss
+++ b/packages/layout/src/components/warning/warning.module.scss
@@ -5,8 +5,8 @@
 	font-weight: $font-weight-3;
 
 	svg {
-		width: 35px;
-		height: 35px;
+		min-width: 35px;
+		min-height: 35px;
    	margin-top: 2px;
 	}
 }

--- a/packages/layout/src/components/warning/warning.module.scss
+++ b/packages/layout/src/components/warning/warning.module.scss
@@ -2,5 +2,11 @@
 
 .warning {
 	border: 4px solid $colors-danger-2;
-	// outline: 4px solid $colors-warning-1;
+	font-weight: $font-weight-3;
+
+	svg {
+		width: 35px;
+		height: 35px;
+   	margin-top: 2px;
+	}
 }

--- a/packages/layout/src/components/warning/warning.tsx
+++ b/packages/layout/src/components/warning/warning.tsx
@@ -10,6 +10,7 @@ export const WarningBox: React.FC<WarningBoxProps> = ({ children, cfg }) => {
 		<Flex
 			cfg={Object.assign({ flexDirection: 'column', p: 4, my: 4 }, cfg)}
 			className={styles.warning}
+			role="alert"
 		>
 			{children}
 		</Flex>

--- a/packages/layout/src/components/warning/warning.tsx
+++ b/packages/layout/src/components/warning/warning.tsx
@@ -5,8 +5,13 @@ import { WarningCircle } from '@tpr/icons';
 
 export type WarningBoxProps = {
 	cfg?: SpaceProps & FlexProps;
+	warningLabel?: string;
 };
-export const WarningBox: React.FC<WarningBoxProps> = ({ children, cfg }) => {
+export const WarningBox: React.FC<WarningBoxProps> = ({
+	children,
+	cfg,
+	warningLabel,
+}) => {
 	return (
 		<Flex
 			cfg={Object.assign({ flexDirection: 'column', p: 4, my: 4 }, cfg)}
@@ -14,7 +19,7 @@ export const WarningBox: React.FC<WarningBoxProps> = ({ children, cfg }) => {
 			role="alert"
 		>
 			<Flex cfg={{ flexDirection: 'row' }}>
-				<WarningCircle cfg={{ mr: 4 }} />
+				<WarningCircle cfg={{ mr: 4 }} ariaLabel={warningLabel} />
 				{children}
 			</Flex>
 		</Flex>

--- a/packages/layout/src/components/warning/warning.tsx
+++ b/packages/layout/src/components/warning/warning.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Flex, SpaceProps, FlexProps } from '@tpr/core';
 import styles from './warning.module.scss';
+import { WarningCircle } from '@tpr/icons';
 
 export type WarningBoxProps = {
 	cfg?: SpaceProps & FlexProps;
@@ -12,7 +13,10 @@ export const WarningBox: React.FC<WarningBoxProps> = ({ children, cfg }) => {
 			className={styles.warning}
 			role="alert"
 		>
-			{children}
+			<Flex cfg={{ flexDirection: 'row' }}>
+				<WarningCircle cfg={{ mr: 4 }} />
+				{children}
+			</Flex>
 		</Flex>
 	);
 };

--- a/packages/layout/src/components/warning/warning.tsx
+++ b/packages/layout/src/components/warning/warning.tsx
@@ -10,7 +10,7 @@ export type WarningBoxProps = {
 export const WarningBox: React.FC<WarningBoxProps> = ({
 	children,
 	cfg,
-	warningLabel,
+	warningLabel = 'Warning',
 }) => {
 	return (
 		<Flex


### PR DESCRIPTION
[AB#82805](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/82805)

Add implementation of the warning text box along the lines of the example here https://design-system.service.gov.uk/components/warning-text/.

Include a role=alert attribute so that screen readers acknowledge the alert instantly when it pops into view.