### PR TITLE
FFSearch - assistiveHint prop

### DIFF
--- a/packages/forms/src/__tests__/addressLookup.spec.tsx
+++ b/packages/forms/src/__tests__/addressLookup.spec.tsx
@@ -117,16 +117,22 @@ describe('Address lookup', () => {
 			});
 
 			await searchForAPostcode(FakeAddressLookupProvider.tprAddress.postcode);
-			
-			const displayedPostcode = await screen.findByText(FakeAddressLookupProvider.tprAddress.postcode);
+
+			const displayedPostcode = await screen.findByText(
+				FakeAddressLookupProvider.tprAddress.postcode,
+			);
 			expect(displayedPostcode).toBeDefined();
 
-			const selectAddressInput = await screen.findByTestId('select-address-list');
+			const selectAddressInput = await screen.findByTestId(
+				'select-address-list',
+			);
 			selectAddressInput.click();
-			
+
 			const addressOptions = await screen.findAllByRole('option');
 
-			expect(addressOptions[0].textContent).toMatch(FakeAddressLookupProvider.tprAddress.addressLine1);
+			expect(addressOptions[0].textContent).toMatch(
+				FakeAddressLookupProvider.tprAddress.addressLine1,
+			);
 		});
 
 		test('should pass selected address to edit address view', async () => {
@@ -136,23 +142,29 @@ describe('Address lookup', () => {
 
 			await searchForAPostcode(FakeAddressLookupProvider.tprAddress.postcode);
 
-			const selectAddressInput = await screen.findByTestId('select-address-list');
+			const selectAddressInput = await screen.findByTestId(
+				'select-address-list',
+			);
 			selectAddressInput.click();
-			
+
 			const addressOptions = await screen.findAllByRole('option');
-			
+
 			await invokeActionWithConsoleErrorTestFailureSuppressed(async () => {
 				// AddressLookup is throwing an error:
 				//     A component is changing a controlled input of type text to be uncontrolled. Input elements should not switch from controlled to uncontrolled (or vice versa).
 				//
-				// The component works despite the console error (which also appears in the gatsby site), and while this does need to be fixed, it is an existing issue. 
+				// The component works despite the console error (which also appears in the gatsby site), and while this does need to be fixed, it is an existing issue.
 				// For now I'm just put a warning in the console for visibility so the tests don't fail.
 				addressOptions[0].click();
-				const selectAddressButton = await screen.findByTestId('select-address-button');
+				const selectAddressButton = await screen.findByTestId(
+					'select-address-button',
+				);
 				selectAddressButton.click();
 			});
 
-			const addressLine1Input = await screen.findByDisplayValue(FakeAddressLookupProvider.tprAddress.addressLine1);
+			const addressLine1Input = await screen.findByDisplayValue(
+				FakeAddressLookupProvider.tprAddress.addressLine1,
+			);
 			expect(addressLine1Input).toBeDefined();
 		});
 	});
