### PR TITLE
AB#82809 Add missing properties

### DIFF
--- a/packages/forms/src/elements/currency/currency.tsx
+++ b/packages/forms/src/elements/currency/currency.tsx
@@ -38,6 +38,7 @@ interface InputCurrencyProps extends FieldRenderProps<number>, FieldExtraProps {
 
 const InputCurrency: React.FC<InputCurrencyProps> = React.memo(
 	({
+		id,
 		label,
 		hint,
 		input,
@@ -250,6 +251,7 @@ const InputCurrency: React.FC<InputCurrencyProps> = React.memo(
 					accessibilityHelper={helper}
 				/>
 				<Input
+					id={id}
 					parentRef={innerInput}
 					type="text"
 					width={width}

--- a/packages/forms/src/elements/email/email.tsx
+++ b/packages/forms/src/elements/email/email.tsx
@@ -12,6 +12,7 @@ import AccessibilityHelper from '../accessibilityHelper';
 
 type InputEmailProps = FieldRenderProps<string> & FieldExtraProps;
 const InputEmail: React.FC<InputEmailProps> = ({
+	id,
 	label,
 	name,
 	hint,
@@ -39,6 +40,7 @@ const InputEmail: React.FC<InputEmailProps> = ({
 				accessibilityHelper={helper}
 			/>
 			<Input
+				id={id}
 				type="email"
 				width={width}
 				testId={testId}

--- a/packages/forms/src/elements/input/input.tsx
+++ b/packages/forms/src/elements/input/input.tsx
@@ -4,6 +4,7 @@ import styles from './input.module.scss';
 import AccessibilityHelper from '../accessibilityHelper';
 
 export type InputProps = {
+	id?: string;
 	type: string;
 	width?: LayoutProps['width'];
 	testId?: string;
@@ -20,6 +21,7 @@ export type InputProps = {
 };
 
 export const Input: React.FC<InputProps> = ({
+	id,
 	type = 'text',
 	width,
 	testId,
@@ -56,6 +58,7 @@ export const Input: React.FC<InputProps> = ({
 		>
 			{Before && <span className={styles.before}>{Before}</span>}
 			<input
+				id={id}
 				ref={parentRef}
 				type={type}
 				data-testid={testId}

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -26,6 +26,7 @@ interface InputNumberProps extends FieldRenderProps<number>, FieldExtraProps {
 }
 
 const InputNumber: React.FC<InputNumberProps> = ({
+	id,
 	label,
 	name,
 	hint,
@@ -141,6 +142,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 				accessibilityHelper={helper}
 			/>
 			<Input
+				id={id}
 				type="number"
 				width={width}
 				testId={testId}

--- a/packages/forms/src/elements/phone/phone.tsx
+++ b/packages/forms/src/elements/phone/phone.tsx
@@ -12,6 +12,7 @@ import AccessibilityHelper from '../accessibilityHelper';
 
 type InputPhoneProps = FieldRenderProps<string> & FieldExtraProps;
 const InputPhone: React.FC<InputPhoneProps> = ({
+	id,
 	label,
 	name,
 	hint,
@@ -39,6 +40,7 @@ const InputPhone: React.FC<InputPhoneProps> = ({
 				accessibilityHelper={helper}
 			/>
 			<Input
+				id={id}
 				type="tel"
 				width={width}
 				testId={testId}

--- a/packages/forms/src/elements/search/search.tsx
+++ b/packages/forms/src/elements/search/search.tsx
@@ -13,7 +13,6 @@ interface SearchProps extends FieldRenderProps<string>, FieldExtraProps {
 	callback?: Function;
 	formatItem?: (item: any) => string;
 	getSelectedItem?: (item: any) => string;
-	placeholder?: string;
 	keyValue: string;
 	minLength?: number;
 	notFoundMessage?: string;

--- a/packages/forms/src/elements/search/search.tsx
+++ b/packages/forms/src/elements/search/search.tsx
@@ -13,7 +13,9 @@ interface SearchProps extends FieldRenderProps<string>, FieldExtraProps {
 	callback?: Function;
 	formatItem?: (item: any) => string;
 	getSelectedItem?: (item: any) => string;
+	placeholder?: string;
 	keyValue: string;
+	minLength?: number;
 	notFoundMessage?: string;
 	optionsArray?: any[];
 	searchService?: (x: string) => Promise<any>;
@@ -23,6 +25,7 @@ type PanelVisibility = 'visible' | 'hidden' | 'complete';
 
 const Search: React.FC<SearchProps> = React.memo(
 	({
+		id,
 		callback,
 		cfg,
 		formatItem = formatItemDefault,
@@ -36,6 +39,7 @@ const Search: React.FC<SearchProps> = React.memo(
 		notFoundMessage = 'There are no matches for your search criteria',
 		optionsArray = [],
 		placeholder,
+		minLength,
 		required = true,
 		searchService,
 		testId = 'search',
@@ -101,7 +105,7 @@ const Search: React.FC<SearchProps> = React.memo(
 			toggleResultsPanel();
 		}, [panelVisible]);
 
-		const helper = new AccessibilityHelper(rest['id'], !!label, !!hint);
+		const helper = new AccessibilityHelper(id, !!label, !!hint);
 
 		return (
 			<div className={classes}>
@@ -124,17 +128,18 @@ const Search: React.FC<SearchProps> = React.memo(
 					>
 						<Autocomplete
 							name={name}
-							id={testId}
+							id={id}
 							source={getResults}
 							onConfirm={chooseOption}
 							showAllValues={false}
-							minLength={3}
+							minLength={minLength}
 							tNoResults={() => notFoundMessage}
 							placeholder={placeholder}
 							templates={{
 								inputValue: getSelectedItemDefault,
 								suggestion: formatItem,
 							}}
+							testId={testId}
 						/>
 					</Flex>
 				</StyledInputLabel>

--- a/packages/forms/src/elements/select/select.tsx
+++ b/packages/forms/src/elements/select/select.tsx
@@ -20,6 +20,7 @@ interface SelectProps extends DownshiftProps<any>, FieldExtraProps {
 export const selectStateChangeTypes = Downshift.stateChangeTypes;
 
 export const Select: React.FC<SelectProps & FieldRenderProps<string>> = ({
+	id,
 	options,
 	label,
 	required,
@@ -39,7 +40,7 @@ export const Select: React.FC<SelectProps & FieldRenderProps<string>> = ({
 	cfg,
 	...rest
 }) => {
-	const helper = new AccessibilityHelper(rest['id'], !!label, !!hint);
+	const helper = new AccessibilityHelper(id, !!label, !!hint);
 
 	return (
 		<Downshift

--- a/packages/forms/src/elements/text/text.tsx
+++ b/packages/forms/src/elements/text/text.tsx
@@ -13,6 +13,7 @@ type InputTextProps = FieldRenderProps<string> &
 const InputText: React.FC<InputTextProps> = React.forwardRef(
 	(
 		{
+			id,
 			label,
 			name,
 			ariaLabel,
@@ -53,6 +54,7 @@ const InputText: React.FC<InputTextProps> = React.forwardRef(
 					accessibilityHelper={helper}
 				/>
 				<Input
+					id={id}
 					parentRef={ref}
 					type="text"
 					width={width}

--- a/packages/forms/src/renderFields.tsx
+++ b/packages/forms/src/renderFields.tsx
@@ -28,6 +28,8 @@ export type FieldOptions = {
 };
 
 export type FieldExtraProps = {
+	/** an id that identifies the input on the page **/
+	id?: string;
 	/** input label above the input box */
 	label?: string;
 	/** aria-label for accessibility when label is not specified */


### PR DESCRIPTION
- Declare various undeclared properties used by the Search component in its PropType.
- Obtain reference to inner input control to be able to set focus on it when required.

NB. Sonar cloud is flagging some required code as duplicated. I propose we treat this as a warning and ignore it.