### PR TITLE
Fix "Uncontrolled component changing to controlled" error in the address lookup component

### DIFF
--- a/packages/forms/src/__tests__/addressLookup.spec.tsx
+++ b/packages/forms/src/__tests__/addressLookup.spec.tsx
@@ -5,7 +5,6 @@ import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { AddressLookup, AddressProps } from '../elements/address/addressLookup';
 import FakeAddressLookupProvider from '../elements/address/fakeAddressLookupProvider';
-import { invokeActionWithConsoleErrorTestFailureSuppressed } from '../utils/consoleErrorTestFailureTemporarySupression';
 
 const addressLookupProvider = new FakeAddressLookupProvider();
 
@@ -148,19 +147,11 @@ describe('Address lookup', () => {
 			selectAddressInput.click();
 
 			const addressOptions = await screen.findAllByRole('option');
-
-			await invokeActionWithConsoleErrorTestFailureSuppressed(async () => {
-				// AddressLookup is throwing an error:
-				//     A component is changing a controlled input of type text to be uncontrolled. Input elements should not switch from controlled to uncontrolled (or vice versa).
-				//
-				// The component works despite the console error (which also appears in the gatsby site), and while this does need to be fixed, it is an existing issue.
-				// For now I'm just put a warning in the console for visibility so the tests don't fail.
-				addressOptions[0].click();
-				const selectAddressButton = await screen.findByTestId(
-					'select-address-button',
-				);
-				selectAddressButton.click();
-			});
+			addressOptions[0].click();
+			const selectAddressButton = await screen.findByTestId(
+				'select-address-button',
+			);
+			selectAddressButton.click();
 
 			const addressLine1Input = await screen.findByDisplayValue(
 				FakeAddressLookupProvider.tprAddress.addressLine1,

--- a/packages/forms/src/elements/address/fakeAddressLookupProvider.ts
+++ b/packages/forms/src/elements/address/fakeAddressLookupProvider.ts
@@ -45,6 +45,14 @@ class FakeAddressLookupProvider implements AddressLookupProvider {
 		if (postcode === FakeAddressLookupProvider.ppfAddress.postcode)
 			matchedAddresses.push(FakeAddressLookupProvider.ppfAddress);
 
+		if (matchedAddresses.length === 0) {
+			return Promise.resolve([
+				FakeAddressLookupProvider.tprAddress,
+				FakeAddressLookupProvider.fcaAddress,
+				FakeAddressLookupProvider.ppfAddress,
+			]);
+		}
+
 		return Promise.resolve(matchedAddresses);
 	}
 

--- a/packages/forms/src/elements/address/selectAddress.tsx
+++ b/packages/forms/src/elements/address/selectAddress.tsx
@@ -85,8 +85,8 @@ export const SelectAddress: React.FC<SelectAddressProps> = ({
 	// Setting a 'valid' object appears to be the only way to control validity of FFSelect.
 	// validate() will run immediately. Initialise to null so that validate() can detect the initial load and set an initial value rather than validating.
 	let [selectAddressValid, setSelectAddressValid] = useState({
-		error: '',
 		touched: false,
+		error: '',
 	});
 	function getAddressIfValid(): Address | undefined {
 		const selectedAddressField = form.getFieldState('selectedAddress');
@@ -100,6 +100,26 @@ export const SelectAddress: React.FC<SelectAddressProps> = ({
 			return selectedAddressField.value.value;
 		}
 	}
+
+	function clearSelectedAddress(): void {
+		const selectedAddressField = form.getFieldState('selectedAddress');
+		if (
+			selectedAddressField &&
+			selectedAddressField.value &&
+			selectedAddressField.value.value
+		) {
+			selectedAddressField.value.value = null;
+		}
+	}
+
+	const updateAddressValidationIfChanged = (updatedSelectAddressValid) => {
+		if (
+			selectAddressValid.touched !== updatedSelectAddressValid.touched ||
+			selectAddressValid.error !== updatedSelectAddressValid.error
+		) {
+			setSelectAddressValid(updatedSelectAddressValid);
+		}
+	};
 
 	return (
 		<>
@@ -136,14 +156,14 @@ export const SelectAddress: React.FC<SelectAddressProps> = ({
 				validate={(value) => {
 					// On initial load, setup the validation object
 					if (!selectAddressValid) {
-						setSelectAddressValid({ error: '', touched: false });
+						updateAddressValidationIfChanged({ touched: false, error: '' });
 						return;
 					}
 					// On subsequent runs, update the validation object.
 					// In this case it can only go from invalid (initial load) to valid (address selected).
 					// You can't select an invalid option from the list because there aren't any, and if you don't select one this never runs.
-					if (value) {
-						setSelectAddressValid({ touched: true, error: '' });
+					if (value && value.value) {
+						updateAddressValidationIfChanged({ touched: true, error: '' });
 					}
 				}}
 				meta={selectAddressValid}
@@ -151,7 +171,7 @@ export const SelectAddress: React.FC<SelectAddressProps> = ({
 				placeholder={selectAddressPlaceholder}
 				readOnly={true}
 				disabled={loading}
-				selectedItem={{}} // don't reselect if the same address turns up again
+				selectedItem={null} // don't reselect if the same address turns up again
 			/>
 			<Button
 				disabled={loading || !getAddressIfValid()}
@@ -161,8 +181,9 @@ export const SelectAddress: React.FC<SelectAddressProps> = ({
 					const validAddress = getAddressIfValid();
 					if (validAddress) {
 						onAddressSelected(validAddress);
+						clearSelectedAddress();
 					} else {
-						setSelectAddressValid({
+						updateAddressValidationIfChanged({
 							touched: true,
 							error: selectAddressRequiredMessage,
 						});

--- a/packages/forms/src/utils/consoleErrorTestFailureTemporarySupression.ts
+++ b/packages/forms/src/utils/consoleErrorTestFailureTemporarySupression.ts
@@ -1,7 +1,0 @@
-export const invokeActionWithConsoleErrorTestFailureSuppressed = async (
-	action: () => any,
-) => {
-	global['throwOnConsoleError'] = false;
-	await action();
-	global['throwOnConsoleError'] = true;
-};


### PR DESCRIPTION
Fixes [AB#71713](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/71713) "Uncontrolled component changing to controlled" error in the address lookup component, which also resolves some of the warnings in the addressLookup.spec.tsx.