@@ -161,7 +173,10 @@ describe('Address lookup', () => {
 		test('to be the default when initialValue is not null', async () => {
 			const { container } = formSetup({
 				render: (
-					<AddressLookup {...defaultProps} initialValue={FakeAddressLookupProvider.tprAddress} />
+					<AddressLookup
+						{...defaultProps}
+						initialValue={FakeAddressLookupProvider.tprAddress}
+					/>
 				),
 			});
 			const input = container.querySelector('input[name="addressLine1"]');
@@ -170,7 +185,10 @@ describe('Address lookup', () => {
 		test('passes accessibility checks', async () => {
 			const { container } = formSetup({
 				render: (
-					<AddressLookup {...defaultProps} initialValue={FakeAddressLookupProvider.tprAddress} />
+					<AddressLookup
+						{...defaultProps}
+						initialValue={FakeAddressLookupProvider.tprAddress}
+					/>
 				),
 			});
 			const results = await axe(container);
@@ -179,7 +197,10 @@ describe('Address lookup', () => {
 		test('to go to postcode lookup view when button clicked', async () => {
 			const { container } = formSetup({
 				render: (
-					<AddressLookup {...defaultProps} initialValue={FakeAddressLookupProvider.tprAddress} />
+					<AddressLookup
+						{...defaultProps}
+						initialValue={FakeAddressLookupProvider.tprAddress}
+					/>
 				),
 			});
 			const button = container.querySelector(

--- a/packages/forms/src/elements/address/fakeAddressLookupProvider.ts
+++ b/packages/forms/src/elements/address/fakeAddressLookupProvider.ts
@@ -32,16 +32,18 @@ class FakeAddressLookupProvider implements AddressLookupProvider {
 		country: 'UK',
 		countryId: 229,
 		uprn: 10091767168,
-	}
+	};
 
 	constructor() {}
 	lookupAddress(postcode): Promise<any> {
-		
 		var matchedAddresses = [];
 
-		if (postcode === FakeAddressLookupProvider.tprAddress.postcode) matchedAddresses.push(FakeAddressLookupProvider.tprAddress);
-		if (postcode === FakeAddressLookupProvider.fcaAddress.postcode) matchedAddresses.push(FakeAddressLookupProvider.fcaAddress);
-		if (postcode === FakeAddressLookupProvider.ppfAddress.postcode) matchedAddresses.push(FakeAddressLookupProvider.ppfAddress);
+		if (postcode === FakeAddressLookupProvider.tprAddress.postcode)
+			matchedAddresses.push(FakeAddressLookupProvider.tprAddress);
+		if (postcode === FakeAddressLookupProvider.fcaAddress.postcode)
+			matchedAddresses.push(FakeAddressLookupProvider.fcaAddress);
+		if (postcode === FakeAddressLookupProvider.ppfAddress.postcode)
+			matchedAddresses.push(FakeAddressLookupProvider.ppfAddress);
 
 		return Promise.resolve(matchedAddresses);
 	}

--- a/packages/forms/src/elements/elements.module.scss
+++ b/packages/forms/src/elements/elements.module.scss
@@ -1,17 +1,17 @@
 @import '@tpr/theming/lib/variables.scss';
 
 fieldset {
-  padding: 0;
+	padding: 0;
 	display: flex;
 	flex-direction: column;
-	
+
 	> legend {
-		float:left;   //position legend within the fieldset
+		float: left; //position legend within the fieldset
 
 		+ * {
 			clear: left;
 			display: block;
-		}		
+		}
 	}
 }
 
@@ -34,6 +34,10 @@ fieldset {
 	margin-bottom: $space-1;
 	white-space: normal;
 	line-height: $line-height-3;
+}
+
+.labelNoBold {
+	font-weight: $font-weight-2 !important;
 }
 
 .hint {

--- a/packages/forms/src/elements/elements.tsx
+++ b/packages/forms/src/elements/elements.tsx
@@ -40,18 +40,25 @@ interface FormLabelTextProps {
 	element?: 'div' | 'legend' | 'label' | null;
 	id?: string;
 	className?: string;
+	labelNotBold?: boolean;
 }
 
 export const FormLabelText: React.FC<FormLabelTextProps> = ({
 	element = 'div',
 	id = null,
 	children,
+	labelNotBold,
 }) => {
+	const classNames = useClassNames({},[
+			styles.labelText,
+			labelNotBold && styles.labelNoBold
+		]
+	)
 	return createElement(
 		element,
 		{
 			id: id,
-			className: styles.labelText,
+			className: classNames,
 		},
 		children,
 	);
@@ -75,6 +82,7 @@ type InputElementHeadingProps = {
 	hint?: string;
 	meta?: any;
 	accessibilityHelper: AccessibilityHelper;
+	labelNotBold?: boolean;
 };
 export const InputElementHeading: React.FC<InputElementHeadingProps> = ({
 	element = 'div',
@@ -83,11 +91,12 @@ export const InputElementHeading: React.FC<InputElementHeadingProps> = ({
 	hint,
 	meta,
 	accessibilityHelper,
+	labelNotBold,
 }) => {
 	return (
 		<>
 			{label && (
-				<FormLabelText element={element} id={accessibilityHelper.labelId}>
+				<FormLabelText element={element} id={accessibilityHelper.labelId} labelNotBold={labelNotBold}>
 					{label} {!required && '(optional)'}
 				</FormLabelText>
 			)}

--- a/packages/forms/src/elements/elements.tsx
+++ b/packages/forms/src/elements/elements.tsx
@@ -49,11 +49,10 @@ export const FormLabelText: React.FC<FormLabelTextProps> = ({
 	children,
 	labelNotBold,
 }) => {
-	const classNames = useClassNames({},[
-			styles.labelText,
-			labelNotBold && styles.labelNoBold
-		]
-	)
+	const classNames = useClassNames({}, [
+		styles.labelText,
+		labelNotBold && styles.labelNoBold,
+	]);
 	return createElement(
 		element,
 		{
@@ -96,7 +95,11 @@ export const InputElementHeading: React.FC<InputElementHeadingProps> = ({
 	return (
 		<>
 			{label && (
-				<FormLabelText element={element} id={accessibilityHelper.labelId} labelNotBold={labelNotBold}>
+				<FormLabelText
+					element={element}
+					id={accessibilityHelper.labelId}
+					labelNotBold={labelNotBold}
+				>
 					{label} {!required && '(optional)'}
 				</FormLabelText>
 			)}

--- a/packages/forms/src/elements/search/search.mdx
+++ b/packages/forms/src/elements/search/search.mdx
@@ -224,11 +224,11 @@ import { FFSearch } from '@tpr/forms';
 							<form onSubmit={handleSubmit}>
 								<FFSearch
 									callback={cb}
-									id="accessible-search"
+									id="accessible-search-2"
 									keyValue={keyValue}
 									label="Search Organisation by town"
 									minLength={3}
-									name="accessible-search"
+									name="accessible-search-2"
 									searchService={searchService}
 								/>
 							</form>
@@ -312,7 +312,7 @@ import { FFSearch } from '@tpr/forms';
 				postcode: 'SE12 6DD',
 			},
 		];
-		const keyValue = 'organinationName';
+		const keyValue = 'organisationName';
 		const [valueSelected, setValueSelected] = useState(null);
 		const cb = (selection) => {
 			console.log('callback function: ', selection);
@@ -335,10 +335,11 @@ import { FFSearch } from '@tpr/forms';
 								<FFSearch
 									assistiveHint="This is the new assistive hint"
 									callback={cb}
-									id="accessible-search"
+									id="accessible-search-3"
 									keyValue={keyValue}
-									minLength={5}
-									name="accessible-search"
+									minLength={2}
+									name="accessible-search-3"
+									placeholder="type here the name of the organisation"
 									searchService={searchService}
 								/>
 							</form>

--- a/packages/forms/src/elements/search/search.mdx
+++ b/packages/forms/src/elements/search/search.mdx
@@ -112,13 +112,14 @@ import { FFSearch } from '@tpr/forms';
 						{({ handleSubmit }) => (
 							<form onSubmit={handleSubmit}>
 								<FFSearch
-									name="accessible-search"
-									label="Organisation"
-									hint="Search by organisation name."
-									optionsArray={values}
-									keyValue="organisationName"
-									inputWidth={5}
 									callback={cb}
+									hint="Search by organisation name."
+									id="accessible-search"
+									inputWidth={5}
+									keyValue="organisationName"
+									label="Organisation"
+									name="accessible-search"
+									optionsArray={values}
 								/>
 							</form>
 						)}

--- a/packages/forms/src/elements/search/search.mdx
+++ b/packages/forms/src/elements/search/search.mdx
@@ -222,12 +222,14 @@ import { FFSearch } from '@tpr/forms';
 						{({ handleSubmit }) => (
 							<form onSubmit={handleSubmit}>
 								<FFSearch
-									name="accessible-search"
-									label="Search Organisation"
-									searchService={searchService}
-									keyValue={keyValue}
+									assistiveHint="This is the new assistive hint"
 									callback={cb}
-									testId="auto"
+									id="accessible-search"
+									keyValue={keyValue}
+									label="Search Organisation"
+									minLength={5}
+									name="accessible-search"
+									searchService={searchService}
 								/>
 							</form>
 						)}
@@ -254,17 +256,19 @@ import { FFSearch } from '@tpr/forms';
 
 ### Props
 
-| Property        | Required | Type       | Description                                                                           |
-| --------------- | -------- | ---------- | ------------------------------------------------------------------------------------- |
-| callback        | false    | function   | callback function that runs when the user chooses an option                           |
-| formatItem      | false    | function   | optional function to specify how to display the results                               |
-| getSelectedItem | false    | function   | optional function for the Autocomplete component to specify how to filter the results |
-| inputWidth      | false    | SpaceProps | the width of the input                                                                |
-| keyValue        | true     | string     | the key value that will be used for the search                                        |
-| label           | true     | string     | text to be displayed as the label of the input                                        |
-| name            | true     | string     | name/id for the input                                                                 |
-| notFoundMessage | false    | string     | text displayed when there are no options to select                                    |
-| optionsArray    | false    | array      | Array of objects with the options to filter                                           |
-| placeholder     | false    | string     | placeholder for the input (not recommended)                                           |
-| searchService   | false    | function   | function that performs the search and returns a promise with the array of results     |
-| testId          | false    | string     | data attribute for testers                                                            |
+| Property        | Required | Type       | Description                                                                                        |
+| --------------- | -------- | ---------- | -------------------------------------------------------------------------------------------------- |
+| assistiveHint   | false    | string     | Accessibility: description of the usage of the component for users with accessibility requirements |
+| callback        | false    | function   | callback function that runs when the user chooses an option                                        |
+| formatItem      | false    | function   | optional function to specify how to display the results                                            |
+| getSelectedItem | false    | function   | optional function for the Autocomplete component to specify how to filter the results              |
+| inputWidth      | false    | SpaceProps | the width of the input                                                                             |
+| keyValue        | true     | string     | the key value that will be used for the search                                                     |
+| label           | true     | string     | text to be displayed as the label of the input                                                     |
+| minLength       | false    | number     | the minimum amount of characters before the search starts                                          |
+| name            | true     | string     | name/id for the input                                                                              |
+| notFoundMessage | false    | string     | text displayed when there are no options to select                                                 |
+| optionsArray    | false    | array      | Array of objects with the options to filter                                                        |
+| placeholder     | false    | string     | placeholder for the input (not recommended)                                                        |
+| searchService   | false    | function   | function that performs the search and returns a promise with the array of results                  |
+| testId          | false    | string     | data attribute for testers                                                                         |

--- a/packages/forms/src/elements/search/search.mdx
+++ b/packages/forms/src/elements/search/search.mdx
@@ -223,11 +223,120 @@ import { FFSearch } from '@tpr/forms';
 						{({ handleSubmit }) => (
 							<form onSubmit={handleSubmit}>
 								<FFSearch
+									callback={cb}
+									id="accessible-search"
+									keyValue={keyValue}
+									label="Search Organisation by town"
+									minLength={3}
+									name="accessible-search"
+									searchService={searchService}
+								/>
+							</form>
+						)}
+					</Form>
+				)}
+				{valueSelected !== null && (
+					<>
+						<p>{valueSelected.organisationName}</p>
+						<Button
+							type="button"
+							cfg={{ mt: 3 }}
+							onClick={() => setValueSelected(null)}
+						>
+							Change Organisation
+						</Button>
+					</>
+				)}
+			</>
+		);
+	}}
+</Playground>
+
+### Search input without label & hint
+
+<Playground>
+	{() => {
+		const values = [
+			{
+				organisationName: 'AAAAAA',
+				addressLine1: 'address1',
+				addressLine2: '',
+				addressLine3: 'address13',
+				postTown: 'London',
+				postCounty: '',
+				postcode: 'SE11 5DD',
+			},
+			{
+				organisationName: 'BBBBBB',
+				addressLine1: 'address2',
+				addressLine2: 'address22',
+				addressLine3: 'address23',
+				postTown: 'Manchester',
+				postCounty: '',
+				postcode: 'SE12 5DD',
+			},
+			{
+				organisationName: 'CCCCCC',
+				addressLine1: 'address3',
+				addressLine2: 'address32',
+				addressLine3: 'address33',
+				postTown: 'Liverpool',
+				postCounty: '',
+				postcode: 'SE13 5DD',
+			},
+			{
+				organisationName: 'DDDDDD',
+				addressLine1: 'address4',
+				addressLine2: 'address42',
+				addressLine3: 'address43',
+				postTown: 'Brighton',
+				postCounty: '',
+				postcode: 'SE14 5DD',
+			},
+			{
+				organisationName: 'EEEEEE',
+				addressLine1: 'address5',
+				addressLine2: 'address52',
+				addressLine3: 'address53',
+				postTown: 'Cardiff',
+				postCounty: '',
+				postcode: 'SE15 5DD',
+			},
+			{
+				organisationName: 'BBABBB',
+				addressLine1: 'address6',
+				addressLine2: 'address62',
+				addressLine3: 'address63',
+				postTown: 'Manchester',
+				postCounty: '',
+				postcode: 'SE12 6DD',
+			},
+		];
+		const keyValue = 'organinationName';
+		const [valueSelected, setValueSelected] = useState(null);
+		const cb = (selection) => {
+			console.log('callback function: ', selection);
+			setValueSelected(selection);
+		};
+		const searchService = (query) => {
+			const resultsFiltered = values.filter((option) => {
+				return (
+					option[keyValue].toLowerCase().indexOf(query.toLowerCase()) !== -1
+				);
+			});
+			return Promise.resolve([...resultsFiltered]);
+		};
+		return (
+			<>
+				{valueSelected == null && (
+					<Form onSubmit={() => console.log('onSubmit:', valueSelected)}>
+						{({ handleSubmit }) => (
+							<form onSubmit={handleSubmit}>
+								<FFSearch
 									assistiveHint="This is the new assistive hint"
 									callback={cb}
 									id="accessible-search"
 									keyValue={keyValue}
-									label="Search Organisation"
 									minLength={5}
 									name="accessible-search"
 									searchService={searchService}
@@ -266,6 +375,7 @@ import { FFSearch } from '@tpr/forms';
 | inputWidth      | false    | SpaceProps | the width of the input                                                                             |
 | keyValue        | true     | string     | the key value that will be used for the search                                                     |
 | label           | true     | string     | text to be displayed as the label of the input                                                     |
+| labelNotBold    | false    | boolean    | allow to display the label text in a normal font-weight instead of bold                            |
 | minLength       | false    | number     | the minimum amount of characters before the search starts                                          |
 | name            | true     | string     | name/id for the input                                                                              |
 | notFoundMessage | false    | string     | text displayed when there are no options to select                                                 |

--- a/packages/forms/src/elements/search/search.module.scss
+++ b/packages/forms/src/elements/search/search.module.scss
@@ -60,7 +60,7 @@
 
 	&.panelVisible {
 		> label {
-			> div:nth-of-type(2) {
+			> div {
 				// autocomplete-wrapper
 
 				> div {

--- a/packages/forms/src/elements/search/search.module.scss
+++ b/packages/forms/src/elements/search/search.module.scss
@@ -6,7 +6,7 @@
 
 .autocomplete {
 	> label {
-		> div:nth-of-type(2) {
+		> div {
 			// autocomplete-wrapper
 
 			> div {

--- a/packages/forms/src/elements/search/search.tsx
+++ b/packages/forms/src/elements/search/search.tsx
@@ -18,6 +18,7 @@ interface SearchProps extends FieldRenderProps<string>, FieldExtraProps {
 	notFoundMessage?: string;
 	optionsArray?: any[];
 	searchService?: (x: string) => Promise<any>;
+	assistiveHint?: string;
 }
 
 type PanelVisibility = 'visible' | 'hidden' | 'complete';
@@ -42,6 +43,7 @@ const Search: React.FC<SearchProps> = React.memo(
 		required = true,
 		searchService,
 		testId = 'search',
+		assistiveHint,
 		...rest
 	}) => {
 		const [panelVisible, setPanelVisible] = useState<PanelVisibility>('hidden');
@@ -139,6 +141,7 @@ const Search: React.FC<SearchProps> = React.memo(
 								suggestion: formatItem,
 							}}
 							testId={testId}
+							tAssistiveHint={() => assistiveHint}
 						/>
 					</Flex>
 				</StyledInputLabel>

--- a/packages/forms/src/elements/search/search.tsx
+++ b/packages/forms/src/elements/search/search.tsx
@@ -15,6 +15,7 @@ interface SearchProps extends FieldRenderProps<string>, FieldExtraProps {
 	formatItem?: (item: any) => string;
 	getSelectedItem?: (item: any) => string;
 	keyValue: string;
+	labelNotBold?: boolean;
 	minLength?: number;
 	notFoundMessage?: string;
 	optionsArray?: any[];
@@ -35,6 +36,7 @@ const Search: React.FC<SearchProps> = React.memo(
 		inputWidth = 10,
 		keyValue,
 		label,
+		labelNotBold = false,
 		meta,
 		minLength,
 		name,
@@ -111,17 +113,18 @@ const Search: React.FC<SearchProps> = React.memo(
 		return (
 			<div className={classes}>
 				<StyledInputLabel
+					cfg={Object.assign({ flexDirection: 'column' }, cfg)}
 					element="label"
 					isError={meta && meta.touched && meta.error}
-					cfg={Object.assign({ flexDirection: 'column' }, cfg)}
 					{...rest.ariaLabel}
 				>
 					<InputElementHeading
-						label={label}
-						required={required}
-						hint={hint}
-						meta={meta}
 						accessibilityHelper={helper}
+						hint={hint}
+						label={label}
+						labelNotBold={labelNotBold}
+						meta={meta}
+						required={required}
 					/>
 					<Flex
 						cfg={{ width: inputWidth, flexDirection: 'column' }}

--- a/packages/forms/src/elements/search/search.tsx
+++ b/packages/forms/src/elements/search/search.tsx
@@ -10,6 +10,7 @@ import { act } from 'react-dom/test-utils';
 import styles from './search.module.scss';
 
 interface SearchProps extends FieldRenderProps<string>, FieldExtraProps {
+	assistiveHint?: string;
 	callback?: Function;
 	formatItem?: (item: any) => string;
 	getSelectedItem?: (item: any) => string;
@@ -18,32 +19,31 @@ interface SearchProps extends FieldRenderProps<string>, FieldExtraProps {
 	notFoundMessage?: string;
 	optionsArray?: any[];
 	searchService?: (x: string) => Promise<any>;
-	assistiveHint?: string;
 }
 
 type PanelVisibility = 'visible' | 'hidden' | 'complete';
 
 const Search: React.FC<SearchProps> = React.memo(
 	({
-		id,
+		assistiveHint = 'When autocomplete results are available use up and down arrows to review and enter to select. Touch device users, explore by touch or with swipe gestures.',
 		callback,
 		cfg,
 		formatItem = formatItemDefault,
 		getSelectedItem,
 		hint,
+		id,
 		inputWidth = 10,
 		keyValue,
 		label,
 		meta,
+		minLength,
 		name,
 		notFoundMessage = 'There are no matches for your search criteria',
 		optionsArray = [],
 		placeholder,
-		minLength,
 		required = true,
 		searchService,
 		testId = 'search',
-		assistiveHint,
 		...rest
 	}) => {
 		const [panelVisible, setPanelVisible] = useState<PanelVisibility>('hidden');
@@ -128,20 +128,20 @@ const Search: React.FC<SearchProps> = React.memo(
 						className={styles.relative}
 					>
 						<Autocomplete
-							name={name}
 							id={id}
-							source={getResults}
-							onConfirm={chooseOption}
-							showAllValues={false}
 							minLength={minLength}
-							tNoResults={() => notFoundMessage}
+							name={name}
+							onConfirm={chooseOption}
 							placeholder={placeholder}
+							showAllValues={false}
+							source={getResults}
+							tAssistiveHint={() => assistiveHint}
 							templates={{
 								inputValue: getSelectedItemDefault,
 								suggestion: formatItem,
 							}}
 							testId={testId}
-							tAssistiveHint={() => assistiveHint}
+							tNoResults={() => notFoundMessage}
 						/>
 					</Flex>
 				</StyledInputLabel>

--- a/packages/forms/src/utils/consoleErrorTestFailureTemporarySupression.ts
+++ b/packages/forms/src/utils/consoleErrorTestFailureTemporarySupression.ts
@@ -1,5 +1,7 @@
-export const invokeActionWithConsoleErrorTestFailureSuppressed = async (action: () => any) => {
-  global['throwOnConsoleError'] = false;
-  await action();
-  global['throwOnConsoleError'] = true;
-}
+export const invokeActionWithConsoleErrorTestFailureSuppressed = async (
+	action: () => any,
+) => {
+	global['throwOnConsoleError'] = false;
+	await action();
+	global['throwOnConsoleError'] = true;
+};


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Adding new optional prop `assistiveHint` to the `FFSearch` component.
It will allow to specify a different text for the description of the component, which by default contains the text:
 _"When autocomplete results are available use up and down arrows to review and enter to select. Touch device users, explore by touch or with swipe gestures."_

- Fixes for when input doesn't receive `label` & `hint` props.
- `labelNotBold` prop to allow displaying the label with normal font-weight and not in bold.
- Adding other properties to the .mdx file for documentation in the Netlify app.


