### PR TITLE
Feature/88254 trustee card redesign

### DIFF
--- a/packages/layout/src/components/__tests__/inHouse.spec.tsx
+++ b/packages/layout/src/components/__tests__/inHouse.spec.tsx
@@ -82,7 +82,6 @@ describe('InHouse Preview', () => {
 	test('editing in house name', () => {
 		findByText('In House Administrator').click();
 		expect(findByTestId('inHouseAdmin-name-form')).not.toBe(null);
-
 		var titleHtmlElement = findByText('Title (optional)') as HTMLElement;
 		var firstNameHtmlElement = findByText('First name') as HTMLElement;
 		var lastNameHtmlElement = findByText('Last name') as HTMLElement;
@@ -272,7 +271,7 @@ describe('InHouse Remove', () => {
 
 describe('In house admin correspondence address', () => {
 	test('Change address is accessible', async () => {
-		const { container, getByText } = render(
+		const { container, getByText, getAllByText } = render(
 			<InHouseCard
 				onSaveContacts={noop}
 				onSaveAddress={noop}
@@ -295,11 +294,14 @@ describe('In house admin correspondence address', () => {
 
 		expect(results).toHaveNoViolations();
 		expect(getByText('Find address')).toBeInTheDocument();
-		expect(getByText('Cancel')).toBeInTheDocument();
+		const cancelButtons = getAllByText(/Cancel/);
+;
+		expect(cancelButtons[0]).toBeInTheDocument();
+		expect(cancelButtons[1]).toBeInTheDocument();
 	});
 
 	test('Cancel change address returns to preview', async () => {
-		const { container, getByText } = render(
+		const { container, getByText, getAllByText } = render(
 			<InHouseCard
 				onSaveContacts={noop}
 				onSaveAddress={noop}
@@ -317,7 +319,9 @@ describe('In house admin correspondence address', () => {
 
 		getByText('Address').click();
 		getByText(/I need to change the address/).click();
-		getByText(/Cancel/).click();
+		const cancelButtons = 	getAllByText(/Cancel/);
+		cancelButtons[0].click();
+		cancelButtons[1].click();
 
 		const results = await axe(container);
 

--- a/packages/layout/src/components/__tests__/trustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/trustee.spec.tsx
@@ -230,18 +230,23 @@ describe('Trustee correspondence address', () => {
 		findByText(/I need to change the address/).click();
 
 		const results = await axe(component);
-
 		expect(results).toHaveNoViolations();
 		expect(findByText('Find address')).toBeInTheDocument();
-		expect(findByText('Cancel')).toBeInTheDocument();
+		;
+		const cancelButtons = 	findAllByText(/Cancel/);
+
+		expect(cancelButtons[0]).toBeInTheDocument();
+		expect(cancelButtons[1]).toBeInTheDocument();
 	});
 
 	test('Cancel change address returns to preview', async () => {
 		findByText('Correspondence address').click();
 		findByText(/I need to change the address/).click();
-		findByText(/Cancel/).click();
+		const cancelButtons = 	findAllByText(/Cancel/);
+		cancelButtons[0].click();
+		cancelButtons[1].click();
 
-		const results = await axe(component);
+	const results = await axe(component);
 
 		expect(results).toHaveNoViolations();
 		expect(findByText('Correspondence address')).toBeInTheDocument();

--- a/packages/layout/src/components/cards/actuary/actuary.tsx
+++ b/packages/layout/src/components/cards/actuary/actuary.tsx
@@ -61,6 +61,7 @@ const ActuaryButton: React.FC = () => {
 					send('EDIT_NAME');
 				}
 			}}
+			isEditButton={true}
 		>
 			{i18n.preview.buttons.one}
 		</UnderlinedButton>

--- a/packages/layout/src/components/cards/actuary/views/contacts/index.tsx
+++ b/packages/layout/src/components/cards/actuary/views/contacts/index.tsx
@@ -74,7 +74,8 @@ export const Contacts: React.FC = () => {
 				emailAddress: actuary.emailAddress,
 			}}
 			fields={fields}
-			send = {send}
+			send={send}
+			subSectionHeaderText={i18n.preview.buttons.four}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/actuary/views/contacts/index.tsx
+++ b/packages/layout/src/components/cards/actuary/views/contacts/index.tsx
@@ -74,6 +74,7 @@ export const Contacts: React.FC = () => {
 				emailAddress: actuary.emailAddress,
 			}}
 			fields={fields}
+			send = {send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/actuary/views/name/index.tsx
+++ b/packages/layout/src/components/cards/actuary/views/name/index.tsx
@@ -85,6 +85,7 @@ export const NameScreen: React.FC = () => {
 			fields={fields}
 			initialValues={originalValues}
 			loading={loading}
+			send = {send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/actuary/views/name/index.tsx
+++ b/packages/layout/src/components/cards/actuary/views/name/index.tsx
@@ -85,7 +85,7 @@ export const NameScreen: React.FC = () => {
 			fields={fields}
 			initialValues={originalValues}
 			loading={loading}
-			send = {send}
+			send={send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
@@ -47,6 +47,7 @@ export const Preview: React.FC<any> = () => {
 					<UnderlinedButton
 						onClick={() => send('EDIT_CONTACTS')}
 						isOpen={current.matches({ edit: 'contacts' })}
+						isEditButton={true}
 					>
 						{i18n.preview.buttons.four}
 					</UnderlinedButton>

--- a/packages/layout/src/components/cards/actuary/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/actuary/views/remove/date/date.tsx
@@ -54,6 +54,7 @@ export const RemoveDateForm = () => {
 			dateField={DateField}
 			type={cardType.actuary}
 			typeName={cardTypeName.actuary}
+			send={send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/common/views/address/addressPage.tsx
+++ b/packages/layout/src/components/cards/common/views/address/addressPage.tsx
@@ -11,7 +11,8 @@ import {
 	Address,
 	I18nAddressLookup,
 } from '@tpr/forms';
-
+import { Link } from '@tpr/core/lib/components/links/links';
+import { useTrusteeContext } from '../../../trustee/context';
 export type AddressPageProps = {
 	onSubmit: (values: Address & { initialValue?: Address }) => void;
 	initialValue?: Address;
@@ -34,7 +35,7 @@ const AddressPage: React.FC<AddressPageProps> = ({
 	onCancelChanges,
 }) => {
 	const [loading, setLoading] = useState(false);
-
+	const {send } = useTrusteeContext();
 	const addressLookupProvider = new ExperianAddressLookupProvider(addressAPI);
 
 	return (
@@ -89,6 +90,7 @@ const AddressPage: React.FC<AddressPageProps> = ({
 										title={i18n.saveAndClose}
 										disabled={loading}
 									/>
+									<Link cfg={{ m: 3 }} underline onClick={() => send('CANCEL')}>Cancel</Link>
 								</Footer>
 							</>
 						}

--- a/packages/layout/src/components/cards/common/views/address/addressPage.tsx
+++ b/packages/layout/src/components/cards/common/views/address/addressPage.tsx
@@ -21,7 +21,8 @@ export type AddressPageProps = {
 	sectionTitle?: string;
 	i18n: I18nAddressLookup;
 	onCancelChanges?: () => void;
-	send?:Function;
+	send?: Function;
+	subSectionHeaderText?: string;
 };
 
 const AddressPage: React.FC<AddressPageProps> = ({
@@ -33,6 +34,7 @@ const AddressPage: React.FC<AddressPageProps> = ({
 	sectionTitle,
 	i18n,
 	onCancelChanges,
+	subSectionHeaderText,
 }) => {
 	const [loading, setLoading] = useState(false);
 	const addressLookupProvider = new ExperianAddressLookupProvider(addressAPI);
@@ -43,6 +45,8 @@ const AddressPage: React.FC<AddressPageProps> = ({
 			typeName={cardTypeName}
 			title={i18n.title}
 			sectionTitle={sectionTitle}
+			subSectionHeaderText={subSectionHeaderText}
+			send={onCancelChanges}
 		>
 			<Form onSubmit={onSubmit}>
 				{({ handleSubmit }) => (
@@ -89,7 +93,13 @@ const AddressPage: React.FC<AddressPageProps> = ({
 										title={i18n.saveAndClose}
 										disabled={loading}
 									/>
-									<Link cfg={{ m: 3 }} underline onClick={() => onCancelChanges()}>Cancel</Link>
+									<Link
+										cfg={{ m: 3 }}
+										underline
+										onClick={() => onCancelChanges()}
+									>
+										Cancel
+									</Link>
 								</Footer>
 							</>
 						}

--- a/packages/layout/src/components/cards/common/views/address/addressPage.tsx
+++ b/packages/layout/src/components/cards/common/views/address/addressPage.tsx
@@ -12,7 +12,6 @@ import {
 	I18nAddressLookup,
 } from '@tpr/forms';
 import { Link } from '@tpr/core/lib/components/links/links';
-import { useTrusteeContext } from '../../../trustee/context';
 export type AddressPageProps = {
 	onSubmit: (values: Address & { initialValue?: Address }) => void;
 	initialValue?: Address;
@@ -22,6 +21,7 @@ export type AddressPageProps = {
 	sectionTitle?: string;
 	i18n: I18nAddressLookup;
 	onCancelChanges?: () => void;
+	send?:Function;
 };
 
 const AddressPage: React.FC<AddressPageProps> = ({
@@ -35,7 +35,6 @@ const AddressPage: React.FC<AddressPageProps> = ({
 	onCancelChanges,
 }) => {
 	const [loading, setLoading] = useState(false);
-	const {send } = useTrusteeContext();
 	const addressLookupProvider = new ExperianAddressLookupProvider(addressAPI);
 
 	return (
@@ -90,7 +89,7 @@ const AddressPage: React.FC<AddressPageProps> = ({
 										title={i18n.saveAndClose}
 										disabled={loading}
 									/>
-									<Link cfg={{ m: 3 }} underline onClick={() => send('CANCEL')}>Cancel</Link>
+									<Link cfg={{ m: 3 }} underline onClick={() => onCancelChanges()}>Cancel</Link>
 								</Footer>
 							</>
 						}

--- a/packages/layout/src/components/cards/common/views/contactDetails/contactDetails.tsx
+++ b/packages/layout/src/components/cards/common/views/contactDetails/contactDetails.tsx
@@ -5,7 +5,6 @@ import { Content } from '../../../components/content';
 import { ArrowButton } from '../../../../buttons/buttons';
 import { cardType, cardTypeName } from '../../../common/interfaces';
 import { Link } from '@tpr/core';
-import { useTrusteeContext } from '../../../trustee/context';
 
 interface ContactDetailsProps {
 	type: cardType;
@@ -20,6 +19,7 @@ interface ContactDetailsProps {
 		emailAddress: string;
 	};
 	fields: FieldProps[];
+	send?: Function;
 }
 
 const ContactDetails: React.FC<ContactDetailsProps> = ({
@@ -32,8 +32,8 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({
 	onSubmit,
 	initialValues,
 	fields,
+	send,
 }) => {
-	const {send } = useTrusteeContext();
 	return (
 		<Content
 			type={type}

--- a/packages/layout/src/components/cards/common/views/contactDetails/contactDetails.tsx
+++ b/packages/layout/src/components/cards/common/views/contactDetails/contactDetails.tsx
@@ -4,6 +4,8 @@ import { Footer } from '../../../components/card';
 import { Content } from '../../../components/content';
 import { ArrowButton } from '../../../../buttons/buttons';
 import { cardType, cardTypeName } from '../../../common/interfaces';
+import { Link } from '@tpr/core';
+import { useTrusteeContext } from '../../../trustee/context';
 
 interface ContactDetailsProps {
 	type: cardType;
@@ -31,6 +33,7 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({
 	initialValues,
 	fields,
 }) => {
+	const {send } = useTrusteeContext();
 	return (
 		<Content
 			type={type}
@@ -60,6 +63,7 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({
 								title="Save and close"
 								disabled={loading}
 							/>
+								<Link cfg={{ m: 3 }} underline onClick={() => send('CANCEL')}>Cancel</Link>
 						</Footer>
 					</form>
 				)}

--- a/packages/layout/src/components/cards/common/views/contactDetails/contactDetails.tsx
+++ b/packages/layout/src/components/cards/common/views/contactDetails/contactDetails.tsx
@@ -67,7 +67,9 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({
 								title="Save and close"
 								disabled={loading}
 							/>
-								<Link cfg={{ m: 3 }} underline onClick={() => send('CANCEL')}>Cancel</Link>
+							<Link cfg={{ m: 3 }} underline onClick={() => send('CANCEL')}>
+								Cancel
+							</Link>
 						</Footer>
 					</form>
 				)}

--- a/packages/layout/src/components/cards/common/views/contactDetails/contactDetails.tsx
+++ b/packages/layout/src/components/cards/common/views/contactDetails/contactDetails.tsx
@@ -20,6 +20,7 @@ interface ContactDetailsProps {
 	};
 	fields: FieldProps[];
 	send?: Function;
+	subSectionHeaderText?: string;
 }
 
 const ContactDetails: React.FC<ContactDetailsProps> = ({
@@ -33,6 +34,7 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({
 	initialValues,
 	fields,
 	send,
+	subSectionHeaderText,
 }) => {
 	return (
 		<Content
@@ -42,6 +44,8 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({
 			subtitle={subtitle}
 			loading={loading}
 			sectionTitle={sectionTitle}
+			subSectionHeaderText={subSectionHeaderText}
+			send={send}
 		>
 			<Form
 				onSubmit={onSubmit}

--- a/packages/layout/src/components/cards/common/views/nameForm/nameForm.tsx
+++ b/packages/layout/src/components/cards/common/views/nameForm/nameForm.tsx
@@ -5,7 +5,6 @@ import { Content } from '../../../components/content';
 import { ArrowButton } from '../../../../buttons/buttons';
 import { cardType, cardTypeName } from '../../interfaces';
 import { Link } from '@tpr/core';
-import { useTrusteeContext } from '../../../trustee/context';
 
 interface NameFormProps {
 	type: cardType;
@@ -21,6 +20,7 @@ interface NameFormProps {
 	};
 	loading: boolean;
 	nextStep?: boolean;
+	send?: Function;
 }
 
 const NameForm: React.FC<NameFormProps> = ({
@@ -33,8 +33,8 @@ const NameForm: React.FC<NameFormProps> = ({
 	initialValues,
 	loading,
 	nextStep,
+	send,
 }) => {
-	const {send } = useTrusteeContext();
 	return (
 		<Content
 			type={type}

--- a/packages/layout/src/components/cards/common/views/nameForm/nameForm.tsx
+++ b/packages/layout/src/components/cards/common/views/nameForm/nameForm.tsx
@@ -21,6 +21,7 @@ interface NameFormProps {
 	loading: boolean;
 	nextStep?: boolean;
 	send?: Function;
+	subSectionHeaderText?: string;
 }
 
 const NameForm: React.FC<NameFormProps> = ({
@@ -34,6 +35,7 @@ const NameForm: React.FC<NameFormProps> = ({
 	loading,
 	nextStep,
 	send,
+	subSectionHeaderText,
 }) => {
 	return (
 		<Content
@@ -42,6 +44,8 @@ const NameForm: React.FC<NameFormProps> = ({
 			title={title}
 			loading={loading}
 			sectionTitle={sectionTitle}
+			subSectionHeaderText={subSectionHeaderText}
+			send={send}
 		>
 			<Form
 				onSubmit={onSubmit}
@@ -64,7 +68,9 @@ const NameForm: React.FC<NameFormProps> = ({
 								type="submit"
 								title={nextStep ? 'Continue' : 'Save and close'}
 							/>
-								<Link cfg={{ m: 3 }} underline onClick={() => send('CANCEL')}>Cancel</Link>
+							<Link cfg={{ m: 3 }} underline onClick={() => send('CANCEL')}>
+								Cancel
+							</Link>
 						</Footer>
 					</form>
 				)}

--- a/packages/layout/src/components/cards/common/views/nameForm/nameForm.tsx
+++ b/packages/layout/src/components/cards/common/views/nameForm/nameForm.tsx
@@ -4,6 +4,8 @@ import { Footer } from '../../../components/card';
 import { Content } from '../../../components/content';
 import { ArrowButton } from '../../../../buttons/buttons';
 import { cardType, cardTypeName } from '../../interfaces';
+import { Link } from '@tpr/core';
+import { useTrusteeContext } from '../../../trustee/context';
 
 interface NameFormProps {
 	type: cardType;
@@ -32,6 +34,7 @@ const NameForm: React.FC<NameFormProps> = ({
 	loading,
 	nextStep,
 }) => {
+	const {send } = useTrusteeContext();
 	return (
 		<Content
 			type={type}
@@ -61,6 +64,7 @@ const NameForm: React.FC<NameFormProps> = ({
 								type="submit"
 								title={nextStep ? 'Continue' : 'Save and close'}
 							/>
+								<Link cfg={{ m: 3 }} underline onClick={() => send('CANCEL')}>Cancel</Link>
 						</Footer>
 					</form>
 				)}

--- a/packages/layout/src/components/cards/common/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/date/date.tsx
@@ -66,7 +66,9 @@ const DateForm: React.FC<DateFormProps> = ({
 								title="Continue"
 								type="submit"
 							/>
-							<Link cfg={{ m: 3 }} underline onClick={() =>send('CANCEL')}>Cancel</Link>
+							<Link cfg={{ m: 3 }} underline onClick={() => send('CANCEL')}>
+								Cancel
+							</Link>
 						</Footer>
 					</form>
 				)}

--- a/packages/layout/src/components/cards/common/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/date/date.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { P } from '@tpr/core';
+import { Link, P } from '@tpr/core';
 import { Form, FFCheckbox, renderFields, FieldProps } from '@tpr/forms';
 import { Content } from '../../../../components/content';
 import { Footer } from '../../../../components/card';
@@ -15,6 +15,7 @@ interface DateFormProps {
 	dateField: FieldProps[];
 	type: cardType;
 	typeName: cardTypeName;
+	send?: Function;
 }
 
 const DateForm: React.FC<DateFormProps> = ({
@@ -25,6 +26,7 @@ const DateForm: React.FC<DateFormProps> = ({
 	dateField,
 	type,
 	typeName,
+	send,
 }) => {
 	const errorMsg: string = `${type}-error-msg`;
 	const testId: string = `remove-${type}-form`;
@@ -64,6 +66,7 @@ const DateForm: React.FC<DateFormProps> = ({
 								title="Continue"
 								type="submit"
 							/>
+							<Link cfg={{ m: 3 }} underline onClick={() =>send('CANCEL')}>Cancel</Link>
 						</Footer>
 					</form>
 				)}

--- a/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
@@ -88,7 +88,9 @@ export const Reason: React.FC<ReasonProps> = ({
 									type="submit"
 									title="Continue"
 								/>
-									<Link cfg={{ m: 3 }} underline onClick={() => send('CANCEL')}>Cancel</Link>
+								<Link cfg={{ m: 3 }} underline onClick={() => send('CANCEL')}>
+									Cancel
+								</Link>
 							</Footer>
 						</form>
 					);

--- a/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
@@ -10,7 +10,6 @@ import {
 	RemoveReasonProps,
 } from '../../../../common/interfaces';
 import styles from './reason.module.scss';
-import { useTrusteeContext } from '../../../../trustee/context';
 
 interface ReasonProps {
 	type: cardType;
@@ -18,6 +17,7 @@ interface ReasonProps {
 	onSubmit: (any) => void;
 	remove: RemoveReasonProps;
 	dateField: FieldProps[];
+	send?: Function;
 }
 
 export const Reason: React.FC<ReasonProps> = ({
@@ -26,8 +26,8 @@ export const Reason: React.FC<ReasonProps> = ({
 	onSubmit,
 	remove,
 	dateField,
+	send,
 }) => {
-	const {send } = useTrusteeContext();
 	return (
 		<Content type={type} title={i18nRemoveReason.title}>
 			<Form

--- a/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { P, H4 } from '@tpr/core';
+import { P, H4, Link } from '@tpr/core';
 import { Footer } from '../../../../components/card';
 import { Form, FFRadioButton, FieldProps, renderFields } from '@tpr/forms';
 import { Content } from '../../../../components/content';
@@ -10,6 +10,7 @@ import {
 	RemoveReasonProps,
 } from '../../../../common/interfaces';
 import styles from './reason.module.scss';
+import { useTrusteeContext } from '../../../../trustee/context';
 
 interface ReasonProps {
 	type: cardType;
@@ -26,6 +27,7 @@ export const Reason: React.FC<ReasonProps> = ({
 	remove,
 	dateField,
 }) => {
+	const {send } = useTrusteeContext();
 	return (
 		<Content type={type} title={i18nRemoveReason.title}>
 			<Form
@@ -86,6 +88,7 @@ export const Reason: React.FC<ReasonProps> = ({
 									type="submit"
 									title="Continue"
 								/>
+									<Link cfg={{ m: 3 }} underline onClick={() => send('CANCEL')}>Cancel</Link>
 							</Footer>
 						</form>
 					);

--- a/packages/layout/src/components/cards/components/arrowButton.tsx
+++ b/packages/layout/src/components/cards/components/arrowButton.tsx
@@ -6,11 +6,11 @@ import styles from './button.module.scss';
 export const EditArrowUp: React.FC<SVGProps> = (props) => {
 	return (
 		<Flex>
-		 <P className={styles.arrowButtonEdit}> Edit</P>
-		<SVG testId="arrow-up" {...props}>
-			<path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z" />
-			<path d="M0 0h24v24H0z" fill="none" />
-		</SVG>
+			<P className={styles.arrowButtonEdit}> Edit</P>
+			<SVG testId="arrow-up" {...props}>
+				<path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z" />
+				<path d="M0 0h24v24H0z" fill="none" />
+			</SVG>
 		</Flex>
 	);
 };
@@ -18,11 +18,11 @@ export const EditArrowUp: React.FC<SVGProps> = (props) => {
 export const EditArrowDown: React.FC<SVGProps> = (props) => {
 	return (
 		<Flex>
-		<P className={styles.arrowButtonEdit}>Edit</P>
-		<SVG testId="arrow-down" {...props}>
-			<path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
-			<path d="M0 0h24v24H0V0z" fill="none" />
-		</SVG>
+			<P className={styles.arrowButtonEdit}>Edit</P>
+			<SVG testId="arrow-down" {...props}>
+				<path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
+				<path d="M0 0h24v24H0V0z" fill="none" />
+			</SVG>
 		</Flex>
 	);
 };

--- a/packages/layout/src/components/cards/components/arrowButton.tsx
+++ b/packages/layout/src/components/cards/components/arrowButton.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { SVGProps, SVG } from '@tpr/icons';
+import { Flex, P } from '@tpr/core';
+import styles from './button.module.scss';
+
+export const EditArrowUp: React.FC<SVGProps> = (props) => {
+	return (
+		<Flex>
+		 <P className={styles.arrowButtonEdit}> Edit</P>
+		<SVG testId="arrow-up" {...props}>
+			<path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z" />
+			<path d="M0 0h24v24H0z" fill="none" />
+		</SVG>
+		</Flex>
+	);
+};
+
+export const EditArrowDown: React.FC<SVGProps> = (props) => {
+	return (
+		<Flex>
+		<P className={styles.arrowButtonEdit}>Edit</P>
+		<SVG testId="arrow-down" {...props}>
+			<path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
+			<path d="M0 0h24v24H0V0z" fill="none" />
+		</SVG>
+		</Flex>
+	);
+};

--- a/packages/layout/src/components/cards/components/button.module.scss
+++ b/packages/layout/src/components/cards/components/button.module.scss
@@ -46,6 +46,10 @@
 	}
 }
 
+.arrowSpacing{
+	justify-content: space-between;
+}
+
 :export {
 	arrowColor: $colors-primary-3;
 }

--- a/packages/layout/src/components/cards/components/button.module.scss
+++ b/packages/layout/src/components/cards/components/button.module.scss
@@ -50,6 +50,10 @@
 	justify-content: space-between;
 }
 
+.arrowButtonEdit{
+	font-size: 16px;
+}
+
 :export {
 	arrowColor: $colors-primary-3;
 }

--- a/packages/layout/src/components/cards/components/button.tsx
+++ b/packages/layout/src/components/cards/components/button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Flex, P } from '@tpr/core';
 import { ArrowUp, ArrowDown } from '@tpr/icons';
 import styles from './button.module.scss';
@@ -14,6 +14,7 @@ export const UnderlinedButton: React.FC<UnderlinedButtonProps> = ({
 	onClick,
 	tabIndex,
 }) => {
+
 	if (typeof onClick === 'undefined') {
 		return (
 			<div className={styles.buttonPlaceholder}>
@@ -23,13 +24,17 @@ export const UnderlinedButton: React.FC<UnderlinedButtonProps> = ({
 			</div>
 		);
 	}
-
+const buttonRef = useRef(null);
+useEffect(()=>{
+	buttonRef.current.focus();
+})
 	return (
 		<button
 			className={styles.button}
 			onClick={onClick}
 			aria-expanded={isOpen}
 			tabIndex={tabIndex}
+			ref={buttonRef}
 		>
 			<Flex className={styles.arrowSpacing}  cfg={{ flex: '0 0 auto', alignItems: 'center' }}>
 				<P cfg={{ fontSize: 2, fontWeight: 3 }}>{children}</P>

--- a/packages/layout/src/components/cards/components/button.tsx
+++ b/packages/layout/src/components/cards/components/button.tsx
@@ -63,12 +63,6 @@ useEffect(()=>{
 		>
 			<Flex className={styles.arrowSpacing}  cfg={{ flex: '0 0 auto', alignItems: 'center' }}>
 				<P cfg={{ fontSize: 2, fontWeight: 3 }}>{children}</P>
-				{/* {isOpen ? (
-
-					<EditArrowUp width="24px" fill={styles.arrowColor} />
-				) : (
-					<EditArrowDown width="24px" fill={styles.arrowColor} />
-				)} */}
 				{getAppropriateButton()}
 			</Flex>
 		</button>

--- a/packages/layout/src/components/cards/components/button.tsx
+++ b/packages/layout/src/components/cards/components/button.tsx
@@ -31,7 +31,7 @@ export const UnderlinedButton: React.FC<UnderlinedButtonProps> = ({
 			aria-expanded={isOpen}
 			tabIndex={tabIndex}
 		>
-			<Flex cfg={{ flex: '0 0 auto', alignItems: 'center' }}>
+			<Flex className={styles.arrowSpacing}  cfg={{ flex: '0 0 auto', alignItems: 'center' }}>
 				<P cfg={{ fontSize: 2, fontWeight: 3 }}>{children}</P>
 				{isOpen ? (
 					<ArrowUp width="24px" fill={styles.arrowColor} />

--- a/packages/layout/src/components/cards/components/button.tsx
+++ b/packages/layout/src/components/cards/components/button.tsx
@@ -1,18 +1,21 @@
 import React, { useEffect, useRef } from 'react';
 import { Flex, P } from '@tpr/core';
-import { ArrowUp, ArrowDown } from '@tpr/icons';
 import styles from './button.module.scss';
+import { EditArrowUp, EditArrowDown } from './arrowButton';
+import { ArrowDown, ArrowUp } from '@tpr/icons';
 
 type UnderlinedButtonProps = {
 	isOpen?: boolean;
 	onClick?: any;
 	tabIndex?: number;
+	isEditButton?:boolean;
 };
 export const UnderlinedButton: React.FC<UnderlinedButtonProps> = ({
 	children,
 	isOpen,
 	onClick,
 	tabIndex,
+	isEditButton,
 }) => {
 
 	if (typeof onClick === 'undefined') {
@@ -28,6 +31,28 @@ const buttonRef = useRef(null);
 useEffect(()=>{
 	buttonRef.current.focus();
 })
+ const getAppropriateButton= () => {
+		if(isOpen && isEditButton){
+			return (
+				<EditArrowUp width="24px" fill={styles.arrowColor} />
+			);
+		}else if(isOpen && !isEditButton){
+			return (
+				<ArrowUp width="24px" fill={styles.arrowColor} />
+			);
+		}
+
+		if(!isOpen && isEditButton){
+			return (
+				<EditArrowDown width="24px" fill={styles.arrowColor} />
+			);
+		}else if(!isOpen && !isEditButton){
+			return (
+				<ArrowDown width="24px" fill={styles.arrowColor} />
+			);
+		}
+ }
+
 	return (
 		<button
 			className={styles.button}
@@ -38,11 +63,13 @@ useEffect(()=>{
 		>
 			<Flex className={styles.arrowSpacing}  cfg={{ flex: '0 0 auto', alignItems: 'center' }}>
 				<P cfg={{ fontSize: 2, fontWeight: 3 }}>{children}</P>
-				{isOpen ? (
-					<ArrowUp width="24px" fill={styles.arrowColor} />
+				{/* {isOpen ? (
+
+					<EditArrowUp width="24px" fill={styles.arrowColor} />
 				) : (
-					<ArrowDown width="24px" fill={styles.arrowColor} />
-				)}
+					<EditArrowDown width="24px" fill={styles.arrowColor} />
+				)} */}
+				{getAppropriateButton()}
 			</Flex>
 		</button>
 	);

--- a/packages/layout/src/components/cards/components/button.tsx
+++ b/packages/layout/src/components/cards/components/button.tsx
@@ -8,7 +8,7 @@ type UnderlinedButtonProps = {
 	isOpen?: boolean;
 	onClick?: any;
 	tabIndex?: number;
-	isEditButton?:boolean;
+	isEditButton?: boolean;
 };
 export const UnderlinedButton: React.FC<UnderlinedButtonProps> = ({
 	children,
@@ -17,7 +17,6 @@ export const UnderlinedButton: React.FC<UnderlinedButtonProps> = ({
 	tabIndex,
 	isEditButton,
 }) => {
-
 	if (typeof onClick === 'undefined') {
 		return (
 			<div className={styles.buttonPlaceholder}>
@@ -27,31 +26,23 @@ export const UnderlinedButton: React.FC<UnderlinedButtonProps> = ({
 			</div>
 		);
 	}
-const buttonRef = useRef(null);
-useEffect(()=>{
-	buttonRef.current.focus();
-})
- const getAppropriateButton= () => {
-		if(isOpen && isEditButton){
-			return (
-				<EditArrowUp width="24px" fill={styles.arrowColor} />
-			);
-		}else if(isOpen && !isEditButton){
-			return (
-				<ArrowUp width="24px" fill={styles.arrowColor} />
-			);
+	const buttonRef = useRef(null);
+	useEffect(() => {
+		buttonRef.current.focus();
+	});
+	const getAppropriateButton = () => {
+		if (isOpen && isEditButton) {
+			return <EditArrowUp width="24px" fill={styles.arrowColor} />;
+		} else if (isOpen && !isEditButton) {
+			return <ArrowUp width="24px" fill={styles.arrowColor} />;
 		}
 
-		if(!isOpen && isEditButton){
-			return (
-				<EditArrowDown width="24px" fill={styles.arrowColor} />
-			);
-		}else if(!isOpen && !isEditButton){
-			return (
-				<ArrowDown width="24px" fill={styles.arrowColor} />
-			);
+		if (!isOpen && isEditButton) {
+			return <EditArrowDown width="24px" fill={styles.arrowColor} />;
+		} else if (!isOpen && !isEditButton) {
+			return <ArrowDown width="24px" fill={styles.arrowColor} />;
 		}
- }
+	};
 
 	return (
 		<button
@@ -61,7 +52,10 @@ useEffect(()=>{
 			tabIndex={tabIndex}
 			ref={buttonRef}
 		>
-			<Flex className={styles.arrowSpacing}  cfg={{ flex: '0 0 auto', alignItems: 'center' }}>
+			<Flex
+				className={styles.arrowSpacing}
+				cfg={{ flex: '0 0 auto', alignItems: 'center' }}
+			>
 				<P cfg={{ fontSize: 2, fontWeight: 3 }}>{children}</P>
 				{getAppropriateButton()}
 			</Flex>

--- a/packages/layout/src/components/cards/components/card.tsx
+++ b/packages/layout/src/components/cards/components/card.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { classNames, Flex, H3, Hr, P } from '@tpr/core';
 import styles from './card.module.scss';
+import { UnderlinedButton } from './button';
+import { useTrusteeContext } from '../trustee/context';
 
 type StyledCardProps = { complete: boolean };
+
 export const StyledCard: React.FC<StyledCardProps> = ({
 	complete = false,
 	children,
@@ -23,6 +26,39 @@ export const StyledCardToolbar: React.FC = ({ children }) => {
 	return <div className={styles.cardToolbar}>{children}</div>;
 };
 
+const CardContentSectionHeader:React.FC =()=>{
+	const { current, i18n, send } = useTrusteeContext();
+	if(current === undefined || current.context===undefined){
+		return(<></>);
+	}
+
+	let sectionHeader = '';
+	let canDisplay = false;
+	if(current.context.openSection==='edit.address'){
+		sectionHeader = i18n.preview.buttons.three;
+		canDisplay = true;
+	}else if(current.context.openSection==='edit.contact'){
+		sectionHeader = i18n.preview.buttons.four;
+		canDisplay = true;
+	}
+
+	if(canDisplay){
+		return (
+			<UnderlinedButton
+				onClick={() => {
+					send("CANCEL");
+					console.log(current.context)
+				}}
+				isOpen={true}
+			>
+				{sectionHeader}
+			</UnderlinedButton>
+		);
+	}else{
+		return (<></>);
+	}
+}
+
 type ToolbarProps = {
 	title: string;
 	subtitle?: string;
@@ -39,6 +75,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
 				cfg={{ flexDirection: 'column', pb: 2 }}
 				className={styles.toolbarBottomBorder}
 			>
+				<CardContentSectionHeader />
+
 				{sectionTitle && <P className={styles.sectionTitle}>{sectionTitle}</P>}
 				<H3 cfg={{ fontWeight: 3 }}>{title}</H3>
 			</Flex>

--- a/packages/layout/src/components/cards/components/card.tsx
+++ b/packages/layout/src/components/cards/components/card.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { classNames, Flex, H3, Hr, P } from '@tpr/core';
 import styles from './card.module.scss';
-import { UnderlinedButton } from './button';
-import { useTrusteeContext } from '../trustee/context';
+import CardContentSectionHeader from './cardContentHeaderSection';
 
 type StyledCardProps = { complete: boolean };
 
@@ -26,48 +25,20 @@ export const StyledCardToolbar: React.FC = ({ children }) => {
 	return <div className={styles.cardToolbar}>{children}</div>;
 };
 
-const CardContentSectionHeader:React.FC =()=>{
-	const { current, i18n, send } = useTrusteeContext();
-	if(current === undefined || current.context===undefined){
-		return(<></>);
-	}
-
-	let sectionHeader = '';
-	let canDisplay = false;
-	if(current.context.openSection==='edit.address'){
-		sectionHeader = i18n.preview.buttons.three;
-		canDisplay = true;
-	}else if(current.context.openSection==='edit.contact'){
-		sectionHeader = i18n.preview.buttons.four;
-		canDisplay = true;
-	}
-
-	if(canDisplay){
-		return (
-			<UnderlinedButton
-				onClick={() => {
-					send("CANCEL");
-					console.log(current.context)
-				}}
-				isOpen={true}
-			>
-				{sectionHeader}
-			</UnderlinedButton>
-		);
-	}else{
-		return (<></>);
-	}
-}
-
 type ToolbarProps = {
 	title: string;
 	subtitle?: string;
 	sectionTitle?: string;
+	subSectionHeaderText?: string;
+	send?: Function;
 };
+
 export const Toolbar: React.FC<ToolbarProps> = ({
 	title,
 	subtitle,
 	sectionTitle,
+	subSectionHeaderText,
+	send,
 }) => {
 	return (
 		<Flex cfg={{ flexDirection: 'column', mt: 4, mb: 3 }}>
@@ -75,7 +46,14 @@ export const Toolbar: React.FC<ToolbarProps> = ({
 				cfg={{ flexDirection: 'column', pb: 2 }}
 				className={styles.toolbarBottomBorder}
 			>
-				<CardContentSectionHeader />
+				{subSectionHeaderText && (
+					<Flex>
+						<CardContentSectionHeader
+							sectionHeaderText={subSectionHeaderText}
+							send={send}
+						/>
+					</Flex>
+				)}
 
 				{sectionTitle && <P className={styles.sectionTitle}>{sectionTitle}</P>}
 				<H3 cfg={{ fontWeight: 3 }}>{title}</H3>

--- a/packages/layout/src/components/cards/components/cardContentHeaderSection.tsx
+++ b/packages/layout/src/components/cards/components/cardContentHeaderSection.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { UnderlinedButton } from './button';
+
+interface CardContentSectionHeaderProps {
+	sectionHeaderText: string;
+	send?: Function;
+}
+export const CardContentSectionHeader: React.FC<CardContentSectionHeaderProps> = ({
+	sectionHeaderText,
+	send,
+}) => {
+	return (
+		<UnderlinedButton
+			onClick={() => {
+				send('CANCEL');
+			}}
+			isOpen={true}
+		>
+			{sectionHeaderText}
+		</UnderlinedButton>
+	);
+};
+
+export default CardContentSectionHeader;

--- a/packages/layout/src/components/cards/components/cardContentHeaderSection.tsx
+++ b/packages/layout/src/components/cards/components/cardContentHeaderSection.tsx
@@ -15,6 +15,7 @@ export const CardContentSectionHeader: React.FC<CardContentSectionHeaderProps> =
 				send('CANCEL');
 			}}
 			isOpen={true}
+			isEditButton={true}
 		>
 			{sectionHeaderText}
 		</UnderlinedButton>

--- a/packages/layout/src/components/cards/components/content.tsx
+++ b/packages/layout/src/components/cards/components/content.tsx
@@ -13,6 +13,8 @@ type ContentProps = {
 	breadcrumbs?: any;
 	subtitle?: string;
 	sectionTitle?: string;
+	subSectionHeaderText?: string;
+	send?: Function;
 };
 export const Content: React.FC<ContentProps> = ({
 	children,
@@ -21,7 +23,10 @@ export const Content: React.FC<ContentProps> = ({
 	breadcrumbs: Breadcrumbs,
 	subtitle,
 	sectionTitle,
+	subSectionHeaderText,
+	send,
 }) => {
+	console.log('section title', sectionTitle);
 	return (
 		<div className={styles.content}>
 			{loading && <Loading />}
@@ -31,6 +36,8 @@ export const Content: React.FC<ContentProps> = ({
 					title={title}
 					subtitle={subtitle}
 					sectionTitle={sectionTitle}
+					subSectionHeaderText={subSectionHeaderText}
+					send={send}
 				/>
 			)}
 			{children}

--- a/packages/layout/src/components/cards/components/toolbar.tsx
+++ b/packages/layout/src/components/cards/components/toolbar.tsx
@@ -3,6 +3,7 @@ import { Flex, classNames } from '@tpr/core';
 import { CheckedCircle, ErrorCircle } from '@tpr/icons';
 import { StatusMessage } from './card';
 import styles from '../cards.module.scss';
+import CardContentSectionHeader from './cardContentHeaderSection';
 
 export type ToolbarProps = {
 	complete: boolean;
@@ -10,6 +11,7 @@ export type ToolbarProps = {
 	buttonLeft: Function;
 	buttonRight: Function;
 	statusText: string;
+	subSectionHeaderText?: string;
 };
 
 export const Toolbar: React.FC<ToolbarProps> = ({
@@ -18,6 +20,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
 	buttonLeft,
 	buttonRight,
 	statusText,
+	subSectionHeaderText,
 }) => {
 	return (
 		<div
@@ -26,6 +29,11 @@ export const Toolbar: React.FC<ToolbarProps> = ({
 				styles.cardToolbar,
 			])}
 		>
+			{subSectionHeaderText && (
+				<Flex>
+					<CardContentSectionHeader sectionHeaderText={subSectionHeaderText} />
+				</Flex>
+			)}
 			<Flex
 				cfg={{
 					width: 5,

--- a/packages/layout/src/components/cards/corporateGroup/corporateGroup.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/corporateGroup.tsx
@@ -21,13 +21,13 @@ import { concatenateStrings } from '../../../utils';
 import styles from '../cards.module.scss';
 
 const CardContentSwitch: React.FC = () => {
-	const { current } = useCorporateGroupContext();
+	const { i18n, current } = useCorporateGroupContext();
 
 	switch (true) {
 		case current.matches('preview'):
 			return <Preview />;
 		case current.matches({ edit: 'name' }):
-			return <NameScreen />;
+			return <NameScreen subSectionHeaderText={i18n.preview.buttons.four} />;
 		case current.matches({ edit: 'contacts' }):
 			return <Contacts />;
 		case current.matches({ edit: 'professional' }):

--- a/packages/layout/src/components/cards/corporateGroup/corporateGroupMachine.ts
+++ b/packages/layout/src/components/cards/corporateGroup/corporateGroupMachine.ts
@@ -115,6 +115,7 @@ const corporateGroupMachine = Machine<
 							})),
 						},
 						REMOVE: '#remove',
+						CANCEL: '#preview',
 					},
 				},
 			},

--- a/packages/layout/src/components/cards/corporateGroup/views/contacts/contacts.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/contacts/contacts.tsx
@@ -63,6 +63,7 @@ export const Contacts: React.FC = () => {
 				emailAddress: corporateGroup.emailAddress,
 			}}
 			fields={fields}
+			send = {send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/corporateGroup/views/contacts/contacts.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/contacts/contacts.tsx
@@ -63,7 +63,8 @@ export const Contacts: React.FC = () => {
 				emailAddress: corporateGroup.emailAddress,
 			}}
 			fields={fields}
-			send = {send}
+			send={send}
+			subSectionHeaderText={i18n.preview.buttons.four}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/corporateGroup/views/name/name.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/name/name.tsx
@@ -39,8 +39,12 @@ const getFields = (
 		inputWidth: 6,
 	},
 ];
-
-export const NameScreen: React.FC = () => {
+interface NameScreenProps {
+	subSectionHeaderText?: string;
+}
+export const NameScreen: React.FC<NameScreenProps> = ({
+	subSectionHeaderText,
+}) => {
 	const [loading, setLoading] = useState(false);
 	const { current, send, i18n, onSaveName } = useCorporateGroupContext();
 	const fields = getFields(i18n.name.fields);
@@ -77,6 +81,7 @@ export const NameScreen: React.FC = () => {
 			loading={loading}
 			nextStep={true}
 			send={send}
+			subSectionHeaderText={subSectionHeaderText}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/corporateGroup/views/name/name.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/name/name.tsx
@@ -76,6 +76,7 @@ export const NameScreen: React.FC = () => {
 			}}
 			loading={loading}
 			nextStep={true}
+			send={send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
@@ -44,6 +44,7 @@ export const Preview: React.FC<any> = () => {
 						<UnderlinedButton
 							onClick={() => send('EDIT_PROFESSIONAL')}
 							isOpen={current.matches({ edit: 'professional' })}
+							isEditButton={true}
 						>
 							{i18n.preview.buttons.five}
 						</UnderlinedButton>
@@ -64,6 +65,7 @@ export const Preview: React.FC<any> = () => {
 					<UnderlinedButton
 						onClick={() => send('EDIT_NAME')}
 						isOpen={current.matches({ edit: 'contacts' })}
+						isEditButton={true}
 					>
 						{i18n.preview.buttons.four}
 					</UnderlinedButton>

--- a/packages/layout/src/components/cards/corporateGroup/views/professional/professional.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/professional/professional.tsx
@@ -82,7 +82,9 @@ export const Professional: React.FC = () => {
 									title="Save and close"
 									type="submit"
 								/>
-								<Link cfg={{ m: 3 }} underline onClick={() =>send('CANCEL')}>Cancel</Link>
+								<Link cfg={{ m: 3 }} underline onClick={() => send('CANCEL')}>
+									Cancel
+								</Link>
 							</Flex>
 						</Footer>
 					</form>

--- a/packages/layout/src/components/cards/corporateGroup/views/professional/professional.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/professional/professional.tsx
@@ -55,6 +55,8 @@ export const Professional: React.FC = () => {
 			type={cardType.trustee}
 			title={i18n.professional.title}
 			sectionTitle={i18n.professional.sectionTitle}
+			subSectionHeaderText={i18n.preview.buttons.five}
+			send={send}
 		>
 			<Form
 				onSubmit={onSubmit}

--- a/packages/layout/src/components/cards/corporateGroup/views/professional/professional.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/professional/professional.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Form, renderFields, validate, FieldProps } from '@tpr/forms';
-import { Flex } from '@tpr/core';
+import { Flex, Link } from '@tpr/core';
 import { Content } from '../../../components/content';
 import { Footer } from '../../../components/card';
 import { ArrowButton } from '../../../../buttons/buttons';
@@ -80,6 +80,7 @@ export const Professional: React.FC = () => {
 									title="Save and close"
 									type="submit"
 								/>
+								<Link cfg={{ m: 3 }} underline onClick={() =>send('CANCEL')}>Cancel</Link>
 							</Flex>
 						</Footer>
 					</form>

--- a/packages/layout/src/components/cards/corporateGroup/views/remove/reason/reason.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/remove/reason/reason.tsx
@@ -63,6 +63,7 @@ export const ReasonRemove: React.FC = () => {
 			onSubmit={onSubmit}
 			remove={remove}
 			dateField={DateField}
+			send={send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/employer/context.tsx
+++ b/packages/layout/src/components/cards/employer/context.tsx
@@ -33,7 +33,7 @@ export interface EmployerProviderProps extends CardProviderProps {
 	onSaveType?: (...args: any[]) => Promise<any>;
 	/** employer props from the API */
 	employer: Partial<Employer>;
-	showStatutoryEmployerSection: boolean;
+	showStatutoryEmployerSection?: boolean;
 	children?: RenderProps | ReactElement;
 	/** overwrite any text that you need */
 	i18n?: RecursivePartial<EmployerI18nProps>;
@@ -72,7 +72,13 @@ export const EmployerProvider = ({
 		},
 	});
 
-	const fwdValues = { current, send, showStatutoryEmployerSection, i18n, ...rest };
+	const fwdValues = {
+		current,
+		send,
+		showStatutoryEmployerSection,
+		i18n,
+		...rest,
+	};
 	const ui = typeof children === 'function' ? children(fwdValues) : children;
 	return (
 		<EmployerContext.Provider value={fwdValues}>{ui}</EmployerContext.Provider>

--- a/packages/layout/src/components/cards/employer/context.tsx
+++ b/packages/layout/src/components/cards/employer/context.tsx
@@ -72,7 +72,13 @@ export const EmployerProvider = ({
 		},
 	});
 
-	const fwdValues = { current, send, showStatutoryEmployerSection, i18n, ...rest };
+	const fwdValues = {
+		current,
+		send,
+		showStatutoryEmployerSection,
+		i18n,
+		...rest,
+	};
 	const ui = typeof children === 'function' ? children(fwdValues) : children;
 	return (
 		<EmployerContext.Provider value={fwdValues}>{ui}</EmployerContext.Provider>

--- a/packages/layout/src/components/cards/employer/context.tsx
+++ b/packages/layout/src/components/cards/employer/context.tsx
@@ -72,13 +72,7 @@ export const EmployerProvider = ({
 		},
 	});
 
-	const fwdValues = {
-		current,
-		send,
-		showStatutoryEmployerSection,
-		i18n,
-		...rest,
-	};
+	const fwdValues = { current, send, showStatutoryEmployerSection, i18n, ...rest };
 	const ui = typeof children === 'function' ? children(fwdValues) : children;
 	return (
 		<EmployerContext.Provider value={fwdValues}>{ui}</EmployerContext.Provider>

--- a/packages/layout/src/components/cards/employer/employer.tsx
+++ b/packages/layout/src/components/cards/employer/employer.tsx
@@ -41,11 +41,11 @@ const CardContentSwitch: React.FC = () => {
 	}
 };
 
-const ToolbarButton: React.FC<{ title: string; tabIndex?: number; isEditButton?:boolean }> = ({
-	title,
-	tabIndex,
-	isEditButton,
-}) => {
+const ToolbarButton: React.FC<{
+	title: string;
+	tabIndex?: number;
+	isEditButton?: boolean;
+}> = ({ title, tabIndex, isEditButton }) => {
 	const { current, send } = useEmployerContext();
 	return (
 		<UnderlinedButton
@@ -74,10 +74,8 @@ const ToolbarButton: React.FC<{ title: string; tabIndex?: number; isEditButton?:
 };
 
 const EmployerSubtitle: React.FC<Partial<EmployerContext>> = ({
-	employer: {
-		employerType, 
-		statutoryEmployer },
-	showStatutoryEmployerSection
+	employer: { employerType, statutoryEmployer },
+	showStatutoryEmployerSection,
 }) => {
 	if (!employerType || !statutoryEmployer) return null;
 
@@ -93,7 +91,10 @@ const EmployerSubtitle: React.FC<Partial<EmployerContext>> = ({
 	);
 
 	const subtitle = useMemo(
-		() => showStatutoryEmployerSection ? capitalize(statutoryEmployer).concat(` employer`): null,
+		() =>
+			showStatutoryEmployerSection
+				? capitalize(statutoryEmployer).concat(` employer`)
+				: null,
 		[statutoryEmployer],
 	);
 
@@ -112,7 +113,7 @@ export const EmployerCard: React.FC<EmployerProviderProps> = ({
 	return (
 		<EmployerProvider {...rest}>
 			{({ current, i18n }) => {
-			return (
+				return (
 					<Section
 						cfg={cfg}
 						data-testid={testId}
@@ -123,16 +124,17 @@ export const EmployerCard: React.FC<EmployerProviderProps> = ({
 					>
 						<Toolbar
 							complete={isComplete(current.context)}
-							subtitle={() => (
-								<EmployerSubtitle {...current.context} />
-							)}
+							subtitle={() => <EmployerSubtitle {...current.context} />}
 							statusText={
 								isComplete(current.context)
 									? i18n.preview.statusText.confirmed
 									: i18n.preview.statusText.unconfirmed
 							}
 							buttonLeft={() => (
-								<ToolbarButton title={i18n.preview.buttons.one} isEditButton={true} />
+								<ToolbarButton
+									title={i18n.preview.buttons.one}
+									isEditButton={true}
+								/>
 							)}
 							buttonRight={() => (
 								<ToolbarButton

--- a/packages/layout/src/components/cards/employer/employer.tsx
+++ b/packages/layout/src/components/cards/employer/employer.tsx
@@ -41,9 +41,10 @@ const CardContentSwitch: React.FC = () => {
 	}
 };
 
-const ToolbarButton: React.FC<{ title: string; tabIndex?: number }> = ({
+const ToolbarButton: React.FC<{ title: string; tabIndex?: number; isEditButton?:boolean }> = ({
 	title,
 	tabIndex,
+	isEditButton,
 }) => {
 	const { current, send } = useEmployerContext();
 	return (
@@ -65,6 +66,7 @@ const ToolbarButton: React.FC<{ title: string; tabIndex?: number }> = ({
 				}
 			}}
 			tabIndex={tabIndex}
+			isEditButton={isEditButton}
 		>
 			{title}
 		</UnderlinedButton>
@@ -130,7 +132,7 @@ export const EmployerCard: React.FC<EmployerProviderProps> = ({
 									: i18n.preview.statusText.unconfirmed
 							}
 							buttonLeft={() => (
-								<ToolbarButton title={i18n.preview.buttons.one} />
+								<ToolbarButton title={i18n.preview.buttons.one} isEditButton={true} />
 							)}
 							buttonRight={() => (
 								<ToolbarButton

--- a/packages/layout/src/components/cards/employer/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/employer/views/remove/date/date.tsx
@@ -54,6 +54,7 @@ export const RemoveDateForm: React.FC = () => {
 			dateField={DateField}
 			type={cardType.employer}
 			typeName={cardTypeName.employer}
+			send={send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/inHouse/inHouse.tsx
+++ b/packages/layout/src/components/cards/inHouse/inHouse.tsx
@@ -105,6 +105,7 @@ const InHouseAdminButton: React.FC = () => {
 					send('EDIT_NAME');
 				}
 			}}
+			isEditButton={true}
 		>
 			{i18n.preview.buttons.one}
 		</UnderlinedButton>

--- a/packages/layout/src/components/cards/inHouse/inHouse.tsx
+++ b/packages/layout/src/components/cards/inHouse/inHouse.tsx
@@ -65,6 +65,7 @@ const CardContentSwitch: React.FC = () => {
 					sectionTitle={i18n.address.sectionTitle}
 					i18n={i18n.address}
 					onCancelChanges={() => send('CANCEL')}
+					subSectionHeaderText={i18n.preview.buttons.three}
 				/>
 			);
 		case current.matches({ edit: 'contacts' }):

--- a/packages/layout/src/components/cards/inHouse/views/contacts/index.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/contacts/index.tsx
@@ -65,6 +65,7 @@ export const Contacts: React.FC = () => {
 				emailAddress: inHouseAdmin.emailAddress,
 			}}
 			fields={fields}
+			send = {send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/inHouse/views/contacts/index.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/contacts/index.tsx
@@ -65,7 +65,8 @@ export const Contacts: React.FC = () => {
 				emailAddress: inHouseAdmin.emailAddress,
 			}}
 			fields={fields}
-			send = {send}
+			send={send}
+			subSectionHeaderText={i18n.preview.buttons.four}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/inHouse/views/name/index.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/name/index.tsx
@@ -77,6 +77,7 @@ export const NameScreen: React.FC = () => {
 			fields={fields}
 			initialValues={originalValues}
 			loading={loading}
+			send= {send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/inHouse/views/name/index.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/name/index.tsx
@@ -77,7 +77,7 @@ export const NameScreen: React.FC = () => {
 			fields={fields}
 			initialValues={originalValues}
 			loading={loading}
-			send= {send}
+			send={send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/inHouse/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/preview/preview.tsx
@@ -29,6 +29,7 @@ export const Preview: React.FC<any> = () => {
 					<UnderlinedButton
 						onClick={() => send('EDIT_ADDRESS')}
 						isOpen={current.matches({ edit: 'address' })}
+						isEditButton={true}
 					>
 						{i18n.preview.buttons.three}
 					</UnderlinedButton>
@@ -52,6 +53,7 @@ export const Preview: React.FC<any> = () => {
 					<UnderlinedButton
 						onClick={() => send('EDIT_CONTACTS')}
 						isOpen={current.matches({ edit: 'contacts' })}
+						isEditButton={true}
 					>
 						{i18n.preview.buttons.four}
 					</UnderlinedButton>

--- a/packages/layout/src/components/cards/inHouse/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/remove/date/date.tsx
@@ -54,6 +54,7 @@ export const RemoveDateForm: React.FC = () => {
 			dateField={DateField}
 			type={cardType.inHouseAdmin}
 			typeName={cardTypeName.inHouseAdmin}
+			send={send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/independentTrustee/independentTrusteeMachine.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/independentTrusteeMachine.tsx
@@ -79,6 +79,7 @@ const independentTrusteeMachine = Machine<
 							})),
 						},
 						REMOVE: '#remove',
+						CANCEL: '#preview',
 					},
 				},
 			},

--- a/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
@@ -38,7 +38,9 @@ export const Preview: React.FC<any> = () => {
 				</Flex>
 
 				{/* Appointed By Regulator section: open for editing	 */}
-				<Flex cfg={{ width: 5, flex: '0 0 auto', flexDirection: 'column', pr: 4 }}>
+				<Flex
+					cfg={{ width: 5, flex: '0 0 auto', flexDirection: 'column', pr: 4 }}
+				>
 					<UnderlinedButton
 						onClick={() => send('EDIT_REGULATOR')}
 						isOpen={current.matches({ edit: 'regulator' })}

--- a/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
@@ -42,6 +42,7 @@ export const Preview: React.FC<any> = () => {
 					<UnderlinedButton
 						onClick={() => send('EDIT_REGULATOR')}
 						isOpen={current.matches({ edit: 'regulator' })}
+						isEditButton={true}
 					>
 						{i18n.preview.buttons.four}
 					</UnderlinedButton>

--- a/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
@@ -38,7 +38,7 @@ export const Preview: React.FC<any> = () => {
 				</Flex>
 
 				{/* Appointed By Regulator section: open for editing	 */}
-				<Flex cfg={{ flexDirection: 'column' }}>
+				<Flex cfg={{ width: 5, flex: '0 0 auto', flexDirection: 'column', pr: 4 }}>
 					<UnderlinedButton
 						onClick={() => send('EDIT_REGULATOR')}
 						isOpen={current.matches({ edit: 'regulator' })}

--- a/packages/layout/src/components/cards/independentTrustee/views/regulator/regulator.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/views/regulator/regulator.tsx
@@ -60,6 +60,8 @@ export const Regulator: React.FC = () => {
 			type={cardType.trustee}
 			title={i18n.regulator.title}
 			sectionTitle={i18n.regulator.sectionTitle}
+			subSectionHeaderText={i18n.preview.buttons.four}
+			send={send}
 		>
 			<Form
 				onSubmit={onSubmit}

--- a/packages/layout/src/components/cards/independentTrustee/views/regulator/regulator.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/views/regulator/regulator.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Form, renderFields, validate, FieldProps } from '@tpr/forms';
-import { Flex } from '@tpr/core';
+import { Flex, Link } from '@tpr/core';
 import { Content } from '../../../components/content';
 import { Footer } from '../../../components/card';
 import { ArrowButton } from '../../../../buttons/buttons';
@@ -85,6 +85,7 @@ export const Regulator: React.FC = () => {
 									title="Save and close"
 									type="submit"
 								/>
+								<Link cfg={{ m: 3 }} underline onClick={() => send("CANCEL")}>Cancel</Link>
 							</Flex>
 						</Footer>
 					</form>

--- a/packages/layout/src/components/cards/independentTrustee/views/regulator/regulator.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/views/regulator/regulator.tsx
@@ -87,7 +87,9 @@ export const Regulator: React.FC = () => {
 									title="Save and close"
 									type="submit"
 								/>
-								<Link cfg={{ m: 3 }} underline onClick={() => send("CANCEL")}>Cancel</Link>
+								<Link cfg={{ m: 3 }} underline onClick={() => send('CANCEL')}>
+									Cancel
+								</Link>
 							</Flex>
 						</Footer>
 					</form>

--- a/packages/layout/src/components/cards/independentTrustee/views/remove/reason/reason.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/views/remove/reason/reason.tsx
@@ -63,6 +63,7 @@ export const ReasonRemove: React.FC = () => {
 			onSubmit={onSubmit}
 			remove={remove}
 			dateField={DateField}
+			send={send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
@@ -44,6 +44,7 @@ export const Preview: React.FC<any> = () => {
 					<UnderlinedButton
 						isOpen={current.matches({ edit: 'reference' })}
 						onClick={() => send('EDIT_INSURER')}
+						isEditButton={true}
 					>
 						{i18n.preview.buttons.four}
 					</UnderlinedButton>

--- a/packages/layout/src/components/cards/insurer/views/reference/index.tsx
+++ b/packages/layout/src/components/cards/insurer/views/reference/index.tsx
@@ -56,6 +56,8 @@ export const Reference: React.FC = () => {
 			subtitle={i18n.reference.subtitle}
 			loading={false}
 			sectionTitle={i18n.reference.sectionTitle}
+			subSectionHeaderText={i18n.preview.buttons.four}
+			send={send}
 		>
 			<Form
 				onSubmit={onSubmit}

--- a/packages/layout/src/components/cards/insurer/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/insurer/views/remove/date/date.tsx
@@ -53,6 +53,7 @@ export const RemoveDateForm: React.FC = () => {
 			dateField={DateField}
 			type={cardType.insurer}
 			typeName={cardTypeName.insurer}
+			send={send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/thirdParty/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/thirdParty/views/remove/date/date.tsx
@@ -54,6 +54,7 @@ export const RemoveDateForm: React.FC = () => {
 			dateField={DateField}
 			type={cardType.thirdParty}
 			typeName={cardTypeName.thirdParty}
+			send={send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/trustee/trustee.tsx
+++ b/packages/layout/src/components/cards/trustee/trustee.tsx
@@ -87,22 +87,12 @@ const TrusteeButton: React.FC = () => {
 			isOpen={
 				current.matches({ edit: { trustee: 'name' } }) ||
 				current.matches({ edit: { trustee: 'kind' } }) ||
-				current.matches({ edit: { trustee: 'save' } }) ||
-				current.matches({ edit: { company: 'address' } }) ||
-				current.matches({ edit: { company: 'save' } }) ||
-				current.matches({ edit: { contact: 'details' } }) ||
-				current.matches({ edit: { contact: 'save' } }) ||
-				current.matches({ remove: 'reason' }) ||
-				current.matches({ remove: 'confirm' })
+				current.matches({ edit: { trustee: 'save' } })
 			}
 			onClick={() => {
 				if (
 					current.matches({ edit: { trustee: 'name' } }) ||
-					current.matches({ edit: { trustee: 'kind' } }) ||
-					current.matches({ edit: { company: 'address' } }) ||
-					current.matches({ edit: { contact: 'details' } }) ||
-					current.matches({ remove: 'reason' }) ||
-					current.matches({ remove: 'confirm' })
+					current.matches({ edit: { trustee: 'kind' } }) 
 				) {
 					send('CANCEL');
 				} else {

--- a/packages/layout/src/components/cards/trustee/trustee.tsx
+++ b/packages/layout/src/components/cards/trustee/trustee.tsx
@@ -60,6 +60,7 @@ const CardContent: React.FC = () => {
 				sectionTitle={i18n.address.sectionTitle}
 				i18n={i18n.address}
 				onCancelChanges={() => send('CANCEL')}
+				subSectionHeaderText={i18n.preview.buttons.three}
 			/>
 		);
 	} else if (

--- a/packages/layout/src/components/cards/trustee/trustee.tsx
+++ b/packages/layout/src/components/cards/trustee/trustee.tsx
@@ -93,13 +93,14 @@ const TrusteeButton: React.FC = () => {
 			onClick={() => {
 				if (
 					current.matches({ edit: { trustee: 'name' } }) ||
-					current.matches({ edit: { trustee: 'kind' } }) 
+					current.matches({ edit: { trustee: 'kind' } })
 				) {
 					send('CANCEL');
 				} else {
 					send('EDIT_TRUSTEE');
 				}
 			}}
+			isEditButton={true}
 		>
 			{i18n.preview.buttons.one}
 		</UnderlinedButton>

--- a/packages/layout/src/components/cards/trustee/trusteeMachine.ts
+++ b/packages/layout/src/components/cards/trustee/trusteeMachine.ts
@@ -75,6 +75,7 @@ export interface TrusteeContext {
 	loading: boolean;
 	complete: boolean;
 	preValidatedData?: boolean | null;
+	openSection: string;
 	trustee: TrusteeProps;
 	remove?: {
 		reason: null | string;
@@ -88,6 +89,7 @@ const trusteeMachine = Machine<TrusteeContext, TrusteeStates, TrusteeEvents>({
 	context: {
 		loading: false,
 		complete: false,
+		openSection:'',
 		trustee: {
 			schemeRoleId: '',
 			//
@@ -116,8 +118,22 @@ const trusteeMachine = Machine<TrusteeContext, TrusteeStates, TrusteeEvents>({
 			id: 'preview',
 			on: {
 				EDIT_TRUSTEE: 'edit.trustee.name',
-				EDIT_ORG: 'edit.company.address',
-				EDIT_CONTACTS: 'edit.contact.details',
+				EDIT_ORG: {
+					target: 'edit.company.address',
+					actions: assign((context, _event) => {
+						return {
+							openSection: context.openSection = 'edit.address'
+						};
+					})
+					},
+				EDIT_CONTACTS: {
+					target: 'edit.contact.details',
+					actions: assign((context, _event) => {
+						return {
+							openSection: context.openSection = 'edit.contact'
+						};
+					})
+				},
 				REMOVE: 'remove',
 				COMPLETE: {
 					actions: assign((_: any, event: any) => ({
@@ -185,7 +201,14 @@ const trusteeMachine = Machine<TrusteeContext, TrusteeStates, TrusteeEvents>({
 										},
 									})),
 								},
-								CANCEL: '#preview',
+								CANCEL:{
+									target:'#preview',
+									actions: assign((context, _event) => {
+										return {
+											openSection: context.openSection = ''
+										};
+									})
+								},
 								REMOVE: '#remove',
 							},
 						},
@@ -207,7 +230,14 @@ const trusteeMachine = Machine<TrusteeContext, TrusteeStates, TrusteeEvents>({
 										},
 									})),
 								},
-								CANCEL: '#preview',
+								CANCEL:{
+									target:'#preview',
+									actions: assign((context, _event) => {
+										return {
+											openSection: context.openSection = ''
+										};
+									})
+								},
 								REMOVE: '#remove',
 							},
 						},

--- a/packages/layout/src/components/cards/trustee/views/contacts/index.tsx
+++ b/packages/layout/src/components/cards/trustee/views/contacts/index.tsx
@@ -56,7 +56,8 @@ export const Contacts: React.FC = () => {
 				emailAddress: trustee.emailAddress,
 			}}
 			fields={fields}
-			send = {send}
+			send={send}
+			subSectionHeaderText={i18n.preview.buttons.four}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/trustee/views/contacts/index.tsx
+++ b/packages/layout/src/components/cards/trustee/views/contacts/index.tsx
@@ -56,6 +56,7 @@ export const Contacts: React.FC = () => {
 				emailAddress: trustee.emailAddress,
 			}}
 			fields={fields}
+			send = {send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/trustee/views/name/index.tsx
+++ b/packages/layout/src/components/cards/trustee/views/name/index.tsx
@@ -77,7 +77,7 @@ const Name: React.FC = () => {
 			initialValues={originalValues}
 			loading={loading}
 			nextStep={true}
-			send = {send}
+			send={send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/trustee/views/name/index.tsx
+++ b/packages/layout/src/components/cards/trustee/views/name/index.tsx
@@ -77,6 +77,7 @@ const Name: React.FC = () => {
 			initialValues={originalValues}
 			loading={loading}
 			nextStep={true}
+			send = {send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
@@ -29,6 +29,7 @@ export const Preview: React.FC = () => {
 					<UnderlinedButton
 						onClick={() => send('EDIT_ORG')}
 						isOpen={current.matches({ edit: 'company' })}
+						isEditButton={true}
 					>
 						{i18n.preview.buttons.three}
 					</UnderlinedButton>
@@ -52,6 +53,7 @@ export const Preview: React.FC = () => {
 					<UnderlinedButton
 						onClick={() => send('EDIT_CONTACTS')}
 						isOpen={current.matches({ edit: 'contact' })}
+						isEditButton ={true}
 					>
 						{i18n.preview.buttons.four}
 					</UnderlinedButton>

--- a/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
@@ -53,7 +53,7 @@ export const Preview: React.FC = () => {
 					<UnderlinedButton
 						onClick={() => send('EDIT_CONTACTS')}
 						isOpen={current.matches({ edit: 'contact' })}
-						isEditButton ={true}
+						isEditButton={true}
 					>
 						{i18n.preview.buttons.four}
 					</UnderlinedButton>

--- a/packages/layout/src/components/cards/trustee/views/remove/reason/reason.tsx
+++ b/packages/layout/src/components/cards/trustee/views/remove/reason/reason.tsx
@@ -63,6 +63,7 @@ const RemoveReason: React.FC = () => {
 			onSubmit={onSubmit}
 			remove={remove}
 			dateField={DateField}
+			send={send}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/trustee/views/type/type.tsx
+++ b/packages/layout/src/components/cards/trustee/views/type/type.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flex, P } from '@tpr/core';
+import { Flex, Link, P } from '@tpr/core';
 import { Form, FieldProps, renderFields } from '@tpr/forms';
 import { useTrusteeContext } from '../../context';
 import { Footer } from '../../../components/card';
@@ -119,6 +119,9 @@ const Type: React.FC = () => {
 								title="Save and close"
 								disabled={loading}
 							/>
+							<Link cfg={{ m: 3 }} underline onClick={() => send('CANCEL')}>
+								Cancel
+							</Link>
 						</Footer>
 					</form>
 				)}


### PR DESCRIPTION
#### Fixes AB#0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable Azure Pipelines for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Trustee card displays sub heading when address and contact details sections are opened
- Chevron is now right aligned
- Cancel link to close an open section is added next to the Save and Continue button

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
