### PR TITLE
Adding custom error messages to FFInputEmail & FFInputPhone

### DIFF
--- a/packages/forms/src/__tests__/email.spec.tsx
+++ b/packages/forms/src/__tests__/email.spec.tsx
@@ -5,56 +5,65 @@ import { axe } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
 import { CheckDescribedByTag } from '../utils/aria-describedByTest';
 
-const wrongFormatMsg = 'Invalid email format';
-const emptyFieldMsg = 'email cannot be empty';
+const emailWrongFormatMsg = 'Invalid email format';
+const emailEmptyFieldMsg = 'email cannot be empty';
+const emailTestId = 'email-input';
+const emailName = 'email';
+const emailLabel = 'Email address';
+const emailHint = 'This explains how to complete the email address field';
+const customErrorEmptyValue = 'please provide an email address';
+const customErrorInvalidValue = 'this is not a valid email address';
+
+const basicProps = {
+	hint: emailHint,
+	label: emailLabel,
+	name: emailName,
+	testId: emailTestId,
+};
+
+const handleSubmit = jest.fn();
 
 describe('Email input', () => {
 	test('is accessible', async () => {
 		const { container } = formSetup({
-			render: <FFInputEmail label="Email" testId="email-input" name="email" />,
+			render: <FFInputEmail {...basicProps} />,
 		});
 		const results = await axe(container);
 		expect(results).toHaveNoViolations();
 	});
 
 	test('values get captured correctly', async () => {
-		const testId = 'email-input';
-		const handleSubmit = jest.fn();
 		const { getByText, getByTestId } = formSetup({
-			render: <FFInputEmail label="Email" testId={testId} name="email" />,
+			render: <FFInputEmail {...basicProps} />,
 			onSubmit: handleSubmit,
 		});
 
-		userEvent.type(getByTestId(testId), 'david.alekna@tpr.gov.uk');
+		userEvent.type(getByTestId(emailTestId), 'david.alekna@tpr.gov.uk');
 		getByText('Submit').click();
 
-		expect(getByTestId(testId)).toHaveValue('david.alekna@tpr.gov.uk');
+		expect(getByTestId(emailTestId)).toHaveValue('david.alekna@tpr.gov.uk');
 	});
 
 	test('should not accept invalid email address', async () => {
-		const testId = 'email-input';
-		const handleSubmit = jest.fn();
 		const { getByText, getByTestId, form } = formSetup({
-			render: <FFInputEmail label="Email" testId={testId} name="email" />,
+			render: <FFInputEmail {...basicProps} />,
 			onSubmit: handleSubmit,
 		});
 
-		userEvent.type(getByTestId(testId), 'this is not an email address');
+		userEvent.type(getByTestId(emailTestId), 'this is not an email address');
 		getByText('Submit').click();
 
-		expect(getByText(wrongFormatMsg)).toBeInTheDocument();
+		expect(getByText(emailWrongFormatMsg)).toBeInTheDocument();
 		expect(form.getState().valid).toBeFalsy();
 	});
 
 	test('accepts valid email', async () => {
-		const testId = 'email-input';
-		const handleSubmit = jest.fn();
 		const { getByText, getByTestId, form } = formSetup({
-			render: <FFInputEmail label="Email" testId={testId} name="email" />,
+			render: <FFInputEmail {...basicProps} />,
 			onSubmit: handleSubmit,
 		});
 
-		userEvent.type(getByTestId(testId), 'david.alekna@tpr.gov.uk');
+		userEvent.type(getByTestId(emailTestId), 'david.alekna@tpr.gov.uk');
 		getByText('Submit').click();
 
 		expect(form.getState().valid).toBeTruthy();
@@ -62,53 +71,32 @@ describe('Email input', () => {
 
 	test('renders readonly', () => {
 		const { queryByTestId } = formSetup({
-			render: <FFInputEmail testId="text-input" name="name" readOnly={true} />,
+			render: <FFInputEmail {...basicProps} readOnly={true} />,
 		});
 
-		const label = queryByTestId('text-input');
+		const label = queryByTestId(emailTestId);
 		expect(label).toHaveAttribute('readonly');
 	});
 
 	test('has correct describedby tag when an error is shown', () => {
-		const testId = 'email-input';
-		const name = 'email';
-		const hint = 'This explains how to complete the field';
-
-		const handleSubmit = jest.fn();
-
 		const { getByText, getByTestId } = formSetup({
-			render: (
-				<FFInputEmail
-					label="Email"
-					testId={testId}
-					name={name}
-					hint={hint}
-					required={true}
-				/>
-			),
+			render: <FFInputEmail {...basicProps} required={true} />,
 			onSubmit: handleSubmit,
 		});
 
-		const emailTest = getByTestId(testId);
-
-		CheckDescribedByTag(getByText, emailTest, emptyFieldMsg, hint);
+		const emailTest = getByTestId(emailTestId);
+		CheckDescribedByTag(getByText, emailTest, emailEmptyFieldMsg, emailHint);
 	});
 
-	describe('custom error messages', () => {
-		test('displaying custom error messages', () => {
-			const testId = 'email-input';
-			const errorEmptyValue = 'please provide an email address';
-			const errorInvalidValue = 'this is not a valid email';
-			const handleSubmit = jest.fn();
+	describe('custom error messages for Email input', () => {
+		test('displaying custom Empty Value error message', () => {
 			const { getByText, form } = formSetup({
 				render: (
 					<FFInputEmail
-						label="Email"
-						testId={testId}
-						name="email"
+						{...basicProps}
 						required={true}
-						errorEmptyValue={errorEmptyValue}
-						errorInvalidValue={errorInvalidValue}
+						errorEmptyValue={customErrorEmptyValue}
+						errorInvalidValue={customErrorInvalidValue}
 					/>
 				),
 				onSubmit: handleSubmit,
@@ -116,33 +104,27 @@ describe('Email input', () => {
 
 			getByText('Submit').click();
 
-			expect(getByText(errorEmptyValue)).toBeInTheDocument();
+			expect(getByText(customErrorEmptyValue)).toBeInTheDocument();
 			expect(form.getState().valid).toBeFalsy();
 		});
 
-		test('displaying custom error messages', () => {
-			const testId = 'email-input';
-			const errorEmptyValue = 'please provide an email address';
-			const errorInvalidValue = 'this is not a valid email';
-			const handleSubmit = jest.fn();
+		test('displaying custom Invalid format error message', () => {
 			const { getByText, getByTestId, form } = formSetup({
 				render: (
 					<FFInputEmail
-						label="Email"
-						testId={testId}
-						name="email"
+						{...basicProps}
 						required={true}
-						errorEmptyValue={errorEmptyValue}
-						errorInvalidValue={errorInvalidValue}
+						errorEmptyValue={customErrorEmptyValue}
+						errorInvalidValue={customErrorInvalidValue}
 					/>
 				),
 				onSubmit: handleSubmit,
 			});
 
-			userEvent.type(getByTestId(testId), 'david.alekna');
+			userEvent.type(getByTestId(emailTestId), 'david.alekna');
 			getByText('Submit').click();
 
-			expect(getByText(errorInvalidValue)).toBeInTheDocument();
+			expect(getByText(customErrorInvalidValue)).toBeInTheDocument();
 			expect(form.getState().valid).toBeFalsy();
 		});
 	});

--- a/packages/forms/src/__tests__/phone.spec.tsx
+++ b/packages/forms/src/__tests__/phone.spec.tsx
@@ -5,6 +5,9 @@ import { axe } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
 import { CheckDescribedByTag } from '../utils/aria-describedByTest';
 
+const wrongFormatMsg = 'Invalid phone number format';
+const emptyFieldMsg = 'phone number cannot be empty';
+
 describe('Phone input', () => {
 	test('is accessible', async () => {
 		const { container } = formSetup({
@@ -49,7 +52,7 @@ describe('Phone input', () => {
 		getByText('Submit').click();
 
 		expect(form.getState().valid).toBeFalsy();
-		expect(getByText('Invalid phone number')).toBeInTheDocument();
+		expect(getByText(wrongFormatMsg)).toBeInTheDocument();
 	});
 
 	test('accepts only valid numbers', async () => {
@@ -68,31 +71,6 @@ describe('Phone input', () => {
 		expect(form.getState().valid).toBeTruthy();
 	});
 
-	test('composes custom validation function', async () => {
-		const testId = 'phone-input';
-		const errorMessage = 'Must include tripple 7';
-		const handleSubmit = jest.fn();
-		const { getByText, getByTestId, queryByText, form } = formSetup({
-			render: (
-				<FFInputPhone
-					label="Phone number"
-					testId={testId}
-					name="phone"
-					validate={(phone) =>
-						phone && phone.includes('777') ? undefined : errorMessage
-					}
-				/>
-			),
-			onSubmit: handleSubmit,
-		});
-
-		userEvent.type(getByTestId(testId), '07543 221 321');
-		getByText('Submit').click();
-
-		expect(queryByText(errorMessage)).toBeInTheDocument();
-		expect(form.getState().valid).toBeFalsy();
-	});
-
 	test('renders readonly', () => {
 		const { queryByTestId } = formSetup({
 			render: <FFInputPhone testId="text-input" name="name" readOnly={true} />,
@@ -103,7 +81,6 @@ describe('Phone input', () => {
 	});
 
 	test('has correct describedby tag when an error is shown', () => {
-		const numberRequired = 'Invalid phone number';
 		const testId = 'phoneTest';
 		const name = 'phoneNumber';
 		const hint = 'This explains how to complete the field';
@@ -117,13 +94,65 @@ describe('Phone input', () => {
 					name={name}
 					hint={hint}
 					required={true}
-					validate={(number) => (number ? undefined : numberRequired)}
 				/>
 			),
 			onSubmit: handleSubmit,
 		});
 
 		const phoneTest = getByTestId(testId);
-		CheckDescribedByTag(getByText, phoneTest, numberRequired, hint);
+		CheckDescribedByTag(getByText, phoneTest, emptyFieldMsg, hint);
+	});
+
+	describe('custom error messages', () => {
+		test('displaying custom error messages', () => {
+			const testId = 'email-input';
+			const errorEmptyValue = 'please provide a phone number';
+			const errorInvalidValue = 'this is not a valid phone number';
+			const handleSubmit = jest.fn();
+			const { getByText, form } = formSetup({
+				render: (
+					<FFInputPhone
+						label="Phone Number"
+						testId={testId}
+						name="phoneNumber"
+						required={true}
+						errorEmptyValue={errorEmptyValue}
+						errorInvalidValue={errorInvalidValue}
+					/>
+				),
+				onSubmit: handleSubmit,
+			});
+
+			getByText('Submit').click();
+
+			expect(getByText(errorEmptyValue)).toBeInTheDocument();
+			expect(form.getState().valid).toBeFalsy();
+		});
+
+		test('displaying custom error messages', () => {
+			const testId = 'email-input';
+			const errorEmptyValue = 'please provide a phone number';
+			const errorInvalidValue = 'this is not a valid phone number';
+			const handleSubmit = jest.fn();
+			const { getByText, getByTestId, form } = formSetup({
+				render: (
+					<FFInputPhone
+						label="Phone Number"
+						testId={testId}
+						name="phoneNumber"
+						required={true}
+						errorEmptyValue={errorEmptyValue}
+						errorInvalidValue={errorInvalidValue}
+					/>
+				),
+				onSubmit: handleSubmit,
+			});
+
+			userEvent.type(getByTestId(testId), '234');
+			getByText('Submit').click();
+
+			expect(getByText(errorInvalidValue)).toBeInTheDocument();
+			expect(form.getState().valid).toBeFalsy();
+		});
 	});
 });

--- a/packages/forms/src/__tests__/phone.spec.tsx
+++ b/packages/forms/src/__tests__/phone.spec.tsx
@@ -5,67 +5,68 @@ import { axe } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
 import { CheckDescribedByTag } from '../utils/aria-describedByTest';
 
-const wrongFormatMsg = 'Invalid phone number format';
-const emptyFieldMsg = 'phone number cannot be empty';
+const phoneWrongFormatMsg = 'Invalid phone number format';
+const phoneEmptyFieldMsg = 'phone number cannot be empty';
+const phoneTestId = 'phone-input';
+const phoneName = 'phoneNumber';
+const phoneLabel = 'Phone number';
+const phoneHint = 'This explains how to complete the phone number field';
+const customErrorEmptyValue = 'please provide a phone number';
+const customErrorInvalidValue = 'this is not a valid phone number';
+
+const basicProps = {
+	hint: phoneHint,
+	label: phoneLabel,
+	name: phoneName,
+	testId: phoneTestId,
+};
+
+const handleSubmit = jest.fn();
 
 describe('Phone input', () => {
 	test('is accessible', async () => {
 		const { container } = formSetup({
-			render: (
-				<FFInputPhone label="Phone number" testId="phone-input" name="phone" />
-			),
+			render: <FFInputPhone {...basicProps} />,
 		});
 		const results = await axe(container);
 		expect(results).toHaveNoViolations();
 	});
 
 	test('values get captured correctly', async () => {
-		const testId = 'phone-input';
-		const handleSubmit = jest.fn();
 		const { getByText, getByTestId } = formSetup({
-			render: (
-				<FFInputPhone label="Phone number" testId={testId} name="phone" />
-			),
+			render: <FFInputPhone {...basicProps} />,
 			onSubmit: handleSubmit,
 		});
 
-		userEvent.type(getByTestId(testId), '07543 221 321');
+		userEvent.type(getByTestId(phoneTestId), '07543 221 321');
 		getByText('Submit').click();
 
-		expect(getByTestId(testId)).toHaveValue('07543 221 321');
+		expect(getByTestId(phoneTestId)).toHaveValue('07543 221 321');
 	});
 
 	test('should not accept invalid numbers', async () => {
-		const testId = 'phone-input';
-		const handleSubmit = jest.fn();
 		const { getByText, getByTestId, form } = formSetup({
-			render: (
-				<FFInputPhone label="Phone number" testId={testId} name="phone" />
-			),
+			render: <FFInputPhone {...basicProps} />,
 			onSubmit: handleSubmit,
 		});
 
 		userEvent.type(
-			getByTestId(testId),
+			getByTestId(phoneTestId),
 			'this is not a valid phone number address',
 		);
 		getByText('Submit').click();
 
 		expect(form.getState().valid).toBeFalsy();
-		expect(getByText(wrongFormatMsg)).toBeInTheDocument();
+		expect(getByText(phoneWrongFormatMsg)).toBeInTheDocument();
 	});
 
 	test('accepts only valid numbers', async () => {
-		const testId = 'phone-input';
-		const handleSubmit = jest.fn();
 		const { getByText, getByTestId, form } = formSetup({
-			render: (
-				<FFInputPhone label="Phone number" testId={testId} name="phone" />
-			),
+			render: <FFInputPhone {...basicProps} />,
 			onSubmit: handleSubmit,
 		});
 
-		userEvent.type(getByTestId(testId), '07543 221 321');
+		userEvent.type(getByTestId(phoneTestId), '07543 221 321');
 		getByText('Submit').click();
 
 		expect(form.getState().valid).toBeTruthy();
@@ -73,51 +74,32 @@ describe('Phone input', () => {
 
 	test('renders readonly', () => {
 		const { queryByTestId } = formSetup({
-			render: <FFInputPhone testId="text-input" name="name" readOnly={true} />,
+			render: <FFInputPhone {...basicProps} readOnly={true} />,
 		});
 
-		const label = queryByTestId('text-input');
+		const label = queryByTestId(phoneTestId);
 		expect(label).toHaveAttribute('readonly');
 	});
 
 	test('has correct describedby tag when an error is shown', () => {
-		const testId = 'phoneTest';
-		const name = 'phoneNumber';
-		const hint = 'This explains how to complete the field';
-
-		const handleSubmit = jest.fn();
 		const { getByTestId, getByText } = formSetup({
-			render: (
-				<FFInputPhone
-					label="Phone Number"
-					testId={testId}
-					name={name}
-					hint={hint}
-					required={true}
-				/>
-			),
+			render: <FFInputPhone {...basicProps} required={true} />,
 			onSubmit: handleSubmit,
 		});
 
-		const phoneTest = getByTestId(testId);
-		CheckDescribedByTag(getByText, phoneTest, emptyFieldMsg, hint);
+		const phoneTest = getByTestId(phoneTestId);
+		CheckDescribedByTag(getByText, phoneTest, phoneEmptyFieldMsg, phoneHint);
 	});
 
-	describe('custom error messages', () => {
-		test('displaying custom error messages', () => {
-			const testId = 'email-input';
-			const errorEmptyValue = 'please provide a phone number';
-			const errorInvalidValue = 'this is not a valid phone number';
-			const handleSubmit = jest.fn();
+	describe('custom error messages for Phone Number input', () => {
+		test('Empty Value error message', () => {
 			const { getByText, form } = formSetup({
 				render: (
 					<FFInputPhone
-						label="Phone Number"
-						testId={testId}
-						name="phoneNumber"
+						{...basicProps}
 						required={true}
-						errorEmptyValue={errorEmptyValue}
-						errorInvalidValue={errorInvalidValue}
+						errorEmptyValue={customErrorEmptyValue}
+						errorInvalidValue={customErrorInvalidValue}
 					/>
 				),
 				onSubmit: handleSubmit,
@@ -125,33 +107,27 @@ describe('Phone input', () => {
 
 			getByText('Submit').click();
 
-			expect(getByText(errorEmptyValue)).toBeInTheDocument();
+			expect(getByText(customErrorEmptyValue)).toBeInTheDocument();
 			expect(form.getState().valid).toBeFalsy();
 		});
 
-		test('displaying custom error messages', () => {
-			const testId = 'email-input';
-			const errorEmptyValue = 'please provide a phone number';
-			const errorInvalidValue = 'this is not a valid phone number';
-			const handleSubmit = jest.fn();
+		test('Invalid format error message', () => {
 			const { getByText, getByTestId, form } = formSetup({
 				render: (
 					<FFInputPhone
-						label="Phone Number"
-						testId={testId}
-						name="phoneNumber"
+						{...basicProps}
 						required={true}
-						errorEmptyValue={errorEmptyValue}
-						errorInvalidValue={errorInvalidValue}
+						errorEmptyValue={customErrorEmptyValue}
+						errorInvalidValue={customErrorInvalidValue}
 					/>
 				),
 				onSubmit: handleSubmit,
 			});
 
-			userEvent.type(getByTestId(testId), '234');
+			userEvent.type(getByTestId(phoneTestId), '234');
 			getByText('Submit').click();
 
-			expect(getByText(errorInvalidValue)).toBeInTheDocument();
+			expect(getByText(customErrorInvalidValue)).toBeInTheDocument();
 			expect(form.getState().valid).toBeFalsy();
 		});
 	});

--- a/packages/forms/src/elements/email/email.mdx
+++ b/packages/forms/src/elements/email/email.mdx
@@ -43,25 +43,42 @@ import { Form, FFInputEmail } from '@tpr/forms';
 
 [CodeSandbox](https://codesandbox.io)
 
-Example using field level validation
+### Field required & custom error messages
 
 <Playground>
 	<Form onSubmit={console.log}>
 		{({ handleSubmit }) => (
 			<form onSubmit={handleSubmit}>
 				<FFInputEmail
-					name="event_name"
-					label="Event name"
+					name="email"
+					label="Email address"
 					placeholder="john.smith@tpr.gov.uk"
 					hint="Must be between 6 and 8 digits long"
-					validate={(email) =>
-						email && email.includes('tpr.gov.uk')
-							? undefined
-							: 'Must be a TPR email'
-					}
 					inputWidth={5}
 					cfg={{ my: 5 }}
 					required={true}
+					errorEmptyValue="Enter an email address"
+					errorInvalidValue="Enter an email address in the correct format, like name@example.com"
+				/>
+				<button type="submit" style={{ display: 'none' }} children="Submit" />
+			</form>
+		)}
+	</Form>
+</Playground>
+
+### Field not required
+
+<Playground>
+	<Form onSubmit={console.log}>
+		{({ handleSubmit }) => (
+			<form onSubmit={handleSubmit}>
+				<FFInputEmail
+					name="email2"
+					label="Email address"
+					placeholder="sam.smith@tpr.gov.uk"
+					hint="Must be between 6 and 8 digits long"
+					inputWidth={5}
+					cfg={{ my: 5 }}
 				/>
 				<button type="submit" style={{ display: 'none' }} children="Submit" />
 			</form>
@@ -77,11 +94,14 @@ Accepted config props: FlexProps, SpaceProps
 
 ### Props
 
-| Property | Required | Type    | Description                                     |
-| -------- | -------- | ------- | --------------------------------------------    |
-| cfg      | false    | object  | FlexProps & SpaceProps                          |
-| disabled | false    | boolean | Disable email field                             |
-| testId   | false    | string  | data attribute for testers                      |
-| label    | true     | string  | Email field description                         |
-| hint     | false    | string  | More detailed description about the email field |
-| readOnly | false    | boolean | Sets whether the field is read only             |
+| Property          | Required | Type    | Description                                               |
+| ----------------- | -------- | ------- | --------------------------------------------------------- |
+| cfg               | false    | object  | FlexProps & SpaceProps                                    |
+| disabled          | false    | boolean | Disable email field                                       |
+| errorEmptyValue   | false    | string  | The error message to display when the field is empty      |
+| errorInvalidValue | false    | string  | The error message to display when the format is not valid |
+| hint              | false    | string  | More detailed description about the email field           |
+| label             | true     | string  | Email field description                                   |
+| readOnly          | false    | boolean | Sets whether the field is read only                       |
+| required          | false    | boolean | Sets whether the field is required (default value: false) |
+| testId            | false    | string  | data attribute for testers                                |

--- a/packages/forms/src/elements/email/email.tsx
+++ b/packages/forms/src/elements/email/email.tsx
@@ -1,28 +1,26 @@
 import React from 'react';
 import { Field, FieldRenderProps } from 'react-final-form';
 import { StyledInputLabel, InputElementHeading } from '../elements';
-import { FieldProps, FieldExtraProps } from '../../renderFields';
+import { FieldExtraProps } from '../../renderFields';
+import { FFInputCommonProps } from 'types/fieldProps';
 import { Input } from '../input/input';
-import {
-	composeValidators,
-	isEmailValid,
-	executeClientValidation,
-} from '../../validators';
+import { isEmailValid } from '../../validators';
 import AccessibilityHelper from '../accessibilityHelper';
 
-type InputEmailProps = FieldRenderProps<string> & FieldExtraProps;
+interface InputEmailProps extends FieldRenderProps<string>, FieldExtraProps {}
+
 const InputEmail: React.FC<InputEmailProps> = ({
-	id,
-	label,
-	name,
 	hint,
+	id,
 	input,
-	testId,
+	inputWidth: width,
+	label,
 	meta,
-	required,
+	name,
 	placeholder,
 	readOnly,
-	inputWidth: width,
+	required,
+	testId,
 	cfg,
 }) => {
 	const helper = new AccessibilityHelper(name, !!label, !!hint);
@@ -56,19 +54,18 @@ const InputEmail: React.FC<InputEmailProps> = ({
 	);
 };
 
-export const FFInputEmail: React.FC<
-	FieldProps & FieldExtraProps
-> = React.forwardRef((fieldProps, ref) => {
-	return (
-		<Field
-			{...fieldProps}
-			validate={composeValidators(
-				executeClientValidation(fieldProps.validate),
-				isEmailValid(
-					fieldProps.error ? fieldProps.error : 'Invalid email address',
-				),
-			)}
-			render={(props) => <InputEmail {...props} {...fieldProps} ref={ref} />}
-		/>
-	);
-});
+export const FFInputEmail: React.FC<FFInputCommonProps> = React.forwardRef(
+	(fieldProps, ref) => {
+		return (
+			<Field
+				{...fieldProps}
+				validate={isEmailValid(
+					fieldProps.errorEmptyValue,
+					fieldProps.errorInvalidValue,
+					fieldProps.required,
+				)}
+				render={(props) => <InputEmail {...props} {...fieldProps} ref={ref} />}
+			/>
+		);
+	},
+);

--- a/packages/forms/src/elements/phone/phone.mdx
+++ b/packages/forms/src/elements/phone/phone.mdx
@@ -43,7 +43,7 @@ import { Form, FFInputPhone } from '@tpr/forms';
 
 [CodeSandbox](https://codesandbox.io)
 
-Example using field level validation
+### Field required & custom error messages
 
 <Playground>
 	<Form onSubmit={console.log}>
@@ -54,14 +54,31 @@ Example using field level validation
 					label="Phone Number"
 					placeholder="07543 221 321"
 					hint="Must be a UK number and 11 digits long"
-					validate={(number) =>
-						number && number.includes('777')
-							? undefined
-							: 'It must include 3 sevens.'
-					}
 					inputWidth={5}
 					cfg={{ my: 5 }}
-					required={false}
+					required={true}
+					errorEmptyValue="Enter a telephone number"
+					errorInvalidValue="Enter a telephone number in the correct format, like 01632 960 001, 07700 900 982 or +44 808 157 019"
+				/>
+				<button type="submit" style={{ display: 'none' }} children="Submit" />
+			</form>
+		)}
+	</Form>
+</Playground>
+
+### Field not required
+
+<Playground>
+	<Form onSubmit={console.log}>
+		{({ handleSubmit }) => (
+			<form onSubmit={handleSubmit}>
+				<FFInputPhone
+					name="phone_number2"
+					label="Phone Number"
+					placeholder="07543 221 321"
+					hint="Must be a UK number and 11 digits long"
+					inputWidth={5}
+					cfg={{ my: 5 }}
 				/>
 				<button type="submit" style={{ display: 'none' }} children="Submit" />
 			</form>
@@ -77,11 +94,14 @@ Accepted config props: FlexProps, SpaceProps
 
 ### Props
 
-| Property | Required | Type    | Description                                     |
-| -------- | -------- | ------- | --------------------------------------------    |
-| cfg      | false    | object  | FlexProps & SpaceProps                          |
-| disabled | false    | boolean | Disable phone field                             |
-| testId   | false    | string  | data attribute for testers                      |
-| label    | true     | string  | Phone field description                         |
-| hint     | false    | string  | More detailed description about the phone field |
-| readOnly | false    | boolean | Sets whether the field is read only             |
+| Property          | Required | Type    | Description                                               |
+| ----------------- | -------- | ------- | --------------------------------------------------------- |
+| cfg               | false    | object  | FlexProps & SpaceProps                                    |
+| disabled          | false    | boolean | Disable phone field                                       |
+| errorEmptyValue   | false    | string  | The error message to display when the field is empty      |
+| errorInvalidValue | false    | string  | The error message to display when the format is not valid |
+| hint              | false    | string  | More detailed description about the phone field           |
+| label             | true     | string  | Phone field description                                   |
+| readOnly          | false    | boolean | Sets whether the field is read only                       |
+| required          | false    | boolean | Sets whether the field is required (default value: false) |
+| testId            | false    | string  | data attribute for testers                                |

--- a/packages/forms/src/elements/phone/phone.tsx
+++ b/packages/forms/src/elements/phone/phone.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
 import { Field, FieldRenderProps } from 'react-final-form';
 import { StyledInputLabel, InputElementHeading } from '../elements';
-import { FieldProps, FieldExtraProps } from '../../renderFields';
+import { FieldExtraProps } from '../../renderFields';
+import { FFInputCommonProps } from 'types/fieldProps';
 import { Input } from '../input/input';
-import {
-	composeValidators,
-	isPhoneValid,
-	executeClientValidation,
-} from '../../validators';
+import { isPhoneValid } from '../../validators';
 import AccessibilityHelper from '../accessibilityHelper';
 
-type InputPhoneProps = FieldRenderProps<string> & FieldExtraProps;
+interface InputPhoneProps extends FieldRenderProps<string>, FieldExtraProps {}
+
 const InputPhone: React.FC<InputPhoneProps> = ({
 	id,
 	label,
@@ -56,17 +54,14 @@ const InputPhone: React.FC<InputPhoneProps> = ({
 	);
 };
 
-export const FFInputPhone: React.FC<FieldProps & FieldExtraProps> = (
-	fieldProps,
-) => {
+export const FFInputPhone: React.FC<FFInputCommonProps> = (fieldProps) => {
 	return (
 		<Field
 			{...fieldProps}
-			validate={composeValidators(
-				executeClientValidation(fieldProps.validate),
-				isPhoneValid(
-					fieldProps.error ? fieldProps.error : 'Invalid phone number',
-				),
+			validate={isPhoneValid(
+				fieldProps.errorEmptyValue,
+				fieldProps.errorInvalidValue,
+				fieldProps.required,
 			)}
 			render={(props) => <InputPhone {...props} {...fieldProps} />}
 		/>

--- a/packages/forms/src/types/fieldProps.ts
+++ b/packages/forms/src/types/fieldProps.ts
@@ -1,0 +1,6 @@
+import { FieldProps, FieldExtraProps } from '../renderFields';
+
+export interface FFInputCommonProps extends FieldProps, FieldExtraProps {
+	errorEmptyValue?: string;
+	errorInvalidValue?: string;
+}

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -17,12 +17,28 @@ export const validateUkPhone = (phone: string) => {
 };
 
 export const isEmailValid = (
-	errorMessage: string = 'Invalid email address',
-) => (email: string) => (validateEmail(email) ? undefined : errorMessage);
+	empty: string = 'email cannot be empty',
+	invalid: string = 'Invalid email format',
+	required: boolean = false,
+) => (email: string) => {
+	if (!email || email == '') {
+		return required ? empty : undefined;
+	} else {
+		return validateEmail(email) ? undefined : invalid;
+	}
+};
 
-export const isPhoneValid = (errorMessage: string = 'Invalid phone number') => (
-	phone: string,
-) => (validateUkPhone(phone) ? undefined : errorMessage);
+export const isPhoneValid = (
+	empty: string = 'phone number cannot be empty',
+	invalid: string = 'Invalid phone number format',
+	required: boolean = false,
+) => (phone: string) => {
+	if (!phone || phone == '') {
+		return required ? empty : undefined;
+	} else {
+		return validateUkPhone(phone) ? undefined : invalid;
+	}
+};
 
 export const executeClientValidation = (validate: Function | void) => (
 	email: string,

--- a/packages/layout/src/components/cards/actuary/i18n.ts
+++ b/packages/layout/src/components/cards/actuary/i18n.ts
@@ -1,3 +1,8 @@
+import {
+	InputErrorMessages,
+	defaultEmailErrorMessages,
+	defaultPhoneErrorMessages,
+} from '../common/interfaces';
 type PropertyFunction<T> = () => T;
 
 export type ActuaryI18nProps = {
@@ -42,11 +47,11 @@ export type ActuaryI18nProps = {
 		fields: {
 			telephone: {
 				label: string;
-				error: string;
+				error: InputErrorMessages;
 			};
 			email: {
 				label: string;
-				error: string;
+				error: InputErrorMessages;
 			};
 		};
 	};
@@ -128,12 +133,11 @@ export const i18n: ActuaryI18nProps = {
 		fields: {
 			telephone: {
 				label: 'Telephone number',
-				error:
-					'Enter a telephone number, like 0163 960 598 or +44 7700 900 359',
+				error: defaultPhoneErrorMessages,
 			},
 			email: {
 				label: 'Email address',
-				error: 'Cannot be empty',
+				error: defaultEmailErrorMessages,
 			},
 		},
 	},

--- a/packages/layout/src/components/cards/actuary/views/contacts/index.tsx
+++ b/packages/layout/src/components/cards/actuary/views/contacts/index.tsx
@@ -17,17 +17,19 @@ const getFields = (
 		name: 'telephoneNumber',
 		label: fields.telephone.label,
 		inputWidth: 2,
-		error: fields.telephone.error,
 		cfg: { mb: 3 },
 		required: true,
+		errorEmptyValue: fields.telephone.error.empty,
+		errorInvalidValue: fields.telephone.error.invalid,
 	},
 	{
 		type: 'email',
 		name: 'emailAddress',
 		label: fields.email.label,
 		inputWidth: 6,
-		error: fields.email.error,
 		required: true,
+		errorEmptyValue: fields.email.error.empty,
+		errorInvalidValue: fields.email.error.invalid,
 	},
 ];
 

--- a/packages/layout/src/components/cards/common/interfaces.ts
+++ b/packages/layout/src/components/cards/common/interfaces.ts
@@ -107,3 +107,18 @@ export interface I18nRemoveReason {
 		dateAddedInTheFuture?: string;
 	};
 }
+
+export interface InputErrorMessages {
+	empty: string;
+	invalid: string;
+}
+
+export const defaultEmailErrorMessages: InputErrorMessages = {
+	empty: 'Email cannot be empty',
+	invalid: 'Invalid email format',
+};
+
+export const defaultPhoneErrorMessages: InputErrorMessages = {
+	empty: 'Phone number cannot be empty',
+	invalid: 'Enter a telephone number, like 0163 960 598 or +44 7700 900 359',
+};

--- a/packages/layout/src/components/cards/corporateGroup/i18n.ts
+++ b/packages/layout/src/components/cards/corporateGroup/i18n.ts
@@ -1,4 +1,9 @@
 import { I18nRemoveReason } from '../common/interfaces';
+import {
+	InputErrorMessages,
+	defaultEmailErrorMessages,
+	defaultPhoneErrorMessages,
+} from '../common/interfaces';
 type PropertyFunction<T> = () => T;
 
 export type CorporateGroupI18nProps = {
@@ -43,11 +48,11 @@ export type CorporateGroupI18nProps = {
 		fields: {
 			telephone: {
 				label: string;
-				error: string;
+				error: InputErrorMessages;
 			};
 			email: {
 				label: string;
-				error: string;
+				error: InputErrorMessages;
 			};
 		};
 	};
@@ -126,12 +131,11 @@ export const i18n: CorporateGroupI18nProps = {
 		fields: {
 			telephone: {
 				label: 'Telephone number',
-				error:
-					'Enter a telephone number, like 0163 960 598 or +44 7700 900 359',
+				error: defaultPhoneErrorMessages,
 			},
 			email: {
 				label: 'Email address',
-				error: 'Cannot be empty',
+				error: defaultEmailErrorMessages,
 			},
 		},
 	},

--- a/packages/layout/src/components/cards/corporateGroup/i18n.ts
+++ b/packages/layout/src/components/cards/corporateGroup/i18n.ts
@@ -1,5 +1,5 @@
-import { I18nRemoveReason } from '../common/interfaces';
 import {
+	I18nRemoveReason,
 	InputErrorMessages,
 	defaultEmailErrorMessages,
 	defaultPhoneErrorMessages,

--- a/packages/layout/src/components/cards/corporateGroup/views/contacts/contacts.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/contacts/contacts.tsx
@@ -17,17 +17,19 @@ const getFields = (
 		name: 'telephoneNumber',
 		label: fields.telephone.label,
 		inputWidth: 2,
-		error: fields.telephone.error,
 		cfg: { mb: 3 },
 		required: true,
+		errorEmptyValue: fields.telephone.error.empty,
+		errorInvalidValue: fields.telephone.error.invalid,
 	},
 	{
 		type: 'email',
 		name: 'emailAddress',
 		label: fields.email.label,
 		inputWidth: 6,
-		error: fields.email.error,
 		required: true,
+		errorEmptyValue: fields.email.error.empty,
+		errorInvalidValue: fields.email.error.invalid,
 	},
 ];
 

--- a/packages/layout/src/components/cards/inHouse/i18n.ts
+++ b/packages/layout/src/components/cards/inHouse/i18n.ts
@@ -1,4 +1,9 @@
 import { I18nAddressLookup, i18n as AddressI18n } from '@tpr/forms';
+import {
+	InputErrorMessages,
+	defaultEmailErrorMessages,
+	defaultPhoneErrorMessages,
+} from '../common/interfaces';
 type PropertyFunction<T> = () => T;
 
 export type InHouseAdminI18nProps = {
@@ -44,11 +49,11 @@ export type InHouseAdminI18nProps = {
 		fields: {
 			telephone: {
 				label: string;
-				error: string;
+				error: InputErrorMessages;
 			};
 			email: {
 				label: string;
-				error: string;
+				error: InputErrorMessages;
 			};
 		};
 	};
@@ -136,12 +141,11 @@ export const i18n: InHouseAdminI18nProps = {
 		fields: {
 			telephone: {
 				label: 'Telephone number',
-				error:
-					'Enter a telephone number, like 0163 960 598 or +44 7700 900 359',
+				error: defaultPhoneErrorMessages,
 			},
 			email: {
 				label: 'Email address',
-				error: 'Cannot be empty',
+				error: defaultEmailErrorMessages,
 			},
 		},
 	},

--- a/packages/layout/src/components/cards/inHouse/views/contacts/index.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/contacts/index.tsx
@@ -17,17 +17,19 @@ const getFields = (
 		name: 'telephoneNumber',
 		label: fields.telephone.label,
 		inputWidth: 2,
-		error: fields.telephone.error,
 		cfg: { mb: 3 },
 		required: true,
+		errorEmptyValue: fields.telephone.error.empty,
+		errorInvalidValue: fields.telephone.error.invalid,
 	},
 	{
 		type: 'email',
 		name: 'emailAddress',
 		label: fields.email.label,
 		inputWidth: 6,
-		error: fields.email.error,
 		required: true,
+		errorEmptyValue: fields.email.error.empty,
+		errorInvalidValue: fields.email.error.invalid,
 	},
 ];
 

--- a/packages/layout/src/components/cards/trustee/i18n.ts
+++ b/packages/layout/src/components/cards/trustee/i18n.ts
@@ -1,5 +1,10 @@
 import { I18nAddressLookup, i18n as AddressI18n } from '@tpr/forms';
 import { I18nRemoveReason } from '../common/interfaces';
+import {
+	InputErrorMessages,
+	defaultEmailErrorMessages,
+	defaultPhoneErrorMessages,
+} from '../common/interfaces';
 type PropertyFunction<T> = () => T;
 
 export type TrusteeI18nProps = {
@@ -11,11 +16,11 @@ export type TrusteeI18nProps = {
 		fields: {
 			telephone: {
 				label: string;
-				error: string;
+				error: InputErrorMessages;
 			};
 			email: {
 				label: string;
-				error: string;
+				error: InputErrorMessages;
 			};
 		};
 	};
@@ -109,12 +114,11 @@ export const i18n: TrusteeI18nProps = {
 		fields: {
 			telephone: {
 				label: 'Telephone number',
-				error:
-					'Enter a telephone number, like 0163 960 598 or +44 7700 900 359',
+				error: defaultPhoneErrorMessages,
 			},
 			email: {
 				label: 'Email address',
-				error: 'Cannot be empty',
+				error: defaultEmailErrorMessages,
 			},
 		},
 	},

--- a/packages/layout/src/components/cards/trustee/i18n.ts
+++ b/packages/layout/src/components/cards/trustee/i18n.ts
@@ -1,6 +1,6 @@
 import { I18nAddressLookup, i18n as AddressI18n } from '@tpr/forms';
-import { I18nRemoveReason } from '../common/interfaces';
 import {
+	I18nRemoveReason,
 	InputErrorMessages,
 	defaultEmailErrorMessages,
 	defaultPhoneErrorMessages,

--- a/packages/layout/src/components/cards/trustee/views/contacts/index.tsx
+++ b/packages/layout/src/components/cards/trustee/views/contacts/index.tsx
@@ -17,17 +17,19 @@ const getFields = (
 		name: 'telephoneNumber',
 		label: fields.telephone.label,
 		inputWidth: 2,
-		error: fields.telephone.error,
 		cfg: { mb: 3 },
 		required: true,
+		errorEmptyValue: fields.telephone.error.empty,
+		errorInvalidValue: fields.telephone.error.invalid,
 	},
 	{
 		type: 'email',
 		name: 'emailAddress',
 		label: fields.email.label,
 		inputWidth: 6,
-		error: fields.email.error,
 		required: true,
+		errorEmptyValue: fields.email.error.empty,
+		errorInvalidValue: fields.email.error.invalid,
 	},
 ];
 

--- a/packages/layout/src/components/hint/hint.tsx
+++ b/packages/layout/src/components/hint/hint.tsx
@@ -5,10 +5,13 @@ import Styles from './hint.module.scss';
 type HintProps = {
 	children?: any;
 	expanded?: boolean;
-}
+};
 
 export const Hint = (props: HintProps) => (
-	<Flex cfg={{ pl: 3 }} className={props.expanded ? Styles.root : Styles.collapsed}>
+	<Flex
+		cfg={{ pl: 3 }}
+		className={props.expanded ? Styles.root : Styles.collapsed}
+	>
 		{props.children}
 	</Flex>
 );


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Adding 2 new optional props for displaying custom error messages in `FFInputEmail` & `FFInputPhone`:
- `errorEmptyValue`: to be displayed when the field is empty (and the field is `required`)
- `errorInvalidValue`: to be displayed when the value entered is not in the right format.

These components won't apply the `validate` function passed via props any more. Instead the validation will occur only via the `IsEmailValid` & `IsPhoneValid` methods implemented in the `validators.ts` file.

- Cards editing contact details (phone & email) have been updated to receive custom error messages
