### PR TITLE
HelpLink should have the same styles as links AB#89349

### DIFF
--- a/packages/layout/src/components/helplink/helplink.module.scss
+++ b/packages/layout/src/components/helplink/helplink.module.scss
@@ -15,6 +15,18 @@
 	padding-bottom: $space-1;
 }
 
+.helpLink button[aria-expanded]:hover {
+	color: $colors-neutral-a1;
+}
+
+.helpLink button[aria-expanded]:focus {
+	color: $colors-neutral-8;
+	background: $colors-warning-1;
+	outline: none;
+	text-decoration: none;
+	box-shadow: 0px -2px $colors-warning-1, 0px 4px $colors-neutral-8;
+}
+
 .helpLink [aria-expanded] svg {
 	fill: $colors-primary-3;
 	position: relative;


### PR DESCRIPTION
#### Fixes [AB#89349](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/89349)

New appearance only when the button is focused:

![image](https://user-images.githubusercontent.com/1260550/112144090-a6090700-8bd0-11eb-881d-030d80c52687.png)

![image](https://user-images.githubusercontent.com/1260550/112144129-b4efb980-8bd0-11eb-9f46-f77b2d6a4ccf.png)
