### PR TITLE
Bugfix/73814 sidenav styles

### DIFF
--- a/packages/forms/src/elements/address/addressLookup.tsx
+++ b/packages/forms/src/elements/address/addressLookup.tsx
@@ -144,7 +144,7 @@ export const AddressLookup: React.FC<AddressProps> = ({
 					selectAddressButton={selectAddressButton}
 					selectAddressRequiredMessage={selectAddressRequiredMessage}
 					noAddressesFoundMessage={noAddressesFoundMessage}
-						onValidatePostcode={(isValid) =>
+					onValidatePostcode={(isValid) =>
 						onValidatePostcode ? onValidatePostcode(isValid) : null
 					}
 				/>

--- a/packages/forms/src/elements/address/postcodeLookup.tsx
+++ b/packages/forms/src/elements/address/postcodeLookup.tsx
@@ -44,7 +44,9 @@ export const PostcodeLookup: React.FC<PostcodeLookupProps> = ({
 
 	const validatePostcode = (value) => {
 		const result = validator.validatePostcode(value);
-		(typeof result === 'undefined') ?	setPostcodeValid(true): setPostcodeValid(false);
+		typeof result === 'undefined'
+			? setPostcodeValid(true)
+			: setPostcodeValid(false);
 		return result;
 	};
 

--- a/packages/layout/src/components/buttons/buttons.tsx
+++ b/packages/layout/src/components/buttons/buttons.tsx
@@ -39,9 +39,7 @@ export const ArrowButton: React.FC<ArrowButtonProps> = ({
 			className={styles.removepadding}
 		>
 			{disabled && disabledText ? (
-				<Span cfg={{ px: 4 }}>
-					{disabledText}
-				</Span>
+				<Span cfg={{ px: 4 }}>{disabledText}</Span>
 			) : (
 				<Flex
 					cfg={{

--- a/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
+++ b/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
@@ -15,15 +15,11 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 	const collapsedClass = styles.nestedWrapper + ' ' + styles.collapsed;
 	const [classes, setClasses] = useState(styles.nestedWrapper);
 	const getTopLevelStyles = (link: SidebarLinkProps, isActive: (path: string, exact: boolean) => {}) => {
-		if (isActive(link.path, false)) {
-			return (isActive(link.path, true)) ?  
-				`${styles.topLevel} ${styles.activeLink}` :
-				`${styles.topLevel} ${styles.activeLink} ${styles.withSelectedChild}`;
-		}
-		else {
-			return styles.topLevel;
-		} 
+		return isActive(link.path, false) ? 
+			`${styles.topLevel} ${styles.activeLink} ${styles.withSelectedChild}` :
+			styles.topLevel;
 	}
+
 	useEffect(() => {
 		collapsed && setClasses(collapsedClass);
 		!collapsed && setClasses(styles.nestedWrapper);
@@ -99,7 +95,7 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 									mb: link.links ? 1 : 5,
 									flexDirection: link.links ? 'column' : 'row',
 								}}
-								className={getTopLevelStyles(link, active)}
+								className={active(link.path, false) ? `${styles.topLevelWrapper} ${styles.containsSelectedLink}` :styles.topLevelWrapper}
 							>
 								<Flex
 									cfg={{
@@ -107,7 +103,7 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 										width: 10,
 										mb: link.links ? 5 : 1,
 									}}
-									className={styles.topLevelWrapper}
+									className={active(link.path, true) ? `${styles.topLevelLink} ${styles.activeLink}`: styles.topLevelLink}
 								>
 									<Link
 										cfg={{

--- a/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
+++ b/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
@@ -32,7 +32,8 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 							<li key={key}>
 								<Flex
 									cfg={{ justifyContent: 'space-between', mb: links ? 5 : 1 }}
-									className={active(innerLink.path, true) ? `${styles.nested} ${styles.activeLink}` : styles.nested}
+									className={styles.nested}
+									aria-current={active(innerLink.path, true) ? 'page': null}
 									>
 									<Link
 										cfg={{
@@ -98,7 +99,8 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 										width: 10,
 										mb: link.links ? 5 : 1,
 									}}
-									className={active(link.path, true) ? `${styles.topLevelLink} ${styles.activeLink}`: styles.topLevelLink}
+									className={styles.topLevelLink}
+									aria-current={active(link.path, true) ? 'page': null}
 								>
 									<Link
 										cfg={{

--- a/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
+++ b/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
@@ -19,7 +19,7 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 		collapsed && setClasses(collapsedClass);
 		!collapsed && setClasses(styles.nestedWrapper);
 	}, [collapsed]);
-	
+
 	const generateSubmenu = (links: SidebarLinkProps[]) => {
 		return (
 			<Flex cfg={{ flexDirection: 'column', pl: 6 }} className={classes}>
@@ -33,8 +33,8 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 								<Flex
 									cfg={{ justifyContent: 'space-between', mb: links ? 5 : 1 }}
 									className={styles.nested}
-									aria-current={active(innerLink.path, true) ? 'page': null}
-									>
+									aria-current={active(innerLink.path, true) ? 'page' : null}
+								>
 									<Link
 										cfg={{
 											color: 'primary.2',
@@ -91,7 +91,11 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 									mb: link.links ? 1 : 5,
 									flexDirection: link.links ? 'column' : 'row',
 								}}
-								className={active(link.path, false) ? `${styles.topLevelWrapper} ${styles.containsSelectedLink}` :styles.topLevelWrapper}
+								className={
+									active(link.path, false)
+										? `${styles.topLevelWrapper} ${styles.containsSelectedLink}`
+										: styles.topLevelWrapper
+								}
 							>
 								<Flex
 									cfg={{
@@ -100,7 +104,7 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 										mb: link.links ? 5 : 1,
 									}}
 									className={styles.topLevelLink}
-									aria-current={active(link.path, true) ? 'page': null}
+									aria-current={active(link.path, true) ? 'page' : null}
 								>
 									<Link
 										cfg={{

--- a/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
+++ b/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { H2, Flex, Hr, Link, classNames } from '@tpr/core';
+import { H2, Flex, Hr, Link } from '@tpr/core';
 import { SidebarLinkProps, SidebarMenuProps } from './types';
 import StatusIcon from './StatusIcon';
 import styles from '../sidebar.module.scss';

--- a/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
+++ b/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
@@ -32,7 +32,7 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 							<li key={key}>
 								<Flex
 									cfg={{ justifyContent: 'space-between', mb: links ? 5 : 1 }}
-									className={active(innerLink.path, true) ? `${styles.nested} ${styles.activeLink}` : styles.nested}
+									className={active(innerLink.path) ? `${styles.nested} ${styles.activeLink}` : styles.nested}
 									>
 									<Link
 										cfg={{
@@ -90,7 +90,7 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 									mb: link.links ? 1 : 5,
 									flexDirection: link.links ? 'column' : 'row',
 								}}
-								className={active(link.path, false) ? `${styles.topLevel} ${styles.activeLink}` : styles.topLevel}
+								className={active(link.path) ? `${styles.topLevel} ${styles.activeLink}` : styles.topLevel}
 							>
 								<Flex
 									cfg={{

--- a/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
+++ b/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
@@ -14,11 +14,6 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 }) => {
 	const collapsedClass = styles.nestedWrapper + ' ' + styles.collapsed;
 	const [classes, setClasses] = useState(styles.nestedWrapper);
-	const getTopLevelStyles = (link: SidebarLinkProps, isActive: (path: string, exact: boolean) => {}) => {
-		return isActive(link.path, false) ? 
-			`${styles.topLevel} ${styles.activeLink} ${styles.withSelectedChild}` :
-			styles.topLevel;
-	}
 
 	useEffect(() => {
 		collapsed && setClasses(collapsedClass);

--- a/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
+++ b/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { H2, Flex, Hr, Link } from '@tpr/core';
+import { H2, Flex, Hr, Link, classNames } from '@tpr/core';
 import { SidebarLinkProps, SidebarMenuProps } from './types';
 import StatusIcon from './StatusIcon';
 import styles from '../sidebar.module.scss';
@@ -107,6 +107,7 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 										width: 10,
 										mb: link.links ? 5 : 1,
 									}}
+									className={styles.topLevelWrapper}
 								>
 									<Link
 										cfg={{

--- a/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
+++ b/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
@@ -19,7 +19,7 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 		collapsed && setClasses(collapsedClass);
 		!collapsed && setClasses(styles.nestedWrapper);
 	}, [collapsed]);
-
+	
 	const generateSubmenu = (links: SidebarLinkProps[]) => {
 		return (
 			<Flex cfg={{ flexDirection: 'column', pl: 6 }} className={classes}>
@@ -32,8 +32,8 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 							<li key={key}>
 								<Flex
 									cfg={{ justifyContent: 'space-between', mb: links ? 5 : 1 }}
-									className={styles.nested}
-								>
+									className={active(innerLink.path, true) ? `${styles.nested} ${styles.activeLink}` : styles.nested}
+									>
 									<Link
 										cfg={{
 											color: 'primary.2',
@@ -90,7 +90,7 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 									mb: link.links ? 1 : 5,
 									flexDirection: link.links ? 'column' : 'row',
 								}}
-								className={active(link.path) ? styles.activeLink : undefined}
+								className={active(link.path, false) ? `${styles.topLevel} ${styles.activeLink}` : styles.topLevel}
 							>
 								<Flex
 									cfg={{

--- a/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
+++ b/packages/layout/src/components/sidebar/components/SidebarMenu.tsx
@@ -14,7 +14,16 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 }) => {
 	const collapsedClass = styles.nestedWrapper + ' ' + styles.collapsed;
 	const [classes, setClasses] = useState(styles.nestedWrapper);
-
+	const getTopLevelStyles = (link: SidebarLinkProps, isActive: (path: string, exact: boolean) => {}) => {
+		if (isActive(link.path, false)) {
+			return (isActive(link.path, true)) ?  
+				`${styles.topLevel} ${styles.activeLink}` :
+				`${styles.topLevel} ${styles.activeLink} ${styles.withSelectedChild}`;
+		}
+		else {
+			return styles.topLevel;
+		} 
+	}
 	useEffect(() => {
 		collapsed && setClasses(collapsedClass);
 		!collapsed && setClasses(styles.nestedWrapper);
@@ -32,7 +41,7 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 							<li key={key}>
 								<Flex
 									cfg={{ justifyContent: 'space-between', mb: links ? 5 : 1 }}
-									className={active(innerLink.path) ? `${styles.nested} ${styles.activeLink}` : styles.nested}
+									className={active(innerLink.path, true) ? `${styles.nested} ${styles.activeLink}` : styles.nested}
 									>
 									<Link
 										cfg={{
@@ -90,7 +99,7 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
 									mb: link.links ? 1 : 5,
 									flexDirection: link.links ? 'column' : 'row',
 								}}
-								className={active(link.path) ? `${styles.topLevel} ${styles.activeLink}` : styles.topLevel}
+								className={getTopLevelStyles(link, active)}
 							>
 								<Flex
 									cfg={{

--- a/packages/layout/src/components/sidebar/components/types.ts
+++ b/packages/layout/src/components/sidebar/components/types.ts
@@ -11,7 +11,7 @@ export type SidebarLinkProps = {
 	completed?: boolean;
 	onClick?: (link: Omit<SidebarLinkProps, 'onClick'>) => void;
 	disabled?: boolean;
-	active?: (path: string) => boolean;
+	active?: (path: string, exact: boolean) => boolean;
 	links?: SidebarLinkProps[];
 	hideIcon?: boolean;
 };

--- a/packages/layout/src/components/sidebar/components/types.ts
+++ b/packages/layout/src/components/sidebar/components/types.ts
@@ -11,7 +11,7 @@ export type SidebarLinkProps = {
 	completed?: boolean;
 	onClick?: (link: Omit<SidebarLinkProps, 'onClick'>) => void;
 	disabled?: boolean;
-	active?: (path: string, exact: boolean) => boolean;
+	active?: (path: string) => boolean;
 	links?: SidebarLinkProps[];
 	hideIcon?: boolean;
 };

--- a/packages/layout/src/components/sidebar/sidebar.module.scss
+++ b/packages/layout/src/components/sidebar/sidebar.module.scss
@@ -88,6 +88,8 @@
 }
 
 .nestedWrapper {
+	padding-left: 0!important;
+	
 	&.collapsed {
 		height: 0;
 		overflow: hidden;

--- a/packages/layout/src/components/sidebar/sidebar.module.scss
+++ b/packages/layout/src/components/sidebar/sidebar.module.scss
@@ -35,7 +35,7 @@
 		position: relative;
 
 		a {
-			text-decoration: none;
+			text-decoration: underline;
 
 			&:hover {
 				text-decoration: underline !important;
@@ -66,6 +66,31 @@
 				box-shadow: 0px 0px 0px 1px white;
 			}
 		}
+		&.topLevel.withSelectedChild {
+			a {
+				text-decoration: none;
+			}	
+		}
+	}
+
+	.nestedWrapper {
+		padding-left: 0!important;
+		
+		&.collapsed {
+			height: 0;
+			overflow: hidden;
+		}
+	
+		.nested {
+			&::before {
+				content: '—';
+				color: $colors-neutral-8;
+				padding-right: 2px;
+			}
+			a {
+				text-decoration: none;
+			}
+		}
 	}
 }
 
@@ -86,26 +111,6 @@
 
 .sidebarMenu:last-child {
 	border-bottom: none;
-}
-
-.nestedWrapper {
-	padding-left: 0!important;
-	
-	&.collapsed {
-		height: 0;
-		overflow: hidden;
-	}
-
-	.nested {
-		&::before {
-			content: '—';
-			color: $colors-neutral-8;
-			padding-right: 2px;
-		}
-		a {
-			text-decoration: none !important;
-		}
-	}
 }
 
 .label {

--- a/packages/layout/src/components/sidebar/sidebar.module.scss
+++ b/packages/layout/src/components/sidebar/sidebar.module.scss
@@ -50,7 +50,7 @@
 		}
 	}
 
-	div.activeLink {
+	div[aria-current] {
 		a {
 			text-decoration: underline;
 

--- a/packages/layout/src/components/sidebar/sidebar.module.scss
+++ b/packages/layout/src/components/sidebar/sidebar.module.scss
@@ -52,7 +52,7 @@
 				text-decoration: underline !important;
 			}
 		}
-		&.topLevel > div:not(.nestedWrapper) {
+		&.topLevel > .topLevelWrapper {
 			a::before {
 				content: ' ';
 				position: absolute;

--- a/packages/layout/src/components/sidebar/sidebar.module.scss
+++ b/packages/layout/src/components/sidebar/sidebar.module.scss
@@ -48,7 +48,7 @@
 			&::before {
 				content: ' ';
 				position: absolute;
-				left: -20px;
+				left: -25px;
 				top: -8px;
 				height: 100%;
 				min-height: 40px;
@@ -91,6 +91,9 @@
 			content: '—';
 			color: $colors-neutral-8;
 			padding-right: 2px;
+		}
+		a {
+			text-decoration: none!important;
 		}
 	}
 }

--- a/packages/layout/src/components/sidebar/sidebar.module.scss
+++ b/packages/layout/src/components/sidebar/sidebar.module.scss
@@ -34,7 +34,7 @@
 		position: relative;
 
 		a {
-			text-decoration: underline;
+			text-decoration: none;
 
 			&:hover {
 				text-decoration: underline !important;
@@ -44,8 +44,15 @@
 				color: $colors-neutral-8 !important;
 				text-decoration: none;
 			}
-
-			&::before {
+		}
+		&.nested {
+			a {
+				color: $colors-neutral-8!important;
+				text-decoration: underline !important;
+			}
+		}
+		&.topLevel > div:not(.nestedWrapper) {
+			a::before {
 				content: ' ';
 				position: absolute;
 				left: -25px;
@@ -93,7 +100,7 @@
 			padding-right: 2px;
 		}
 		a {
-			text-decoration: none!important;
+			text-decoration: none !important;
 		}
 	}
 }

--- a/packages/layout/src/components/sidebar/sidebar.module.scss
+++ b/packages/layout/src/components/sidebar/sidebar.module.scss
@@ -31,14 +31,31 @@
 		}
 	}
 
-	div.activeLink {
+	div.topLevelWrapper {
 		position: relative;
 
+		&.containsSelectedLink>.topLevelLink {
+				a::before {
+					content: ' ';
+					position: absolute;
+					left: -25px;
+					top: -8px;
+					height: 100%;
+					min-height: 40px;
+					width: 5px;
+					background: $colors-primary-3;
+					// to hide outline from pseudo element
+					box-shadow: 0px 0px 0px 1px white;
+			}
+		}
+	}
+
+	div.activeLink {
 		a {
 			text-decoration: underline;
 
 			&:hover {
-				text-decoration: underline !important;
+				text-decoration: underline;
 			}
 
 			&:focus {
@@ -49,27 +66,11 @@
 		&.nested {
 			a {
 				color: $colors-neutral-8!important;
-				text-decoration: underline !important;
+
+				&:hover {
+					color: $colors-neutral-a1!important;
+				}
 			}
-		}
-		&.topLevel > .topLevelWrapper {
-			a::before {
-				content: ' ';
-				position: absolute;
-				left: -25px;
-				top: -8px;
-				height: 100%;
-				min-height: 40px;
-				width: 5px;
-				background: $colors-primary-3;
-				// to hide outline from pseudo element
-				box-shadow: 0px 0px 0px 1px white;
-			}
-		}
-		&.topLevel.withSelectedChild {
-			a {
-				text-decoration: none;
-			}	
 		}
 	}
 
@@ -86,9 +87,6 @@
 				content: '—';
 				color: $colors-neutral-8;
 				padding-right: 2px;
-			}
-			a {
-				text-decoration: none;
 			}
 		}
 	}

--- a/packages/layout/src/components/sidebar/sidebar.tsx
+++ b/packages/layout/src/components/sidebar/sidebar.tsx
@@ -111,6 +111,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
 							fontWeight: 3,
 							color: 'primary.2',
 							textAlign: 'left',
+							lineHeight: 6,
 							fontSize: 4,
 						}}
 						onClick={() => history.push(titlePath)}

--- a/packages/layout/src/components/sidebar/sidebar.tsx
+++ b/packages/layout/src/components/sidebar/sidebar.tsx
@@ -6,11 +6,11 @@ import { ReactRouterDomProps, SidebarSectionProps } from './components/types';
 import styles from './sidebar.module.scss';
 
 export const isActive = (settings: { matchPath: any; location: any }) => (
-	path: string
+	path: string,
+	exact: boolean
 ): boolean => {
 	const { matchPath = () => {}, location } = settings;
-	const matched = matchPath(location.pathname, { path });
-	return matched ? true : false;
+	return matchPath(location.pathname, { path, exact });
 };
 
 export const useSectionsUpdater = (

--- a/packages/layout/src/components/sidebar/sidebar.tsx
+++ b/packages/layout/src/components/sidebar/sidebar.tsx
@@ -7,7 +7,7 @@ import styles from './sidebar.module.scss';
 
 export const isActive = (settings: { matchPath: any; location: any }) => (
 	path: string,
-	exact: boolean
+	exact: boolean,
 ): boolean => {
 	const { matchPath = () => {}, location } = settings;
 	return matchPath(location.pathname, { path, exact });

--- a/packages/layout/src/components/sidebar/sidebar.tsx
+++ b/packages/layout/src/components/sidebar/sidebar.tsx
@@ -7,9 +7,10 @@ import styles from './sidebar.module.scss';
 
 export const isActive = (settings: { matchPath: any; location: any }) => (
 	path: string,
+	exact: boolean
 ): boolean => {
 	const { matchPath = () => {}, location } = settings;
-	const matched = matchPath(location.pathname, { path });
+	const matched = matchPath(location.pathname, { path, exact });
 	return matched ? true : false;
 };
 

--- a/packages/layout/src/components/sidebar/sidebar.tsx
+++ b/packages/layout/src/components/sidebar/sidebar.tsx
@@ -6,11 +6,10 @@ import { ReactRouterDomProps, SidebarSectionProps } from './components/types';
 import styles from './sidebar.module.scss';
 
 export const isActive = (settings: { matchPath: any; location: any }) => (
-	path: string,
-	exact: boolean
+	path: string
 ): boolean => {
 	const { matchPath = () => {}, location } = settings;
-	const matched = matchPath(location.pathname, { path, exact });
+	const matched = matchPath(location.pathname, { path });
 	return matched ? true : false;
 };
 


### PR DESCRIPTION
Add classes for active submenu links to enable differentiation between top level and child menu items.
Apply selected styling according to item level in the link tree