### PR TITLE
On cards, titles were slightly misaligned with the text below.

### DIFF
--- a/packages/layout/src/components/cards/components/button.module.scss
+++ b/packages/layout/src/components/cards/components/button.module.scss
@@ -1,18 +1,22 @@
 @import '@tpr/theming/lib/variables.scss';
 @import '@tpr/theming/lib/resets.module.scss';
 
-.button {
+@mixin button-base {
 	text-align: left;
 	background: transparent;
 	box-shadow: none;
 	border: none;
-	cursor: pointer;
-	color: $colors-primary-3;
 	border-bottom: 1px solid;
-	border-bottom-color: $colors-primary-3;
-	padding: 0 0 4px 2px;
+	padding: 0 0 4px 0;
 	width: 100%;
 	min-height: $space-5;
+}
+
+.button {
+	@include button-base;
+	cursor: pointer;
+	color: $colors-primary-3;
+	border-bottom-color: $colors-primary-3;
 
 	p {
 		color: $colors-primary-3;
@@ -32,17 +36,10 @@
 }
 
 .buttonPlaceholder {
-	text-align: left;
-	background: transparent;
-	box-shadow: none;
-	border: none;
+	@include button-base;
 	cursor: default;
 	color: $colors-neutral-7;
-	border-bottom: 1px solid;
 	border-bottom-color: $colors-neutral-7;
-	padding: 0 0 4px 2px;
-	width: 100%;
-	min-height: $space-5;
 
 	p {
 		@include removeMarginBottom;
@@ -50,5 +47,5 @@
 }
 
 :export {
-	arrowColor : $colors-primary-3;
+	arrowColor: $colors-primary-3;
 }


### PR DESCRIPTION
Fixes [AB#62795](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/62795).

Before:
![image](https://user-images.githubusercontent.com/1260550/112172201-69e39f80-8bec-11eb-8ba8-daa550295544.png)

After:
![image](https://user-images.githubusercontent.com/1260550/112172301-81bb2380-8bec-11eb-8302-92557d8c3507.png)
