### PR TITLE
Bugfix/81839 paragraph margin bottom

### DIFF
--- a/packages/core/src/components/typography/typography.module.scss
+++ b/packages/core/src/components/typography/typography.module.scss
@@ -103,6 +103,7 @@
 	font-size: $font-size-2;
 	letter-spacing: 0px;
 	line-height: $line-height-3;
+	margin-bottom: 1em;
 }
 
 .span {

--- a/packages/forms/src/__tests__/addressLookup.spec.tsx
+++ b/packages/forms/src/__tests__/addressLookup.spec.tsx
@@ -100,7 +100,7 @@ describe('Address lookup', () => {
 		});
 	});
 
-	describe('select address view', () => {		
+	describe('select address view', () => {
 		test('passes accessibility checks', async () => {
 			const { container } = formSetup({
 				render: <AddressLookup {...defaultProps} />,

--- a/packages/forms/src/elements/checkbox/checkbox.module.scss
+++ b/packages/forms/src/elements/checkbox/checkbox.module.scss
@@ -1,4 +1,5 @@
 @import '@tpr/theming/lib/variables.scss';
+@import '@tpr/theming/lib/resets.module.scss';
 
 .wrapper {
 	display: flex;
@@ -36,5 +37,5 @@
 }
 
 .label {
-	margin-bottom: 0;
+	@include removeMarginBottom;
 }

--- a/packages/forms/src/elements/checkbox/checkbox.module.scss
+++ b/packages/forms/src/elements/checkbox/checkbox.module.scss
@@ -32,4 +32,9 @@
 	font-weight: $font-weight-2;
 	margin-top: $space-2;
 	margin-left: 55px;
+	margin-bottom: 0;
+}
+
+.label {
+	margin-bottom: 0;
 }

--- a/packages/forms/src/elements/checkbox/checkbox.tsx
+++ b/packages/forms/src/elements/checkbox/checkbox.tsx
@@ -56,7 +56,9 @@ export const Checkbox: React.FC<Partial<CheckboxIconProps>> = ({
 				) : (
 					<CheckboxBlank className={styles.checkbox} />
 				)}
-				<P cfg={{ ml: 3, fontWeight: 3 }}>{label}</P>
+				<P cfg={{ ml: 3, fontWeight: 3 }} className={styles.label}>
+					{label}
+				</P>
 			</label>
 			{hint && (
 				<P id={helper.hintId} className={styles.hint}>

--- a/packages/forms/src/elements/radio/radio.module.scss
+++ b/packages/forms/src/elements/radio/radio.module.scss
@@ -1,4 +1,5 @@
 @import '@tpr/theming/lib/variables.scss';
+@import '@tpr/theming/lib/resets.module.scss';
 
 .wrapper {
 	display: flex;
@@ -22,7 +23,7 @@
 	font-weight: $font-weight-3;
 	line-height: $line-height-3;
 	padding-left: $space-1;
-	margin-bottom: 0;
+	@include removeMarginBottom;
 	cursor: pointer;
 }
 
@@ -47,7 +48,7 @@
 	font-size: $font-size-2;
 	font-weight: $font-weight-2;
 	margin-top: $space-2;
-	margin-bottom: 0;
+	@include removeMarginBottom;
 	padding-left: 55px;
 	max-width: 100%;
 }

--- a/packages/forms/src/elements/radio/radio.module.scss
+++ b/packages/forms/src/elements/radio/radio.module.scss
@@ -22,6 +22,7 @@
 	font-weight: $font-weight-3;
 	line-height: $line-height-3;
 	padding-left: $space-1;
+	margin-bottom: 0;
 	cursor: pointer;
 }
 
@@ -46,6 +47,7 @@
 	font-size: $font-size-2;
 	font-weight: $font-weight-2;
 	margin-top: $space-2;
+	margin-bottom: 0;
 	padding-left: 55px;
 	max-width: 100%;
 }

--- a/packages/layout/src/components/beta/beta.tsx
+++ b/packages/layout/src/components/beta/beta.tsx
@@ -50,7 +50,7 @@ export const BetaHeader: React.FC<BetaHeaderProps> = ({ text, mail }) => {
 					>
 						BETA
 					</P>
-					<P cfg={{ fontSize: 2, color: 'neutral.8' }}>
+					<P cfg={{ fontSize: 2, color: 'neutral.8', my: 1 }}>
 						<TextComponent />
 					</P>
 				</Flex>

--- a/packages/layout/src/components/buttons/buttons.module.scss
+++ b/packages/layout/src/components/buttons/buttons.module.scss
@@ -7,3 +7,7 @@
 	background: none;
 	cursor: pointer;
 }
+
+.moMarginBottom {
+	margin-bottom: 0;
+}

--- a/packages/layout/src/components/buttons/buttons.module.scss
+++ b/packages/layout/src/components/buttons/buttons.module.scss
@@ -1,3 +1,5 @@
+@import '@tpr/theming/lib/resets.module.scss';
+
 .removepadding {
 	padding-left: 0px !important;
 	padding-right: 0px !important;
@@ -9,5 +11,5 @@
 }
 
 .moMarginBottom {
-	margin-bottom: 0;
+	@include removeMarginBottom;
 }

--- a/packages/layout/src/components/buttons/buttons.tsx
+++ b/packages/layout/src/components/buttons/buttons.tsx
@@ -39,7 +39,9 @@ export const ArrowButton: React.FC<ArrowButtonProps> = ({
 			className={styles.removepadding}
 		>
 			{disabled && disabledText ? (
-				<P cfg={{ px: 4 }}>{disabledText}</P>
+				<P cfg={{ px: 4 }} className={styles.noMarginBottom}>
+					{disabledText}
+				</P>
 			) : (
 				<Flex
 					cfg={{

--- a/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
@@ -8,7 +8,7 @@ import {
 	EmailPreview,
 } from '../../../common/views/preview/components';
 import styles from './preview.module.scss';
-
+import CommonStyles from '../../../cards.module.scss';
 export const Preview: React.FC<any> = () => {
 	const { current, send, onCorrect, i18n } = useActuaryContext();
 	const { actuary, complete, preValidatedData } = current.context;
@@ -22,7 +22,9 @@ export const Preview: React.FC<any> = () => {
 			}
 		>
 			{/* Actuary's Organisation name: display only	 */}
-			<P cfg={{ mb: 4 }}>{actuary.organisationName}</P>
+			<P cfg={{ mb: 4 }} className={CommonStyles.noMarginBottom}>
+				{actuary.organisationName}
+			</P>
 
 			<Flex>
 				{/* Address section: display only	 */}
@@ -31,17 +33,35 @@ export const Preview: React.FC<any> = () => {
 				>
 					<UnderlinedButton>{i18n.preview.buttons.three}</UnderlinedButton>
 					<Flex cfg={{ my: 2, flexDirection: 'column' }}>
-						<P>{actuary.address.addressLine1}</P>
+						<P className={CommonStyles.noMarginBottom}>
+							{actuary.address.addressLine1}
+						</P>
 						{actuary.address.addressLine2 && (
-							<P>{actuary.address.addressLine2}</P>
+							<P className={CommonStyles.noMarginBottom}>
+								{actuary.address.addressLine2}
+							</P>
 						)}
 						{actuary.address.addressLine3 && (
-							<P>{actuary.address.addressLine3}</P>
+							<P className={CommonStyles.noMarginBottom}>
+								{actuary.address.addressLine3}
+							</P>
 						)}
-						<P>{actuary.address.postTown}</P>
-						{actuary.address.county && <P>{actuary.address.county}</P>}
-						<P>{actuary.address.postcode}</P>
-						{actuary.address.country && <P>{actuary.address.country}</P>}
+						<P className={CommonStyles.noMarginBottom}>
+							{actuary.address.postTown}
+						</P>
+						{actuary.address.county && (
+							<P className={CommonStyles.noMarginBottom}>
+								{actuary.address.county}
+							</P>
+						)}
+						<P className={CommonStyles.noMarginBottom}>
+							{actuary.address.postcode}
+						</P>
+						{actuary.address.country && (
+							<P className={CommonStyles.noMarginBottom}>
+								{actuary.address.country}
+							</P>
+						)}
 					</Flex>
 				</Flex>
 

--- a/packages/layout/src/components/cards/cards.module.scss
+++ b/packages/layout/src/components/cards/cards.module.scss
@@ -1,6 +1,6 @@
 @import '@tpr/theming/lib/variables.scss';
 @import '@tpr/core/lib/components/typography/typography.module.scss';
-
+@import '@tpr/theming/lib/resets.module.scss';
 .card {
 	position: relative;
 	display: flex;
@@ -36,5 +36,5 @@
 }
 
 .noMarginBottom {
-	margin-bottom: 0;
+	@include removeMarginBottom;
 }

--- a/packages/layout/src/components/cards/cards.module.scss
+++ b/packages/layout/src/components/cards/cards.module.scss
@@ -34,3 +34,7 @@
 .extraPB {
 	padding-bottom: 16px;
 }
+
+.noMarginBottom {
+	margin-bottom: 0;
+}

--- a/packages/layout/src/components/cards/common/views/preview/components/emailPreview.tsx
+++ b/packages/layout/src/components/cards/common/views/preview/components/emailPreview.tsx
@@ -14,7 +14,9 @@ export const EmailPreview: React.FC<EmailPreviewProps> = React.memo(
 				<Span cfg={{ lineHeight: 3 }} className={styles.styledAsH4}>
 					{label}
 				</Span>
-				<P cfg={{ wordBreak: 'all' }}>{value}</P>
+				<P cfg={{ wordBreak: 'all' }} className={styles.noMarginBottom}>
+					{value}
+				</P>
 			</>
 		);
 	},

--- a/packages/layout/src/components/cards/common/views/preview/components/phonePreview.tsx
+++ b/packages/layout/src/components/cards/common/views/preview/components/phonePreview.tsx
@@ -14,7 +14,9 @@ export const PhonePreview: React.FC<PhonePreviewProps> = React.memo(
 				<Span cfg={{ lineHeight: 3 }} className={styles.styledAsH4}>
 					{label}
 				</Span>
-				<P x-ms-format-detection="none">{value}</P>
+				<P x-ms-format-detection="none" className={styles.noMarginBottom}>
+					{value}
+				</P>
 			</>
 		);
 	},

--- a/packages/layout/src/components/cards/common/views/remove/confirm/confirm.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/confirm/confirm.tsx
@@ -4,6 +4,7 @@ import { Content } from '../../../../components/content';
 import { ArrowButton } from '../../../../../buttons/buttons';
 import { WarningBox } from '../../../../../warning/warning';
 import { cardType, cardTypeName } from '../../../interfaces';
+import styles from '../../../../cards.module.scss';
 
 interface ConfirmProps {
 	cardType: cardType;
@@ -40,7 +41,7 @@ const Confirm: React.FC<ConfirmProps> = ({
 			<Hr cfg={{ my: 4 }} />
 			<WarningBox warningLabel={warningLabel}>
 				<Flex cfg={{ flexDirection: 'column' }}>
-					<P>{removeMessage1}</P>
+					<P className={styles.noMarginBottom}>{removeMessage1}</P>
 					{removeMessage2 && <P cfg={{ mt: 3 }}>{removeMessage2}</P>}
 					<Flex cfg={{ mt: 3 }}>
 						<ArrowButton

--- a/packages/layout/src/components/cards/common/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/date/date.tsx
@@ -6,6 +6,7 @@ import { Footer } from '../../../../components/card';
 import { ArrowButton } from '../../../../../buttons/buttons';
 import { cardType, cardTypeName } from '../../../../common/interfaces';
 import styles from './date.module.scss';
+import CommonStyles from '../../../../cards.module.scss';
 
 interface DateFormProps {
 	title: string;
@@ -45,7 +46,12 @@ const DateForm: React.FC<DateFormProps> = ({
 						/>
 						<div className={styles.dateWrapper}>{renderFields(dateField)}</div>
 						{submitError && (
-							<P cfg={{ color: 'danger.2', mt: 5 }}>{submitError}</P>
+							<P
+								cfg={{ color: 'danger.2', mt: 5 }}
+								className={CommonStyles.noMarginBottom}
+							>
+								{submitError}
+							</P>
 						)}
 						<Footer>
 							<ArrowButton

--- a/packages/layout/src/components/cards/components/button.module.scss
+++ b/packages/layout/src/components/cards/components/button.module.scss
@@ -1,4 +1,5 @@
 @import '@tpr/theming/lib/variables.scss';
+@import '@tpr/theming/lib/resets.module.scss';
 
 .button {
 	text-align: left;
@@ -15,7 +16,7 @@
 
 	p {
 		color: $colors-primary-3;
-		margin-bottom: 0;
+		@include removeMarginBottom;
 	}
 }
 
@@ -43,6 +44,6 @@
 	width: 100%;
 	min-height: $space-5;
 	p {
-		margin-bottom: 0;
+		@include removeMarginBottom;
 	}
 }

--- a/packages/layout/src/components/cards/components/button.module.scss
+++ b/packages/layout/src/components/cards/components/button.module.scss
@@ -15,6 +15,7 @@
 
 	p {
 		color: $colors-primary-3;
+		margin-bottom: 0;
 	}
 }
 
@@ -41,4 +42,7 @@
 	padding: 0 0 4px 2px;
 	width: 100%;
 	min-height: $space-5;
+	p {
+		margin-bottom: 0;
+	}
 }

--- a/packages/layout/src/components/cards/components/card.tsx
+++ b/packages/layout/src/components/cards/components/card.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Flex, H3, P, classNames, Hr } from '@tpr/core';
 import styles from './card.module.scss';
+import CommonStyles from '../cards.module.scss';
 
 type StyledCardProps = { complete: boolean };
 export const StyledCard: React.FC<StyledCardProps> = ({
@@ -40,14 +41,24 @@ export const Toolbar: React.FC<ToolbarProps> = ({
 				className={styles.toolbarBottomBorder}
 			>
 				{sectionTitle && (
-					<P cfg={{ color: 'neutral.6', fontSize: 3 }}>{sectionTitle}</P>
+					<P
+						cfg={{ color: 'neutral.6', fontSize: 3 }}
+						className={CommonStyles.noMarginBottom}
+					>
+						{sectionTitle}
+					</P>
 				)}
 
 				<H3 cfg={{ fontWeight: 3 }}>{title}</H3>
 			</Flex>
 			{subtitle && (
 				<Flex cfg={{ py: 3 }} className={styles.toolbarBottomBorder}>
-					<P cfg={{ color: 'neutral.6' }}>{subtitle}</P>
+					<P
+						cfg={{ color: 'neutral.6' }}
+						className={CommonStyles.noMarginBottom}
+					>
+						{subtitle}
+					</P>
 				</Flex>
 			)}
 		</Flex>
@@ -87,6 +98,7 @@ export const StatusMessage = ({ complete, icon: Icon, text }) => {
 					fontWeight: 3,
 					color: complete ? 'success.1' : 'danger.2',
 				}}
+				className={CommonStyles.noMarginBottom}
 			>
 				{text}
 			</P>

--- a/packages/layout/src/components/cards/components/removedBox.tsx
+++ b/packages/layout/src/components/cards/components/removedBox.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Flex, P } from '@tpr/core';
 import styles from './removedBox.module.scss';
+import CommonStyles from '../cards.module.scss';
 
 interface RemovedBoxProps {
 	type: string;
@@ -25,6 +26,7 @@ const RemovedBox: React.FC<RemovedBoxProps> = ({ type }) => {
 						lineHeight: 3,
 						p: 10,
 					}}
+					className={CommonStyles.noMarginBottom}
 				>
 					{type} removed successfully
 				</P>

--- a/packages/layout/src/components/cards/corporateGroup/corporateGroup.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/corporateGroup.tsx
@@ -95,7 +95,9 @@ export const CorporateGroupCard: React.FC<CorporateGroupProviderProps> = ({
 									<Span cfg={{ lineHeight: 3 }} className={styles.styledAsH4}>
 										{context.corporateGroup.organisationName}
 									</Span>
-									<P>{i18n.preview.trusteeType}</P>
+									<P className={styles.noMarginBottom}>
+										{i18n.preview.trusteeType}
+									</P>
 								</>
 							)}
 							statusText={

--- a/packages/layout/src/components/cards/corporateGroup/views/preview/preview.module.scss
+++ b/packages/layout/src/components/cards/corporateGroup/views/preview/preview.module.scss
@@ -11,3 +11,7 @@
 .complete {
 	border-color: $colors-success-1;
 }
+
+.noMarginBottom {
+	margin-bottom: 0;
+}

--- a/packages/layout/src/components/cards/corporateGroup/views/preview/preview.module.scss
+++ b/packages/layout/src/components/cards/corporateGroup/views/preview/preview.module.scss
@@ -1,4 +1,5 @@
 @import '@tpr/theming/lib/variables.scss';
+@import '@tpr/theming/lib/resets.module.scss';
 
 .content {
 	display: flex;
@@ -13,5 +14,5 @@
 }
 
 .noMarginBottom {
-	margin-bottom: 0;
+	@include removeMarginBottom;
 }

--- a/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
@@ -28,20 +28,34 @@ export const Preview: React.FC<any> = () => {
 				>
 					<UnderlinedButton>{i18n.preview.buttons.three}</UnderlinedButton>
 					<Flex cfg={{ my: 2, flexDirection: 'column' }}>
-						<P>{corporateGroup.address.addressLine1}</P>
+						<P className={styles.noMarginBottom}>
+							{corporateGroup.address.addressLine1}
+						</P>
 						{corporateGroup.address.addressLine2 && (
-							<P>{corporateGroup.address.addressLine2}</P>
+							<P className={styles.noMarginBottom}>
+								{corporateGroup.address.addressLine2}
+							</P>
 						)}
 						{corporateGroup.address.addressLine3 && (
-							<P>{corporateGroup.address.addressLine3}</P>
+							<P className={styles.noMarginBottom}>
+								{corporateGroup.address.addressLine3}
+							</P>
 						)}
-						<P>{corporateGroup.address.postTown}</P>
+						<P className={styles.noMarginBottom}>
+							{corporateGroup.address.postTown}
+						</P>
 						{corporateGroup.address.county && (
-							<P>{corporateGroup.address.county}</P>
+							<P className={styles.noMarginBottom}>
+								{corporateGroup.address.county}
+							</P>
 						)}
-						<P>{corporateGroup.address.postcode}</P>
+						<P className={styles.noMarginBottom}>
+							{corporateGroup.address.postcode}
+						</P>
 						{corporateGroup.address.country && (
-							<P>{corporateGroup.address.country}</P>
+							<P className={styles.noMarginBottom}>
+								{corporateGroup.address.country}
+							</P>
 						)}
 					</Flex>
 
@@ -53,7 +67,7 @@ export const Preview: React.FC<any> = () => {
 						>
 							{i18n.preview.buttons.five}
 						</UnderlinedButton>
-						<P cfg={{ pt: 3 }}>
+						<P cfg={{ pt: 3 }} className={styles.noMarginBottom}>
 							{corporateGroup.directorIsProfessional
 								? i18n.professional.fields.isProfessional.labels
 										.isProfessionalYes
@@ -74,7 +88,7 @@ export const Preview: React.FC<any> = () => {
 						{i18n.preview.buttons.four}
 					</UnderlinedButton>
 					<Flex cfg={{ my: 2, flexDirection: 'column' }}>
-						<P cfg={{ mb: 2 }}>
+						<P cfg={{ mb: 2 }} className={styles.noMarginBottom}>
 							{corporateGroup.title
 								? `${corporateGroup.title} ${corporateGroup.firstName} ${corporateGroup.lastName}`
 								: `${corporateGroup.firstName} ${corporateGroup.lastName}`}

--- a/packages/layout/src/components/cards/employer/employer.tsx
+++ b/packages/layout/src/components/cards/employer/employer.tsx
@@ -95,8 +95,8 @@ const EmployerSubtitle: React.FC<Partial<Employer>> = ({
 
 	return (
 		<>
-			<P>{title}</P>
-			<P>{subtitle}</P>
+			<P className={styles.noMarginBottom}>{title}</P>
+			<P className={styles.noMarginBottom}>{subtitle}</P>
 		</>
 	);
 };

--- a/packages/layout/src/components/cards/employer/views/preview/preview.module.scss
+++ b/packages/layout/src/components/cards/employer/views/preview/preview.module.scss
@@ -1,5 +1,6 @@
 @import '@tpr/theming/lib/variables.scss';
 @import '@tpr/core/lib/components/typography/typography.module.scss';
+@import '@tpr/theming/lib/resets.module.scss';
 
 .content {
 	display: flex;
@@ -14,5 +15,5 @@
 }
 
 .noMarginBottom {
-	margin-bottom: 0;
+	@include removeMarginBottom;
 }

--- a/packages/layout/src/components/cards/employer/views/preview/preview.module.scss
+++ b/packages/layout/src/components/cards/employer/views/preview/preview.module.scss
@@ -12,3 +12,7 @@
 .complete {
 	border-color: $colors-success-1;
 }
+
+.noMarginBottom {
+	margin-bottom: 0;
+}

--- a/packages/layout/src/components/cards/employer/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/employer/views/preview/preview.tsx
@@ -12,7 +12,7 @@ const IdentifiersItem: React.FC<IdentifiersItemProps> = ({ title, number }) => {
 			<Span cfg={{ lineHeight: 3 }} className={styles.styledAsH4}>
 				{title}
 			</Span>
-			<P>{number}</P>
+			<P className={styles.noMarginBottom}>{number}</P>
 		</>
 	);
 };
@@ -54,16 +54,22 @@ export const Preview: React.FC<any> = () => {
 						<Span cfg={{ lineHeight: 3 }} className={styles.styledAsH4}>
 							{employer.organisationName}
 						</Span>
-						<P>{employer.address.addressLine1}</P>
+						<P className={styles.noMarginBottom}>
+							{employer.address.addressLine1}
+						</P>
 						{employer.address.addressLine2 && (
-							<P>{employer.address.addressLine2}</P>
+							<P className={styles.noMarginBottom}>
+								{employer.address.addressLine2}
+							</P>
 						)}
 						{employer.address.addressLine3 && (
-							<P>{employer.address.addressLine3}</P>
+							<P className={styles.noMarginBottom}>
+								{employer.address.addressLine3}
+							</P>
 						)}
-						<P>{employer.address.postTown}</P>
+						<P className={styles.noMarginBottom}>{employer.address.postTown}</P>
 						{employer.address.county && <P>{employer.address.county}</P>}
-						<P>{employer.address.postcode}</P>
+						<P className={styles.noMarginBottom}>{employer.address.postcode}</P>
 					</Flex>
 				</Flex>
 				<Flex

--- a/packages/layout/src/components/cards/inHouse/views/preview/preview.module.scss
+++ b/packages/layout/src/components/cards/inHouse/views/preview/preview.module.scss
@@ -11,3 +11,7 @@
 .complete {
 	border-color: $colors-success-1;
 }
+
+.noMarginBottom {
+	margin-bottom: 0;
+}

--- a/packages/layout/src/components/cards/inHouse/views/preview/preview.module.scss
+++ b/packages/layout/src/components/cards/inHouse/views/preview/preview.module.scss
@@ -1,4 +1,5 @@
 @import '@tpr/theming/lib/variables.scss';
+@import '@tpr/theming/lib/resets.module.scss';
 
 .content {
 	display: flex;
@@ -13,5 +14,5 @@
 }
 
 .noMarginBottom {
-	margin-bottom: 0;
+	@include removeMarginBottom;
 }

--- a/packages/layout/src/components/cards/inHouse/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/preview/preview.tsx
@@ -33,20 +33,34 @@ export const Preview: React.FC<any> = () => {
 						{i18n.preview.buttons.three}
 					</UnderlinedButton>
 					<Flex cfg={{ my: 2, flexDirection: 'column' }}>
-						<P>{inHouseAdmin.address.addressLine1}</P>
+						<P className={styles.noMarginBottom}>
+							{inHouseAdmin.address.addressLine1}
+						</P>
 						{inHouseAdmin.address.addressLine2 && (
-							<P>{inHouseAdmin.address.addressLine2}</P>
+							<P className={styles.noMarginBottom}>
+								{inHouseAdmin.address.addressLine2}
+							</P>
 						)}
 						{inHouseAdmin.address.addressLine3 && (
-							<P>{inHouseAdmin.address.addressLine3}</P>
+							<P className={styles.noMarginBottom}>
+								{inHouseAdmin.address.addressLine3}
+							</P>
 						)}
-						<P>{inHouseAdmin.address.postTown}</P>
+						<P className={styles.noMarginBottom}>
+							{inHouseAdmin.address.postTown}
+						</P>
 						{inHouseAdmin.address.county && (
-							<P>{inHouseAdmin.address.county}</P>
+							<P className={styles.noMarginBottom}>
+								{inHouseAdmin.address.county}
+							</P>
 						)}
-						<P>{inHouseAdmin.address.postcode}</P>
+						<P className={styles.noMarginBottom}>
+							{inHouseAdmin.address.postcode}
+						</P>
 						{inHouseAdmin.address.country && (
-							<P>{inHouseAdmin.address.country}</P>
+							<P className={styles.noMarginBottom}>
+								{inHouseAdmin.address.country}
+							</P>
 						)}
 					</Flex>
 				</Flex>

--- a/packages/layout/src/components/cards/independentTrustee/independentTrustee.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/independentTrustee.tsx
@@ -90,7 +90,9 @@ export const IndependentTrusteeCard: React.FC<IndependentTrusteeProviderProps> =
 									<Span cfg={{ lineHeight: 3 }} className={styles.styledAsH4}>
 										{context.independentTrustee.organisationName}
 									</Span>
-									<P>{i18n.preview.trusteeType}</P>
+									<P className={styles.noMarginBottom}>
+										{i18n.preview.trusteeType}
+									</P>
 								</>
 							)}
 							statusText={

--- a/packages/layout/src/components/cards/independentTrustee/views/preview/preview.module.scss
+++ b/packages/layout/src/components/cards/independentTrustee/views/preview/preview.module.scss
@@ -11,3 +11,7 @@
 .complete {
 	border-color: $colors-success-1;
 }
+
+.noMarginBottom {
+	margin-bottom: 0;
+}

--- a/packages/layout/src/components/cards/independentTrustee/views/preview/preview.module.scss
+++ b/packages/layout/src/components/cards/independentTrustee/views/preview/preview.module.scss
@@ -1,4 +1,5 @@
 @import '@tpr/theming/lib/variables.scss';
+@import '@tpr/theming/lib/resets.module.scss';
 
 .content {
 	display: flex;
@@ -13,5 +14,5 @@
 }
 
 .noMarginBottom {
-	margin-bottom: 0;
+	@include removeMarginBottom;
 }

--- a/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
@@ -24,20 +24,34 @@ export const Preview: React.FC<any> = () => {
 				>
 					<UnderlinedButton>{i18n.preview.buttons.three}</UnderlinedButton>
 					<Flex cfg={{ my: 2, flexDirection: 'column' }}>
-						<P>{independentTrustee.address.addressLine1}</P>
+						<P className={styles.noMarginBottom}>
+							{independentTrustee.address.addressLine1}
+						</P>
 						{independentTrustee.address.addressLine2 && (
-							<P>{independentTrustee.address.addressLine2}</P>
+							<P className={styles.noMarginBottom}>
+								{independentTrustee.address.addressLine2}
+							</P>
 						)}
 						{independentTrustee.address.addressLine3 && (
-							<P>{independentTrustee.address.addressLine3}</P>
+							<P className={styles.noMarginBottom}>
+								{independentTrustee.address.addressLine3}
+							</P>
 						)}
-						<P>{independentTrustee.address.postTown}</P>
+						<P className={styles.noMarginBottom}>
+							{independentTrustee.address.postTown}
+						</P>
 						{independentTrustee.address.county && (
-							<P>{independentTrustee.address.county}</P>
+							<P className={styles.noMarginBottom}>
+								{independentTrustee.address.county}
+							</P>
 						)}
-						<P>{independentTrustee.address.postcode}</P>
+						<P className={styles.noMarginBottom}>
+							{independentTrustee.address.postcode}
+						</P>
 						{independentTrustee.address.country && (
-							<P>{independentTrustee.address.country}</P>
+							<P className={styles.noMarginBottom}>
+								{independentTrustee.address.country}
+							</P>
 						)}
 					</Flex>
 				</Flex>
@@ -50,7 +64,7 @@ export const Preview: React.FC<any> = () => {
 					>
 						{i18n.preview.buttons.four}
 					</UnderlinedButton>
-					<P cfg={{ pt: 3 }}>
+					<P cfg={{ pt: 3 }} className={styles.noMarginBottom}>
 						{independentTrustee.appointedByRegulator
 							? i18n.regulator.fields.appointedByRegulator.labels
 									.isAppointedByRegulatorYes

--- a/packages/layout/src/components/cards/insurer/views/preview/preview.module.scss
+++ b/packages/layout/src/components/cards/insurer/views/preview/preview.module.scss
@@ -1,5 +1,6 @@
 @import '@tpr/theming/lib/variables.scss';
 @import '@tpr/core/lib/components/typography/typography.module.scss';
+@import '@tpr/theming/lib/resets.module.scss';
 
 .content {
 	display: flex;
@@ -14,5 +15,5 @@
 }
 
 .noMarginBottom {
-	margin-bottom: 0;
+	@include removeMarginBottom;
 }

--- a/packages/layout/src/components/cards/insurer/views/preview/preview.module.scss
+++ b/packages/layout/src/components/cards/insurer/views/preview/preview.module.scss
@@ -12,3 +12,7 @@
 .complete {
 	border-color: $colors-success-1;
 }
+
+.noMarginBottom {
+	margin-bottom: 0;
+}

--- a/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
@@ -24,17 +24,27 @@ export const Preview: React.FC<any> = () => {
 				>
 					<UnderlinedButton>{i18n.preview.buttons.three}</UnderlinedButton>
 					<Flex cfg={{ my: 2, flexDirection: 'column' }}>
-						<P>{insurer.address.addressLine1}</P>
+						<P className={styles.noMarginBottom}>
+							{insurer.address.addressLine1}
+						</P>
 						{insurer.address.addressLine2 && (
-							<P>{insurer.address.addressLine2}</P>
+							<P className={styles.noMarginBottom}>
+								{insurer.address.addressLine2}
+							</P>
 						)}
 						{insurer.address.addressLine3 && (
-							<P>{insurer.address.addressLine3}</P>
+							<P className={styles.noMarginBottom}>
+								{insurer.address.addressLine3}
+							</P>
 						)}
-						<P>{insurer.address.postTown}</P>
-						{insurer.address.county && <P>{insurer.address.county}</P>}
-						<P>{insurer.address.postcode}</P>
-						{insurer.address.country && <P>{insurer.address.country}</P>}
+						<P className={styles.noMarginBottom}>{insurer.address.postTown}</P>
+						{insurer.address.county && (
+							<P className={styles.noMarginBottom}>{insurer.address.county}</P>
+						)}
+						<P className={styles.noMarginBottom}>{insurer.address.postcode}</P>
+						{insurer.address.country && (
+							<P className={styles.noMarginBottom}>{insurer.address.country}</P>
+						)}
 					</Flex>
 				</Flex>
 
@@ -49,7 +59,9 @@ export const Preview: React.FC<any> = () => {
 						{i18n.preview.buttons.four}
 					</UnderlinedButton>
 					<Flex cfg={{ mt: 1, flexDirection: 'column' }}>
-						<P>{insurer.insurerCompanyReference}</P>
+						<P className={styles.noMarginBottom}>
+							{insurer.insurerCompanyReference}
+						</P>
 					</Flex>
 				</Flex>
 			</Flex>

--- a/packages/layout/src/components/cards/thirdParty/views/preview/preview.module.scss
+++ b/packages/layout/src/components/cards/thirdParty/views/preview/preview.module.scss
@@ -1,5 +1,6 @@
 @import '@tpr/theming/lib/variables.scss';
 @import '@tpr/core/lib/components/typography/typography.module.scss';
+@import '@tpr/theming/lib/resets.module.scss';
 
 .content {
 	display: flex;
@@ -14,5 +15,5 @@
 }
 
 .noMarginBottom {
-	margin-bottom: 0;
+	@include removeMarginBottom;
 }

--- a/packages/layout/src/components/cards/thirdParty/views/preview/preview.module.scss
+++ b/packages/layout/src/components/cards/thirdParty/views/preview/preview.module.scss
@@ -12,3 +12,7 @@
 .complete {
 	border-color: $colors-success-1;
 }
+
+.noMarginBottom {
+	margin-bottom: 0;
+}

--- a/packages/layout/src/components/cards/thirdParty/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/thirdParty/views/preview/preview.tsx
@@ -23,17 +23,35 @@ export const Preview: React.FC<any> = () => {
 				>
 					<UnderlinedButton>{i18n.preview.buttons.three}</UnderlinedButton>
 					<Flex cfg={{ my: 2, flexDirection: 'column' }}>
-						<P>{thirdParty.address.addressLine1}</P>
+						<P className={styles.noMarginBottom}>
+							{thirdParty.address.addressLine1}
+						</P>
 						{thirdParty.address.addressLine2 && (
-							<P>{thirdParty.address.addressLine2}</P>
+							<P className={styles.noMarginBottom}>
+								{thirdParty.address.addressLine2}
+							</P>
 						)}
 						{thirdParty.address.addressLine3 && (
-							<P>{thirdParty.address.addressLine3}</P>
+							<P className={styles.noMarginBottom}>
+								{thirdParty.address.addressLine3}
+							</P>
 						)}
-						<P>{thirdParty.address.postTown}</P>
-						{thirdParty.address.county && <P>{thirdParty.address.county}</P>}
-						<P>{thirdParty.address.postcode}</P>
-						{thirdParty.address.country && <P>{thirdParty.address.country}</P>}
+						<P className={styles.noMarginBottom}>
+							{thirdParty.address.postTown}
+						</P>
+						{thirdParty.address.county && (
+							<P className={styles.noMarginBottom}>
+								{thirdParty.address.county}
+							</P>
+						)}
+						<P className={styles.noMarginBottom}>
+							{thirdParty.address.postcode}
+						</P>
+						{thirdParty.address.country && (
+							<P className={styles.noMarginBottom}>
+								{thirdParty.address.country}
+							</P>
+						)}
 					</Flex>
 				</Flex>
 				<Flex

--- a/packages/layout/src/components/cards/trustee/views/preview/preview.module.scss
+++ b/packages/layout/src/components/cards/trustee/views/preview/preview.module.scss
@@ -1,5 +1,6 @@
 @import '@tpr/theming/lib/variables.scss';
 @import '@tpr/core/lib/components/typography/typography.module.scss';
+@import '@tpr/theming/lib/resets.module.scss';
 
 .content {
 	display: flex;
@@ -14,5 +15,5 @@
 }
 
 .noMarginBottom {
-	margin-bottom: 0;
+	@include removeMarginBottom;
 }

--- a/packages/layout/src/components/cards/trustee/views/preview/preview.module.scss
+++ b/packages/layout/src/components/cards/trustee/views/preview/preview.module.scss
@@ -12,3 +12,7 @@
 .complete {
 	border-color: $colors-success-1;
 }
+
+.noMarginBottom {
+	margin-bottom: 0;
+}

--- a/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
@@ -22,7 +22,9 @@ export const Preview: React.FC = () => {
 					: classNames([{ [styles.complete]: complete }, styles.content])
 			}
 		>
-			<P cfg={{ mb: 4 }}>{capitalize(trustee.trusteeType)} trustee</P>
+			<P cfg={{ mb: 4 }} className={styles.noMarginBottom}>
+				{capitalize(trustee.trusteeType)} trustee
+			</P>
 			<Flex>
 				{/* Addres section: open for editing	 */}
 				<Flex
@@ -39,14 +41,20 @@ export const Preview: React.FC = () => {
 							{trustee.address.addressLine1}
 						</Span>
 						{trustee.address.addressLine2 && (
-							<P>{trustee.address.addressLine2}</P>
+							<P className={styles.noMarginBottom}>
+								{trustee.address.addressLine2}
+							</P>
 						)}
 						{trustee.address.addressLine3 && (
-							<P>{trustee.address.addressLine3}</P>
+							<P className={styles.noMarginBottom}>
+								{trustee.address.addressLine3}
+							</P>
 						)}
-						<P>{trustee.address.postTown}</P>
-						{trustee.address.county && <P>{trustee.address.county}</P>}
-						<P>{trustee.address.postcode}</P>
+						<P className={styles.noMarginBottom}>{trustee.address.postTown}</P>
+						{trustee.address.county && (
+							<P className={styles.noMarginBottom}>{trustee.address.county}</P>
+						)}
+						<P className={styles.noMarginBottom}>{trustee.address.postcode}</P>
 					</Flex>
 				</Flex>
 

--- a/packages/layout/src/components/footer/footer.tsx
+++ b/packages/layout/src/components/footer/footer.tsx
@@ -48,7 +48,7 @@ export const Footer: React.FC<FooterProps> = ({
 								</Link>
 							))}
 						</Flex>
-						<P cfg={{ fontSize: 1, color: 'neutral.a2' }}>{copyright}</P>
+						<P cfg={{ fontSize: 1, color: 'neutral.a2', my: 1 }}>{copyright}</P>
 					</Flex>
 				</Flex>
 			</AppWidth>

--- a/packages/layout/src/components/header/header.tsx
+++ b/packages/layout/src/components/header/header.tsx
@@ -47,6 +47,7 @@ export const Header: React.FC<HeaderProps> = ({
 								fontSize: 3,
 								fontWeight: 3,
 								lineHeight: 5,
+								my: 1,
 							}}
 						>
 							{title}

--- a/packages/layout/src/components/sidebar/sidebar.module.scss
+++ b/packages/layout/src/components/sidebar/sidebar.module.scss
@@ -1,5 +1,6 @@
 @import '@tpr/theming/lib/variables.scss';
 @import '@tpr/core/lib/components/typography/typography.module.scss';
+@import '@tpr/theming/lib/resets.module.scss';
 
 .sidebar {
 	display: flex;
@@ -96,5 +97,5 @@
 }
 
 .label {
-	margin-bottom: 0;
+	@include removeMarginBottom;
 }

--- a/packages/layout/src/components/sidebar/sidebar.module.scss
+++ b/packages/layout/src/components/sidebar/sidebar.module.scss
@@ -94,3 +94,7 @@
 		}
 	}
 }
+
+.label {
+	margin-bottom: 0;
+}

--- a/packages/layout/src/components/sidebar/sidebar.tsx
+++ b/packages/layout/src/components/sidebar/sidebar.tsx
@@ -126,6 +126,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
 							fontWeight: 3,
 							lineHeight: 6,
 						}}
+						className={styles.label}
 					>
 						Section
 					</P>
@@ -136,6 +137,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
 							fontWeight: 3,
 							lineHeight: 6,
 						}}
+						className={styles.label}
 					>
 						Progress {totalCompleted.length} / {totalSections.length}
 					</P>

--- a/packages/theming/src/resets.module.scss
+++ b/packages/theming/src/resets.module.scss
@@ -22,3 +22,7 @@
 	-webkit-appearance: none;
 	-moz-appearance: none;
 }
+
+@mixin removeMarginBottom {
+	margin-bottom: 0;
+}

--- a/packages/theming/src/richTextEditor.module.scss
+++ b/packages/theming/src/richTextEditor.module.scss
@@ -28,6 +28,7 @@
 		font-size: $font-size-2;
 		letter-spacing: 0px;
 		line-height: $line-height-3;
+		margin-bottom: 1rem;
 	}
 	b {
 		font-weight: $font-weight-3;
@@ -77,6 +78,7 @@
 		font-size: $font-size-2;
 		letter-spacing: 0px;
 		line-height: $line-height-3;
+		margin-bottom: 1rem;
 	}
 	blockquote {
 		background: $colors-neutral-2;


### PR DESCRIPTION
#### Fixes AB#81839

#### Changes proposed in this pull request:
- Add a margin bottom of  `1rem` to all `P`, `UL` and `OL` tags. 

#### Reviewers should focus on:
- margin bottom added correctly
- fix styling issues caused by using `P` in cards, sidebar, form elements, beta

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
