### PR TITLE
Fix accessibility issue AB#86097 when navigating between cards

### DIFF
--- a/packages/core/src/components/globals/globals.tsx
+++ b/packages/core/src/components/globals/globals.tsx
@@ -151,3 +151,31 @@ export const Flex: React.FC<FlexBoxProps> = ({
 		children,
 	);
 };
+
+export type SectionProps = {
+	ariaLabel: string;
+	testId?: string;
+	className?: string;
+	cfg?: SpaceProps;
+};
+export const Section: React.FC<SectionProps> = ({
+	ariaLabel,
+	testId,
+	className,
+	children,
+	cfg = {},
+	...props
+}) => {
+	const classNames = useClassNames(cfg, [className]);
+	return createElement(
+		'section',
+		{
+			role: 'region',
+			className: classNames,
+			'data-testid': testId,
+			'aria-label': ariaLabel,
+			...props,
+		},
+		children,
+	);
+};

--- a/packages/layout/src/components/__tests__/actuary.spec.tsx
+++ b/packages/layout/src/components/__tests__/actuary.spec.tsx
@@ -6,6 +6,7 @@ import { axe } from 'jest-axe';
 import { act } from 'react-dom/test-utils';
 import { cleanup } from '@testing-library/react-hooks';
 import {
+	assertThatASectionExistsWithAnAriaLabel,
 	assertThatButtonHasAriaExpanded,
 	assertThatButtonHasBeenRemovedFromTheTabFlow,
 	assertThatTitleWasSetToNullWhileFirstAndLastNamesWereLeftUnchanged,
@@ -107,10 +108,8 @@ describe('Actuary Card', () => {
 		});
 
 		test('renders with a section containing an aria label', () => {
-			const section = findByRole('region');
-			expect(section).toBeDefined();
-			expect(section).toHaveAttribute(
-				'aria-label',
+			assertThatASectionExistsWithAnAriaLabel(
+				findByRole,
 				`${actuary.title} ${actuary.firstName} ${actuary.lastName} Actuary`,
 			);
 		});

--- a/packages/layout/src/components/__tests__/actuary.spec.tsx
+++ b/packages/layout/src/components/__tests__/actuary.spec.tsx
@@ -38,9 +38,15 @@ const actuary: Actuary = {
 
 describe('Actuary Card', () => {
 	describe('Preview', () => {
-		let component, findByText, findAllByText, findByTitle;
+		let component, findByText, findAllByText, findByTitle, findByRole;
 		beforeEach(() => {
-			const { container, getByText, getAllByText, queryByTitle } = render(
+			const {
+				container,
+				getByText,
+				getAllByText,
+				queryByTitle,
+				getByRole,
+			} = render(
 				<ActuaryCard
 					actuary={actuary}
 					complete={true}
@@ -56,6 +62,7 @@ describe('Actuary Card', () => {
 			findByText = getByText;
 			findAllByText = getAllByText;
 			findByTitle = queryByTitle;
+			findByRole = getByRole;
 		});
 
 		test('no Violations', async () => {
@@ -97,6 +104,15 @@ describe('Actuary Card', () => {
 
 		test('displays email correctly', () => {
 			expect(findByText('john@actuary.com')).toBeDefined();
+		});
+
+		test('renders with a section containing an aria label', () => {
+			const section = findByRole('region');
+			expect(section).toBeDefined();
+			expect(section).toHaveAttribute(
+				'aria-label',
+				`${actuary.title} ${actuary.firstName} ${actuary.lastName} Actuary`,
+			);
 		});
 	});
 

--- a/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
+++ b/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
@@ -34,9 +34,15 @@ const corporateGroup: CorporateGroup = {
 
 describe('Corporate Group Trustee Card', () => {
 	describe('Preview', () => {
-		let component, findByText, findAllByText, findByTitle;
+		let component, findByText, findAllByText, findByTitle, findByRole;
 		beforeEach(() => {
-			const { container, getByText, getAllByText, queryByTitle } = render(
+			const {
+				container,
+				getByText,
+				getAllByText,
+				queryByTitle,
+				getByRole,
+			} = render(
 				<CorporateGroupCard
 					corporateGroup={corporateGroup}
 					complete={true}
@@ -52,6 +58,7 @@ describe('Corporate Group Trustee Card', () => {
 			findByText = getByText;
 			findAllByText = getAllByText;
 			findByTitle = queryByTitle;
+			findByRole = getByRole;
 		});
 
 		test('no Violations', async () => {
@@ -102,6 +109,15 @@ describe('Corporate Group Trustee Card', () => {
 
 		test('Director(s) block displays values correctly', () => {
 			expect(findByText('Yes')).toBeDefined();
+		});
+
+		test('renders with a section containing an aria label', () => {
+			const section = findByRole('region');
+			expect(section).toBeDefined();
+			expect(section).toHaveAttribute(
+				'aria-label',
+				`${corporateGroup.organisationName} Corporate Group trustee`,
+			);
 		});
 	});
 

--- a/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
+++ b/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
@@ -5,7 +5,10 @@ import { CorporateGroup } from '../cards/corporateGroup/context';
 import { axe } from 'jest-axe';
 import { cleanup } from '@testing-library/react-hooks';
 import { act } from 'react-dom/test-utils';
-import { assertThatButtonHasAriaExpanded } from '../testHelpers/testHelpers';
+import {
+	assertThatASectionExistsWithAnAriaLabel,
+	assertThatButtonHasAriaExpanded,
+} from '../testHelpers/testHelpers';
 
 const noop = () => Promise.resolve();
 
@@ -112,10 +115,8 @@ describe('Corporate Group Trustee Card', () => {
 		});
 
 		test('renders with a section containing an aria label', () => {
-			const section = findByRole('region');
-			expect(section).toBeDefined();
-			expect(section).toHaveAttribute(
-				'aria-label',
+			assertThatASectionExistsWithAnAriaLabel(
+				findByRole,
 				`${corporateGroup.organisationName} Corporate Group trustee`,
 			);
 		});

--- a/packages/layout/src/components/__tests__/employer.spec.tsx
+++ b/packages/layout/src/components/__tests__/employer.spec.tsx
@@ -4,7 +4,10 @@ import { EmployerCard } from '../cards/employer/employer';
 import { axe } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
 import { Employer } from '../cards/employer/context';
-import { assertThatButtonHasBeenRemovedFromTheTabFlow } from '../testHelpers/testHelpers';
+import {
+	assertThatASectionExistsWithAnAriaLabel,
+	assertThatButtonHasBeenRemovedFromTheTabFlow,
+} from '../testHelpers/testHelpers';
 
 const noop = () => Promise.resolve();
 
@@ -56,9 +59,10 @@ describe('Employer Preview', () => {
 			/>,
 		);
 
-		const section = getByRole('region');
-		expect(section).toBeDefined();
-		expect(section).toHaveAttribute('aria-label', employer.organisationName);
+		assertThatASectionExistsWithAnAriaLabel(
+			getByRole,
+			employer.organisationName,
+		);
 	});
 });
 

--- a/packages/layout/src/components/__tests__/employer.spec.tsx
+++ b/packages/layout/src/components/__tests__/employer.spec.tsx
@@ -45,6 +45,21 @@ describe('Employer Preview', () => {
 		const results = await axe(container);
 		expect(results).toHaveNoViolations();
 	});
+
+	test('renders with a section containing an aria label', () => {
+		const { getByRole } = render(
+			<EmployerCard
+				onSaveType={noop}
+				onRemove={noop}
+				complete={true}
+				employer={employer}
+			/>,
+		);
+
+		const section = getByRole('region');
+		expect(section).toBeDefined();
+		expect(section).toHaveAttribute('aria-label', employer.organisationName);
+	});
 });
 
 describe('Employer type', () => {

--- a/packages/layout/src/components/__tests__/inHouse.spec.tsx
+++ b/packages/layout/src/components/__tests__/inHouse.spec.tsx
@@ -5,6 +5,7 @@ import { axe } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
 import { InHouseAdminNoApi } from '../cards/inHouse/context';
 import {
+	assertThatASectionExistsWithAnAriaLabel,
 	assertThatButtonHasAriaExpanded,
 	assertThatButtonHasBeenRemovedFromTheTabFlow,
 	assertThatTitleWasSetToNullWhileFirstAndLastNamesWereLeftUnchanged,
@@ -118,10 +119,8 @@ describe('InHouse Preview', () => {
 	});
 
 	test('renders with a section containing an aria label', () => {
-		const section = findByRole('region');
-		expect(section).toBeDefined();
-		expect(section).toHaveAttribute(
-			'aria-label',
+		assertThatASectionExistsWithAnAriaLabel(
+			findByRole,
 			`${inHouseAdmin.title} ${inHouseAdmin.firstName} ${inHouseAdmin.lastName} In House Administrator`,
 		);
 	});

--- a/packages/layout/src/components/__tests__/inHouse.spec.tsx
+++ b/packages/layout/src/components/__tests__/inHouse.spec.tsx
@@ -34,11 +34,11 @@ const inHouseAdmin: InHouseAdminNoApi = {
 };
 
 describe('InHouse Preview', () => {
-	let component, findByText, findByTestId;
+	let component, findByText, findByTestId, findByRole;
 	let updatedInHouseAdmin = null;
 
 	beforeEach(async () => {
-		const { container, getByText, getByTestId } = render(
+		const { container, getByText, getByTestId, getByRole } = render(
 			<InHouseCard
 				onSaveContacts={noop}
 				onSaveAddress={noop}
@@ -60,6 +60,7 @@ describe('InHouse Preview', () => {
 		component = container;
 		findByText = getByText;
 		findByTestId = getByTestId;
+		findByRole = getByRole;
 	});
 
 	test('is accessible', async () => {
@@ -113,6 +114,15 @@ describe('InHouse Preview', () => {
 			component,
 			inHouseAdmin,
 			updatedInHouseAdmin,
+		);
+	});
+
+	test('renders with a section containing an aria label', () => {
+		const section = findByRole('region');
+		expect(section).toBeDefined();
+		expect(section).toHaveAttribute(
+			'aria-label',
+			`${inHouseAdmin.title} ${inHouseAdmin.firstName} ${inHouseAdmin.lastName} In House Administrator`,
 		);
 	});
 });

--- a/packages/layout/src/components/__tests__/independentTrustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/independentTrustee.spec.tsx
@@ -29,9 +29,15 @@ const independentTrustee: IndependentTrustee = {
 
 describe('Professional / Independent Trustee Card', () => {
 	describe('Preview', () => {
-		let component, findByText, findAllByText, findByTitle;
+		let component, findByText, findAllByText, findByTitle, findByRole;
 		beforeEach(() => {
-			const { container, getByText, getAllByText, queryByTitle } = render(
+			const {
+				container,
+				getByText,
+				getAllByText,
+				queryByTitle,
+				getByRole,
+			} = render(
 				<IndependentTrusteeCard
 					independentTrustee={independentTrustee}
 					complete={true}
@@ -45,6 +51,7 @@ describe('Professional / Independent Trustee Card', () => {
 			findByText = getByText;
 			findAllByText = getAllByText;
 			findByTitle = queryByTitle;
+			findByRole = getByRole;
 		});
 
 		test('no Violations', async () => {
@@ -87,6 +94,15 @@ describe('Professional / Independent Trustee Card', () => {
 
 		test('Appointed by the regulator block displays value correctly', () => {
 			expect(findByText('Yes')).toBeDefined();
+		});
+
+		test('renders with a section containing an aria label', () => {
+			const section = findByRole('region');
+			expect(section).toBeDefined();
+			expect(section).toHaveAttribute(
+				'aria-label',
+				`${independentTrustee.organisationName} Professional / Independent Trustee`,
+			);
 		});
 	});
 

--- a/packages/layout/src/components/__tests__/independentTrustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/independentTrustee.spec.tsx
@@ -5,7 +5,10 @@ import { IndependentTrustee } from '../cards/independentTrustee/context';
 import { axe } from 'jest-axe';
 import { cleanup } from '@testing-library/react-hooks';
 import { act } from 'react-dom/test-utils';
-import { assertThatButtonHasAriaExpanded } from '../testHelpers/testHelpers';
+import {
+	assertThatASectionExistsWithAnAriaLabel,
+	assertThatButtonHasAriaExpanded,
+} from '../testHelpers/testHelpers';
 
 const noop = () => Promise.resolve();
 
@@ -97,10 +100,8 @@ describe('Professional / Independent Trustee Card', () => {
 		});
 
 		test('renders with a section containing an aria label', () => {
-			const section = findByRole('region');
-			expect(section).toBeDefined();
-			expect(section).toHaveAttribute(
-				'aria-label',
+			assertThatASectionExistsWithAnAriaLabel(
+				findByRole,
 				`${independentTrustee.organisationName} Professional / Independent Trustee`,
 			);
 		});

--- a/packages/layout/src/components/__tests__/insurer.spec.tsx
+++ b/packages/layout/src/components/__tests__/insurer.spec.tsx
@@ -57,7 +57,7 @@ describe('Insurer Preview', () => {
 			<InsurerCard
 				onSaveRef={noop}
 				onRemove={noop}
-				onCorrect={(_value) => {}}
+				onCorrect={noop}
 				complete={true}
 				insurer={insurer}
 			/>,

--- a/packages/layout/src/components/__tests__/insurer.spec.tsx
+++ b/packages/layout/src/components/__tests__/insurer.spec.tsx
@@ -51,6 +51,25 @@ describe('Insurer Preview', () => {
 			false,
 		);
 	});
+
+	test('renders with a section containing an aria label', () => {
+		const { getByRole } = render(
+			<InsurerCard
+				onSaveRef={noop}
+				onRemove={noop}
+				onCorrect={(_value) => {}}
+				complete={true}
+				insurer={insurer}
+			/>,
+		);
+
+		const section = getByRole('region');
+		expect(section).toBeDefined();
+		expect(section).toHaveAttribute(
+			'aria-label',
+			`${insurer.organisationName} Insurer administrator`,
+		);
+	});
 });
 
 describe('Insurer Remove', () => {

--- a/packages/layout/src/components/__tests__/insurer.spec.tsx
+++ b/packages/layout/src/components/__tests__/insurer.spec.tsx
@@ -4,7 +4,10 @@ import { InsurerCard } from '../cards/insurer/insurer';
 import { axe } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
 import { Insurer } from '../cards/insurer/context';
-import { assertThatButtonHasAriaExpanded } from '../testHelpers/testHelpers';
+import {
+	assertThatASectionExistsWithAnAriaLabel,
+	assertThatButtonHasAriaExpanded,
+} from '../testHelpers/testHelpers';
 
 const noop = () => Promise.resolve();
 
@@ -63,10 +66,8 @@ describe('Insurer Preview', () => {
 			/>,
 		);
 
-		const section = getByRole('region');
-		expect(section).toBeDefined();
-		expect(section).toHaveAttribute(
-			'aria-label',
+		assertThatASectionExistsWithAnAriaLabel(
+			getByRole,
 			`${insurer.organisationName} Insurer administrator`,
 		);
 	});

--- a/packages/layout/src/components/__tests__/thirdParty.spec.tsx
+++ b/packages/layout/src/components/__tests__/thirdParty.spec.tsx
@@ -4,6 +4,7 @@ import { ThirdPartyCard } from '../cards/thirdParty/thirdParty';
 import { axe } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
 import { ThirdPartyProps } from '../cards/thirdParty/context';
+import { assertThatASectionExistsWithAnAriaLabel } from '../testHelpers/testHelpers';
 
 const noop = () => Promise.resolve();
 
@@ -48,10 +49,8 @@ describe('ThirdParty Preview', () => {
 			/>,
 		);
 
-		const section = getByRole('region');
-		expect(section).toBeDefined();
-		expect(section).toHaveAttribute(
-			'aria-label',
+		assertThatASectionExistsWithAnAriaLabel(
+			getByRole,
 			`${thirdPartyAdmin.organisationName} Third Party Administrator`,
 		);
 	});

--- a/packages/layout/src/components/__tests__/thirdParty.spec.tsx
+++ b/packages/layout/src/components/__tests__/thirdParty.spec.tsx
@@ -42,7 +42,7 @@ describe('ThirdParty Preview', () => {
 		const { getByRole } = render(
 			<ThirdPartyCard
 				onRemove={noop}
-				onCorrect={(_value) => {}}
+				onCorrect={noop}
 				complete={true}
 				thirdParty={thirdPartyAdmin}
 			/>,

--- a/packages/layout/src/components/__tests__/thirdParty.spec.tsx
+++ b/packages/layout/src/components/__tests__/thirdParty.spec.tsx
@@ -37,6 +37,24 @@ describe('ThirdParty Preview', () => {
 		const results = await axe(container);
 		expect(results).toHaveNoViolations();
 	});
+
+	test('renders with a section containing an aria label', () => {
+		const { getByRole } = render(
+			<ThirdPartyCard
+				onRemove={noop}
+				onCorrect={(_value) => {}}
+				complete={true}
+				thirdParty={thirdPartyAdmin}
+			/>,
+		);
+
+		const section = getByRole('region');
+		expect(section).toBeDefined();
+		expect(section).toHaveAttribute(
+			'aria-label',
+			`${thirdPartyAdmin.organisationName} Third Party Administrator`,
+		);
+	});
 });
 
 describe('ThirdParty Remove', () => {

--- a/packages/layout/src/components/__tests__/trustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/trustee.spec.tsx
@@ -35,7 +35,7 @@ const trustee: Trustee = {
 	emailAddress: 'fred.sandoors@trp.gov.uk',
 	effectiveDate: '1997-04-01T00:00:00',
 };
-let component, findByText, findAllByText, findByTitle, findByTestId;
+let component, findByText, findAllByText, findByTitle, findByTestId, findByRole;
 let updatedTrustee = null;
 
 beforeEach(async () => {
@@ -45,6 +45,7 @@ beforeEach(async () => {
 		getAllByText,
 		queryByTitle,
 		getByTestId,
+		getByRole,
 	} = render(
 		<TrusteeCard
 			onDetailsSave={(values) => {
@@ -70,6 +71,7 @@ beforeEach(async () => {
 	findByTestId = getByTestId;
 	findAllByText = getAllByText;
 	findByTitle = queryByTitle;
+	findByRole = getByRole;
 });
 
 afterEach(() => {
@@ -115,6 +117,15 @@ describe('Trustee Preview', () => {
 		expect(findByText(trustee.telephoneNumber)).toBeDefined();
 		expect(findByText('Email')).toBeDefined();
 		expect(findByText(trustee.emailAddress)).toBeDefined();
+	});
+
+	test('renders with a section containing an aria label', () => {
+		const section = findByRole('region');
+		expect(section).toBeDefined();
+		expect(section).toHaveAttribute(
+			'aria-label',
+			`${trustee.title} ${trustee.firstName} ${trustee.lastName} ${trustee.trusteeType} Trustee`,
+		);
 	});
 });
 

--- a/packages/layout/src/components/__tests__/trustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/trustee.spec.tsx
@@ -4,6 +4,7 @@ import { TrusteeCard } from '../cards/trustee/trustee';
 import { axe } from 'jest-axe';
 import { Trustee } from '../cards/trustee/context';
 import {
+	assertThatASectionExistsWithAnAriaLabel,
 	assertThatButtonHasAriaExpanded,
 	assertThatButtonHasBeenRemovedFromTheTabFlow,
 	assertThatTitleWasSetToNullWhileFirstAndLastNamesWereLeftUnchanged,
@@ -120,10 +121,8 @@ describe('Trustee Preview', () => {
 	});
 
 	test('renders with a section containing an aria label', () => {
-		const section = findByRole('region');
-		expect(section).toBeDefined();
-		expect(section).toHaveAttribute(
-			'aria-label',
+		assertThatASectionExistsWithAnAriaLabel(
+			findByRole,
 			`${trustee.title} ${trustee.firstName} ${trustee.lastName} ${trustee.trusteeType} Trustee`,
 		);
 	});

--- a/packages/layout/src/components/cards/actuary/actuary.tsx
+++ b/packages/layout/src/components/cards/actuary/actuary.tsx
@@ -4,7 +4,7 @@ import {
 	ActuaryProviderProps,
 	useActuaryContext,
 } from './context';
-import { Flex, Span } from '@tpr/core';
+import { Section, Span } from '@tpr/core';
 import { Toolbar } from '../components/toolbar';
 import { UnderlinedButton } from '../components/button';
 import { Preview } from './views/preview/preview';
@@ -16,7 +16,7 @@ import RemovedBox from '../components/removedBox';
 import { cardTypeName } from '../common/interfaces';
 import styles from '../cards.module.scss';
 import { ActuaryContext } from './actuaryMachine';
-import { removeFromTabFlowIfMatches } from '../../../utils';
+import { removeFromTabFlowIfMatches, concatenateStrings } from '../../../utils';
 
 const CardContentSwitch: React.FC = () => {
 	const { current } = useActuaryContext();
@@ -107,18 +107,26 @@ export const ActuaryCard: React.FC<ActuaryProviderProps> = ({
 		<ActuaryProvider {...rest}>
 			{({ current, i18n }) => {
 				return (
-					<Flex cfg={cfg} data-testid={testId} className={styles.card}>
+					<Section
+						cfg={cfg}
+						data-testid={testId}
+						className={styles.card}
+						ariaLabel={concatenateStrings([
+							current.context.actuary.title,
+							current.context.actuary.firstName,
+							current.context.actuary.lastName,
+							i18n.preview.buttons.one,
+						])}
+					>
 						<Toolbar
 							complete={isComplete(current.context)}
 							subtitle={() => (
 								<Span cfg={{ lineHeight: 3 }} className={styles.styledAsH4}>
-									{[
+									{concatenateStrings([
 										current.context.actuary.title,
 										current.context.actuary.firstName,
 										current.context.actuary.lastName,
-									]
-										.filter(Boolean)
-										.join(' ')}
+									])}
 								</Span>
 							)}
 							statusText={
@@ -137,7 +145,7 @@ export const ActuaryCard: React.FC<ActuaryProviderProps> = ({
 							)}
 						/>
 						<CardContentSwitch />
-					</Flex>
+					</Section>
 				);
 			}}
 		</ActuaryProvider>

--- a/packages/layout/src/components/cards/cards.module.scss
+++ b/packages/layout/src/components/cards/cards.module.scss
@@ -7,6 +7,7 @@
 	flex-direction: column;
 	border: 1px solid $colors-neutral-4;
 	box-shadow: 0 2px 3px rgba(0, 0, 0, 0.2);
+	margin-bottom: $space-6;
 }
 
 .cardToolbar {

--- a/packages/layout/src/components/cards/corporateGroup/corporateGroup.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/corporateGroup.tsx
@@ -4,7 +4,7 @@ import {
 	CorporateGroupProviderProps,
 	useCorporateGroupContext,
 } from './context';
-import { Flex, P, Span } from '@tpr/core';
+import { P, Section, Span } from '@tpr/core';
 import { Toolbar } from '../components/toolbar';
 import { UnderlinedButton } from '../components/button';
 import RemovedBox from '../components/removedBox';
@@ -17,6 +17,7 @@ import { ConfirmRemove } from './views/remove/confirm/confirm';
 import { cardTypeName } from '../common/interfaces';
 import styles from '../cards.module.scss';
 import { CorporateGroupContext } from './corporateGroupMachine';
+import { concatenateStrings } from '../../../utils';
 
 const CardContentSwitch: React.FC = () => {
 	const { current } = useCorporateGroupContext();
@@ -78,7 +79,15 @@ export const CorporateGroupCard: React.FC<CorporateGroupProviderProps> = ({
 		<CorporateGroupProvider {...rest}>
 			{({ current: { context }, i18n }) => {
 				return (
-					<Flex cfg={cfg} data-testid={testId} className={styles.card}>
+					<Section
+						cfg={cfg}
+						data-testid={testId}
+						className={styles.card}
+						ariaLabel={concatenateStrings([
+							context.corporateGroup.organisationName,
+							i18n.preview.trusteeType,
+						])}
+					>
 						<Toolbar
 							complete={isComplete(context)}
 							subtitle={() => (
@@ -103,7 +112,7 @@ export const CorporateGroupCard: React.FC<CorporateGroupProviderProps> = ({
 							extraPB={true}
 						/>
 						<CardContentSwitch />
-					</Flex>
+					</Section>
 				);
 			}}
 		</CorporateGroupProvider>

--- a/packages/layout/src/components/cards/employer/employer.tsx
+++ b/packages/layout/src/components/cards/employer/employer.tsx
@@ -1,12 +1,16 @@
 import React, { useMemo } from 'react';
 import { UnderlinedButton } from '../components/button';
 import { Toolbar } from '../components/toolbar';
-import { Flex, P } from '@tpr/core';
+import { Section, P } from '@tpr/core';
 import { Preview } from './views/preview/preview';
 import { RemoveDateForm } from './views/remove/date/date';
 import { EmployerType } from './views/type/type';
 import { ConfirmRemove } from './views/remove/confirm/confirm';
-import { capitalize, removeFromTabFlowIfMatches } from '../../../utils';
+import {
+	capitalize,
+	removeFromTabFlowIfMatches,
+	concatenateStrings,
+} from '../../../utils';
 import {
 	EmployerProvider,
 	useEmployerContext,
@@ -110,7 +114,14 @@ export const EmployerCard: React.FC<EmployerProviderProps> = ({
 		<EmployerProvider {...rest}>
 			{({ current, i18n }) => {
 				return (
-					<Flex cfg={cfg} data-testid={testId} className={styles.card}>
+					<Section
+						cfg={cfg}
+						data-testid={testId}
+						className={styles.card}
+						ariaLabel={concatenateStrings([
+							current.context.employer.organisationName,
+						])}
+					>
 						<Toolbar
 							complete={isComplete(current.context)}
 							subtitle={() => (
@@ -132,7 +143,7 @@ export const EmployerCard: React.FC<EmployerProviderProps> = ({
 							)}
 						/>
 						<CardContentSwitch />
-					</Flex>
+					</Section>
 				);
 			}}
 		</EmployerProvider>

--- a/packages/layout/src/components/cards/inHouse/inHouse.tsx
+++ b/packages/layout/src/components/cards/inHouse/inHouse.tsx
@@ -4,7 +4,7 @@ import {
 	InHouseAdminProviderProps,
 	useInHouseAdminContext,
 } from './context';
-import { Flex, Span } from '@tpr/core';
+import { Section, Span } from '@tpr/core';
 import { Toolbar } from '../components/toolbar';
 import { UnderlinedButton } from '../components/button';
 import { Preview } from './views/preview/preview';
@@ -18,7 +18,7 @@ import { cardType, cardTypeName } from '../common/interfaces';
 import styles from '../cards.module.scss';
 import { AddressComparer } from '@tpr/forms';
 import { InHouseAdminContext } from './inHouseMachine';
-import { removeFromTabFlowIfMatches } from '../../../utils';
+import { removeFromTabFlowIfMatches, concatenateStrings } from '../../../utils';
 
 const CardContentSwitch: React.FC = () => {
 	const {
@@ -150,18 +150,26 @@ export const InHouseCard: React.FC<InHouseAdminProviderProps> = ({
 		<InHouseAdminProvider {...rest}>
 			{({ current, i18n }) => {
 				return (
-					<Flex cfg={cfg} data-testid={testId} className={styles.card}>
+					<Section
+						cfg={cfg}
+						data-testid={testId}
+						className={styles.card}
+						ariaLabel={concatenateStrings([
+							current.context.inHouseAdmin.title,
+							current.context.inHouseAdmin.firstName,
+							current.context.inHouseAdmin.lastName,
+							i18n.preview.buttons.one,
+						])}
+					>
 						<Toolbar
 							complete={isComplete(current.context)}
 							subtitle={() => (
 								<Span cfg={{ lineHeight: 3 }} className={styles.styledAsH4}>
-									{[
+									{concatenateStrings([
 										current.context.inHouseAdmin.title,
 										current.context.inHouseAdmin.firstName,
 										current.context.inHouseAdmin.lastName,
-									]
-										.filter(Boolean)
-										.join(' ')}
+									])}
 								</Span>
 							)}
 							statusText={
@@ -180,7 +188,7 @@ export const InHouseCard: React.FC<InHouseAdminProviderProps> = ({
 							)}
 						/>
 						<CardContentSwitch />
-					</Flex>
+					</Section>
 				);
 			}}
 		</InHouseAdminProvider>

--- a/packages/layout/src/components/cards/independentTrustee/independentTrustee.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/independentTrustee.tsx
@@ -4,7 +4,7 @@ import {
 	IndependentTrusteeProviderProps,
 	useIndependentTrusteeContext,
 } from './context';
-import { Flex, P, Span } from '@tpr/core';
+import { P, Section, Span } from '@tpr/core';
 import { Toolbar } from '../components/toolbar';
 import { UnderlinedButton } from '../components/button';
 import RemovedBox from '../components/removedBox';
@@ -15,6 +15,7 @@ import { ConfirmRemove } from './views/remove/confirm/confirm';
 import { cardTypeName } from '../common/interfaces';
 import styles from '../cards.module.scss';
 import { IndependentTrusteeContext } from './independentTrusteeMachine';
+import { concatenateStrings } from '../../../utils';
 
 const CardContentSwitch: React.FC = () => {
 	const { current } = useIndependentTrusteeContext();
@@ -73,7 +74,15 @@ export const IndependentTrusteeCard: React.FC<IndependentTrusteeProviderProps> =
 		<IndependentTrusteeProvider {...rest}>
 			{({ current: { context }, i18n }) => {
 				return (
-					<Flex cfg={cfg} data-testid={testId} className={styles.card}>
+					<Section
+						cfg={cfg}
+						data-testid={testId}
+						className={styles.card}
+						ariaLabel={concatenateStrings([
+							context.independentTrustee.organisationName,
+							i18n.preview.trusteeType,
+						])}
+					>
 						<Toolbar
 							complete={isComplete(context)}
 							subtitle={() => (
@@ -98,7 +107,7 @@ export const IndependentTrusteeCard: React.FC<IndependentTrusteeProviderProps> =
 							extraPB={true}
 						/>
 						<CardContentSwitch />
-					</Flex>
+					</Section>
 				);
 			}}
 		</IndependentTrusteeProvider>

--- a/packages/layout/src/components/cards/insurer/insurer.tsx
+++ b/packages/layout/src/components/cards/insurer/insurer.tsx
@@ -4,7 +4,7 @@ import {
 	InsurerProviderProps,
 	useInsurerContext,
 } from './context';
-import { Flex, Span } from '@tpr/core';
+import { Section, Span } from '@tpr/core';
 import { Toolbar } from '../components/toolbar';
 import { UnderlinedButton } from '../components/button';
 import { Preview } from './views/preview/preview';
@@ -15,6 +15,7 @@ import RemovedBox from '../components/removedBox';
 import { cardTypeName } from '../common/interfaces';
 import styles from '../cards.module.scss';
 import { InsurerContext } from './insurerMachine';
+import { concatenateStrings } from '../../../utils';
 
 const CardContentSwitch: React.FC = () => {
 	const { current } = useInsurerContext();
@@ -72,7 +73,15 @@ export const InsurerCard: React.FC<InsurerProviderProps> = ({
 		<InsurerProvider {...rest}>
 			{({ current: { context }, i18n }) => {
 				return (
-					<Flex cfg={cfg} data-testid={testId} className={styles.card}>
+					<Section
+						cfg={cfg}
+						data-testid={testId}
+						className={styles.card}
+						ariaLabel={concatenateStrings([
+							context.insurer.organisationName,
+							i18n.preview.buttons.one,
+						])}
+					>
 						<Toolbar
 							complete={isComplete(context)}
 							subtitle={() => (
@@ -93,7 +102,7 @@ export const InsurerCard: React.FC<InsurerProviderProps> = ({
 							)}
 						/>
 						<CardContentSwitch />
-					</Flex>
+					</Section>
 				);
 			}}
 		</InsurerProvider>

--- a/packages/layout/src/components/cards/thirdParty/thirdParty.tsx
+++ b/packages/layout/src/components/cards/thirdParty/thirdParty.tsx
@@ -4,7 +4,7 @@ import {
 	ThirdPartyProviderProps,
 	useThirdPartyContext,
 } from './context';
-import { Flex, Span } from '@tpr/core';
+import { Section, Span } from '@tpr/core';
 import { Toolbar } from '../components/toolbar';
 import { UnderlinedButton } from '../components/button';
 import { Preview } from './views/preview/preview';
@@ -14,6 +14,7 @@ import RemovedBox from '../components/removedBox';
 import { cardTypeName } from '../common/interfaces';
 import styles from '../cards.module.scss';
 import { ThirdPartyContext } from './thirdPartyMachine';
+import { concatenateStrings } from '../../../utils';
 
 const CardContentSwitch: React.FC = () => {
 	const { current } = useThirdPartyContext();
@@ -69,7 +70,15 @@ export const ThirdPartyCard: React.FC<ThirdPartyProviderProps> = ({
 		<ThirdPartyProvider {...rest}>
 			{({ current: { context }, i18n }) => {
 				return (
-					<Flex cfg={cfg} data-testid={testId} className={styles.card}>
+					<Section
+						cfg={cfg}
+						data-testid={testId}
+						className={styles.card}
+						ariaLabel={concatenateStrings([
+							context.thirdParty.organisationName,
+							i18n.preview.buttons.one,
+						])}
+					>
 						<Toolbar
 							complete={isComplete(context)}
 							subtitle={() => (
@@ -90,7 +99,7 @@ export const ThirdPartyCard: React.FC<ThirdPartyProviderProps> = ({
 							)}
 						/>
 						<CardContentSwitch />
-					</Flex>
+					</Section>
 				);
 			}}
 		</ThirdPartyProvider>

--- a/packages/layout/src/components/cards/trustee/trustee.tsx
+++ b/packages/layout/src/components/cards/trustee/trustee.tsx
@@ -4,7 +4,7 @@ import {
 	useTrusteeContext,
 	TrusteeCardProps,
 } from './context';
-import { Flex, Span } from '@tpr/core';
+import { Section, Span } from '@tpr/core';
 import { UnderlinedButton } from '../components/button';
 import { Preview } from './views/preview';
 import { Toolbar } from '../components/toolbar';
@@ -19,7 +19,7 @@ import { cardType, cardTypeName } from '../common/interfaces';
 import styles from '../cards.module.scss';
 import { AddressComparer } from '@tpr/forms';
 import { TrusteeContext } from './trusteeMachine';
-import { removeFromTabFlowIfMatches } from '../../../utils';
+import { concatenateStrings, removeFromTabFlowIfMatches } from '../../../utils';
 
 const CardContent: React.FC = () => {
 	const { current, i18n, send, addressAPI } = useTrusteeContext();
@@ -147,7 +147,18 @@ export const TrusteeCard: React.FC<Omit<TrusteeCardProps, 'children'>> = ({
 	return (
 		<TrusteeProvider {...props}>
 			{({ current, i18n }) => (
-				<Flex cfg={cfg} data-testid={props.testId} className={styles.card}>
+				<Section
+					cfg={cfg}
+					data-testid={props.testId}
+					className={styles.card}
+					ariaLabel={concatenateStrings([
+						current.context.trustee.title,
+						current.context.trustee.firstName,
+						current.context.trustee.lastName,
+						current.context.trustee.trusteeType,
+						i18n.preview.buttons.one,
+					])}
+				>
 					<Toolbar
 						complete={isComplete(current.context)}
 						buttonLeft={() => <TrusteeButton />}
@@ -160,13 +171,11 @@ export const TrusteeCard: React.FC<Omit<TrusteeCardProps, 'children'>> = ({
 						)}
 						subtitle={() => (
 							<Span cfg={{ lineHeight: 3 }} className={styles.styledAsH4}>
-								{[
+								{concatenateStrings([
 									current.context.trustee.title,
 									current.context.trustee.firstName,
 									current.context.trustee.lastName,
-								]
-									.filter(Boolean)
-									.join(' ')}
+								])}
 							</Span>
 						)}
 						statusText={
@@ -176,7 +185,7 @@ export const TrusteeCard: React.FC<Omit<TrusteeCardProps, 'children'>> = ({
 						}
 					/>
 					<CardContent />
-				</Flex>
+				</Section>
 			)}
 		</TrusteeProvider>
 	);

--- a/packages/layout/src/components/testHelpers/testHelpers.ts
+++ b/packages/layout/src/components/testHelpers/testHelpers.ts
@@ -33,6 +33,15 @@ export const assertThatTitleWasSetToNullWhileFirstAndLastNamesWereLeftUnchanged 
 	expect(updatedName.lastName).toEqual(originalName.lastName);
 };
 
+export const assertThatASectionExistsWithAnAriaLabel = (
+	findByRole,
+	expectedAriaLabel,
+) => {
+	const section = findByRole('region');
+	expect(section).toBeDefined();
+	expect(section).toHaveAttribute('aria-label', expectedAriaLabel);
+};
+
 export const clearTitleField = (findByText: any) => {
 	var titleInput = (findByText('Title (optional)') as HTMLElement).nextSibling
 		.firstChild as HTMLElement;

--- a/packages/layout/src/utils.ts
+++ b/packages/layout/src/utils.ts
@@ -41,3 +41,7 @@ export function removeFromTabFlowIfMatches<T>(
 ): number | null {
 	return current.matches(match) ? -1 : null;
 }
+
+export function concatenateStrings(strings: string[]): string {
+	return strings.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
Fix accessibility issue [AB#86097](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/86097) when navigating between cards, making it clearer to screen readers that the context is changing when tabbing out of one card and into the next

- [x ] Includes tests