### PR TITLE
Add checking for secrets

### DIFF
--- a/.githooks/Confirm-AzureDevOpsWorkItem.ps1
+++ b/.githooks/Confirm-AzureDevOpsWorkItem.ps1
@@ -1,0 +1,7 @@
+param(
+    # Path, relative to the root of the repo, to the file containing the commit message
+    [string]$CommitMessageFile
+)
+
+# Check for a work item reference
+If (!((Get-Content $CommitMessageFile) -Match "AB#\d")) { Write-Warning "Commit aborted. Your commit message must include a Azure DevOps work item reference, eg AB#12345"; Exit 1 } else { Exit 0 }

--- a/.githooks/Invoke-CommitMessageHook.ps1
+++ b/.githooks/Invoke-CommitMessageHook.ps1
@@ -1,0 +1,8 @@
+param(
+    # Path, relative to the root of the repo, to the file containing the commit message
+    [string]$CommitMessageFile
+)
+
+# Add custom commands for this repo here
+Invoke-Expression -Command "./.githooks/Confirm-AzureDevOpsWorkItem.ps1 $CommitMessageFile"
+If ($LASTEXITCODE -gt 0) { Exit $LASTEXITCODE }

--- a/Confirm-CommitMessage.ps1
+++ b/Confirm-CommitMessage.ps1
@@ -1,9 +1,0 @@
-$path = Resolve-Path($PSScriptRoot)
-While (!(Test-Path -Path (Join-Path -Path $path -ChildPath ".git") -PathType Container)) {
-    $path = Resolve-Path(Join-Path -Path $path -ChildPath "..")
-    If (($path).Path.Length -eq 3) { Break }
-}
-If (Test-Path "$path\.git" -PathType Container) {
-    If (!((Get-Content "$path/.git/COMMIT_EDITMSG") -Match "AB#\d")) { Write-Warning "Commit aborted. Your commit message must include a Azure DevOps work item reference, eg AB#12345"; Exit 1 } else { Exit 0 }
-} 
-Else { Exit 0 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
 
       - task: Cache@2
         inputs:
-          key: 'yarn | "$(Agent.OS)" | $(Build.SourcesDirectory)/**/yarn.lock'
+          key: 'yarn | "$(Agent.OS)" | $(Build.SourcesDirectory)/react-components/**/yarn.lock'
           restoreKeys: |
             yarn | "$(Agent.OS)"
           path: $(YARN_CACHE_FOLDER)
@@ -35,19 +35,19 @@ jobs:
 
       - task: Yarn@3
         inputs:
-          projectDirectory: '$(Build.SourcesDirectory)'
+          projectDirectory: '$(Build.SourcesDirectory)\react-components'
           arguments: '--frozen-lockfile'
         displayName: yarn install
 
       - task: Yarn@3
         inputs:
-          projectDirectory: '$(Build.SourcesDirectory)'
+          projectDirectory: '$(Build.SourcesDirectory)\react-components'
           arguments: 'build'
         displayName: yarn build
 
       - task: Yarn@3
         inputs:
-          projectDirectory: '$(Build.SourcesDirectory)'
+          projectDirectory: '$(Build.SourcesDirectory)\react-components'
           arguments: test --ci --watchAll=false --reporters=jest-junit --reporters=default --coverage --coverageReporters=cobertura --testMatch "**\*.spec.[t]s?(x)"
         displayName: Run tests
         continueOnError: true # Test failures should be published before failing the build
@@ -56,7 +56,7 @@ jobs:
         displayName: 'Publish unit test results'
         inputs:
           testResultsFiles: junit.xml
-          searchFolder: $(Build.SourcesDirectory)
+          searchFolder: $(Build.SourcesDirectory)\react-components
           mergeTestResults: true
           testRunTitle: 'Jest Unit Tests'
           failTaskOnFailedTests: true
@@ -65,7 +65,7 @@ jobs:
         displayName: 'Publish code coverage from Jest tests'
         inputs:
           codeCoverageTool: Cobertura
-          summaryFileLocation: $(Build.SourcesDirectory)\coverage\cobertura-coverage.xml
+          summaryFileLocation: $(Build.SourcesDirectory)\react-components\coverage\cobertura-coverage.xml
           failIfCoverageEmpty: true
 
       - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/develop') }}:
@@ -74,15 +74,15 @@ jobs:
 
           - task: Yarn@3
             inputs:
-              projectDirectory: '$(Build.SourcesDirectory)'
+              projectDirectory: '$(Build.SourcesDirectory)\react-components'
               arguments: 'postinstall'
             displayName: yarn postinstall
 
-          - script: echo "//registry.npmjs.org/:_authToken=$(NPM-Access-Token)" > $(Build.SourcesDirectory)\.npmrc
+          - script: echo "//registry.npmjs.org/:_authToken=$(NPM-Access-Token)" > $(Build.SourcesDirectory)\react-components\.npmrc
             displayName: Authenticate with NPM registry
 
           - task: Yarn@3
             inputs:
-              projectDirectory: '$(Build.SourcesDirectory)'
+              projectDirectory: '$(Build.SourcesDirectory)\react-components'
               arguments: deploy --canary --yes --preid next --dist-tag next
             displayName: Publish packages to NPM

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,8 @@ jobs:
       - checkout: self
       - checkout: hooks
       - template: git-secrets.steps.yml@hooks
+        parameters:
+          repoPath: $(Build.SourcesDirectory)\react-components
 
       - task: Cache@2
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,13 @@
 pool:
   vmImage: 'windows-2019'
 
+resources:
+  repositories:
+    - repository: hooks
+      type: git
+      name: TPR/Tools-TPRGitHooks
+      ref: develop
+
 variables:
   - name: YARN_CACHE_FOLDER
     value: $(Pipeline.Workspace)/.yarn
@@ -10,6 +17,10 @@ jobs:
   - job: Build_and_test
     displayName: Build and test
     steps:
+      - checkout: self
+      - checkout: hooks
+      - template: git-secrets.steps.yml@hooks
+
       - task: Cache@2
         inputs:
           key: 'yarn | "$(Agent.OS)" | $(Build.SourcesDirectory)/**/yarn.lock'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,5 @@
+trigger: none
+
 pool:
   vmImage: 'windows-2019'
 

--- a/package.json
+++ b/package.json
@@ -104,8 +104,8 @@
 	},
 	"husky": {
 		"hooks": {
-			"commit-msg": "pwsh ./Confirm-CommitMessage.ps1",
-			"pre-commit": "yarn format"
+			"commit-msg": "git secrets --commit_msg_hook -- .git/COMMIT_EDITMSG && pwsh -NoProfile ./.githooks/Invoke-CommitMessageHook.ps1 .git/COMMIT_EDITMSG",
+			"pre-commit": "git secrets --pre_commit_hook && yarn format"
 		}
 	}
 }


### PR DESCRIPTION
#### [AB#82883](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/82883)

- Updates git hook script for checking work item reference to one now installed as standard (and here customised for Github)
- Adds checking for secrets using git secrets at the pre-commit and pull request validation stages

The Azure DevOps status check for this PR will fail until PR 6091 is approved on Azure DevOps.