### PR TITLE
AB#69925 - Numeric fields not rendering decimal places consistently

### DIFF
--- a/packages/core/src/testHelpers.ts
+++ b/packages/core/src/testHelpers.ts
@@ -1,0 +1,3 @@
+export const sleep = (millisecondsToSleep): Promise<unknown> => {
+	return new Promise((resolve) => setTimeout(resolve, millisecondsToSleep));
+};

--- a/packages/forms/src/__tests__/number.spec.tsx
+++ b/packages/forms/src/__tests__/number.spec.tsx
@@ -5,6 +5,7 @@ import { axe } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
 import { fireEvent } from '@testing-library/react';
 import { CheckDescribedByTag } from '../utils/aria-describedByTest';
+import { sleep } from '@tpr/core/src/testHelpers';
 
 const testId = 'number-input';
 
@@ -262,6 +263,48 @@ describe('Number', () => {
 			userEvent.type(getByTestId(testId), '1.2');
 			fireEvent.blur(getByTestId(testId));
 			expect(getByTestId(testId)).toHaveValue(1.2);
+		});
+		test('field with initial value renders with decimal places set', async () => {
+			const { getByTestId } = formSetup({
+				render: (
+					<FFInputNumber
+						label="Number"
+						testId={testId}
+						name="number"
+						decimalPlaces={2}
+						initialValue={15}
+					/>
+				),
+			});
+
+			// There is a setTimeout function in the number.tsx so we
+			// need to wait for that to complete before running the
+			// test assertions
+			await sleep(1000);
+
+			var inputNumberField = await getByTestId(testId);
+			expect(inputNumberField).toHaveAttribute('value', '15.00');
+		});
+		test('form with initial values renders with decimal places set', async () => {
+			const { getByTestId } = formSetup({
+				render: (
+					<FFInputNumber
+						label="Number"
+						testId={testId}
+						name="rpiIncrease"
+						decimalPlaces={2}
+					/>
+				),
+				initialValues: { rpiIncrease: 2.5 },
+			});
+
+			// There is a setTimeout function in the number.tsx so we
+			// need to wait for that to complete before running the
+			// test assertions
+			await sleep(1000);
+
+			var inputNumberField = await getByTestId(testId);
+			expect(inputNumberField).toHaveAttribute('value', '2.50');
 		});
 	});
 

--- a/packages/forms/src/elements/number/number.mdx
+++ b/packages/forms/src/elements/number/number.mdx
@@ -43,7 +43,10 @@ import { FFInputNumber } from '@tpr/forms';
 [CodeSandbox](https://codesandbox.io)
 
 <Playground>
-	<Form onSubmit={(values) => console.log(values)}>
+	<Form 
+		onSubmit={(values) => console.log(values)}
+		initialValues={{rpiIncrease: 2.5}}
+	>
 		{({ handleSubmit }) => (
 			<form onSubmit={handleSubmit}>
 				<FFInputNumber
@@ -82,7 +85,27 @@ import { FFInputNumber } from '@tpr/forms';
 					name="percentage"
 					label="Amount deducted from expenses"
 					hint="amount in %"
-					inputWidth={5}
+					inputWidth={1}
+					cfg={{ my: 5 }}
+					required={false}
+					noLeftBorder={true}
+					optionalText={false}
+					decimalPlaces={2}
+					min={0}
+					max={100}
+					after="%"
+					validate={(value) => {
+						if (value < 0 || value > 100)
+							return 'must be value between 0 and 100%';
+					}}
+					callback={(e) => console.log(e.target.value)}
+					i18n={{ ariaLabelExtension: ' as a percentage' }}
+					initialValue={10}
+				/>
+				<FFInputNumber
+					name="rpiIncrease"
+					label="Increase in RPI"
+					inputWidth={1}
 					cfg={{ my: 5 }}
 					required={false}
 					noLeftBorder={true}

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -103,18 +103,6 @@ const InputNumber: React.FC<InputNumberProps> = ({
 		setInitialDisplayValue(innerInput.current.defaultValue);
 	}, [innerInput.current]);
 
-	useEffect(() => {
-		if (
-			initialValue === undefined ||
-			initialValue === null ||
-			initialValue === ''
-		) {
-			return;
-		}
-
-		setInitialDisplayValue(initialValue);
-	}, [initialValue]);
-
 	const reachedMaxIntDigits = (value: string): boolean => {
 		const newInt: number = parseInt(value);
 		return Math.abs(newInt).toString().length > maxIntDigits ? true : false;

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState } from 'react';
+import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { Field, FieldRenderProps } from 'react-final-form';
 import { StyledInputLabel, InputElementHeading } from '../elements';
 import { FieldExtraProps } from '../../renderFields';
@@ -47,6 +47,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 	maxLength,
 	maxIntDigits,
 	i18n = numberFieldI18nDefaults,
+	initialValue,
 	...props
 }) => {
 	const digits = [
@@ -67,6 +68,52 @@ const InputNumber: React.FC<InputNumberProps> = ({
 	const validKeys = [...vk, ...digits];
 
 	const [prevValue, setPrevValue] = useState<string | null>(null);
+	const innerInput = useRef(null);
+
+	const setInitialDisplayValue = (initialDisplayValue) => {
+		const formattedInitialValue = fixToDecimals(
+			initialDisplayValue.toString(),
+			decimalPlaces,
+		);
+
+		if (innerInput.current.value === formattedInitialValue) {
+			return;
+		}
+
+		innerInput.current.value = formattedInitialValue;
+		// /*
+		// 		When initialValue changes from null to a numeric value there is a situation where the format
+		// 		is not correctly applied because somehow the blur event triggers before the value is formatted.
+		// 		Delaying minimally the execution of the blur event solves this problem.
+		// 	*/
+		setTimeout(() => {
+			innerInput.current.dispatchEvent(new Event('blur', { bubbles: true }));
+		}, 100);
+	};
+
+	useEffect(() => {
+		if (
+			innerInput.current.defaultValue === undefined ||
+			innerInput.current.defaultValue === null ||
+			innerInput.current.defaultValue === ''
+		) {
+			return;
+		}
+
+		setInitialDisplayValue(innerInput.current.defaultValue);
+	}, [innerInput.current]);
+
+	useEffect(() => {
+		if (
+			initialValue === undefined ||
+			initialValue === null ||
+			initialValue === ''
+		) {
+			return;
+		}
+
+		setInitialDisplayValue(initialValue);
+	}, [initialValue]);
 
 	const reachedMaxIntDigits = (value: string): boolean => {
 		const newInt: number = parseInt(value);
@@ -159,6 +206,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 				before={before}
 				ariaLabelExtension={i18n.ariaLabelExtension}
 				accessibilityHelper={helper}
+				parentRef={innerInput}
 				{...props}
 			/>
 		</StyledInputLabel>
@@ -171,7 +219,13 @@ export const FFInputNumber: React.FC<FieldWithAriaLabelExtensionProps> = (
 	return (
 		<Field
 			{...fieldProps}
-			render={(props) => <InputNumber {...props} name={fieldProps.name} />}
+			render={(props) => (
+				<InputNumber
+					{...props}
+					name={fieldProps.name}
+					initialValue={fieldProps.initialValue}
+				/>
+			)}
 		/>
 	);
 };


### PR DESCRIPTION
Address issue [AB#69925](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/69925) where trailing decimal place values are not rendered consistently in cases where integer values are used in numeric fields which allow decimal places.

