### PR TITLE
renaming isRss prop to enableContactDetails

### DIFF
--- a/packages/layout/src/components/__tests__/trustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/trustee.spec.tsx
@@ -46,7 +46,7 @@ let component,
 	findByTextQuery;
 let updatedTrustee = null;
 
-const getCard = (isRssCard: boolean) => {
+const getCard = (enableContactDetails: boolean) => {
 	return (
 		<TrusteeCard
 			onDetailsSave={(values) => {
@@ -64,12 +64,12 @@ const getCard = (isRssCard: boolean) => {
 			complete={true}
 			trustee={trustee}
 			testId={trustee.schemeRoleId}
-			isRssCard={isRssCard}
+			enableContactDetails={enableContactDetails}
 		/>
 	);
 };
 
-const setupComponent = (isRssCard: boolean) => {
+const setupComponent = (enableContactDetails: boolean) => {
 	const {
 		container,
 		getByText,
@@ -78,7 +78,7 @@ const setupComponent = (isRssCard: boolean) => {
 		getByTestId,
 		getByRole,
 		queryByText,
-	} = render(getCard(isRssCard));
+	} = render(getCard(enableContactDetails));
 
 	component = container;
 	findByText = getByText;
@@ -89,9 +89,9 @@ const setupComponent = (isRssCard: boolean) => {
 	findByTextQuery = queryByText;
 };
 
-describe('TrusteeCard when isRssCard is false', () => {
+describe('TrusteeCard enableContactDetails == true', () => {
 	beforeEach(async () => {
-		setupComponent(false);
+		setupComponent(true);
 	});
 
 	afterEach(() => {
@@ -133,7 +133,7 @@ describe('TrusteeCard when isRssCard is false', () => {
 			expect(addressPreview.innerHTML).toEqual(addressExpected);
 		});
 
-		test('contact details shows up correctly, when isRssCard property is false', () => {
+		test('contact details shows up correctly', () => {
 			expect(findByText('Phone')).toBeDefined();
 			expect(findByText(trustee.telephoneNumber)).toBeDefined();
 			expect(findByText('Email')).toBeDefined();
@@ -271,9 +271,9 @@ describe('TrusteeCard when isRssCard is false', () => {
 	});
 });
 
-describe('TrusteeCard when isRssCard is true', () => {
+describe('TrusteeCard when enableContactDetails == false', () => {
 	beforeEach(async () => {
-		setupComponent(true);
+		setupComponent(false);
 	});
 
 	afterEach(() => {
@@ -281,7 +281,7 @@ describe('TrusteeCard when isRssCard is true', () => {
 	});
 
 	describe('Trustee Preview', () => {
-		test('contact details does not show when isRssCard property is true', () => {
+		test('contact details does not show when enableContactDetails property is false', () => {
 			expect(findByTextQuery('Phone')).toBeNull();
 			expect(findByTextQuery(trustee.telephoneNumber)).toBeNull();
 			expect(findByTextQuery('Email')).toBeNull();

--- a/packages/layout/src/components/cards/common/interfaces.ts
+++ b/packages/layout/src/components/cards/common/interfaces.ts
@@ -124,5 +124,5 @@ export const defaultPhoneErrorMessages: InputErrorMessages = {
 };
 
 export interface CardContentProps {
-	isRssCard?: boolean;
+	enableContactDetails?: boolean;
 }

--- a/packages/layout/src/components/cards/trustee/context.tsx
+++ b/packages/layout/src/components/cards/trustee/context.tsx
@@ -16,6 +16,7 @@ import {
 	CardPersonalDetails,
 	CardContactDetails,
 	CardAddress,
+	CardContentProps,
 } from '../common/interfaces';
 import { AddressAPIType } from '@tpr/forms';
 
@@ -60,7 +61,7 @@ export interface TrusteeContextProps {
 	current: Partial<State<TC, any, any, any>>;
 }
 
-export interface TrusteeCardProps {
+export interface TrusteeCardProps extends CardContentProps {
 	trustee: Trustee;
 	complete?: boolean;
 	preValidatedData?: boolean;
@@ -75,7 +76,6 @@ export interface TrusteeCardProps {
 	testId?: string | number;
 	children?: RenderProps | ReactElement;
 	cfg?: SpaceProps;
-	isRssCard?: boolean;
 }
 
 export const TrusteeProvider = ({

--- a/packages/layout/src/components/cards/trustee/trustee.mdx
+++ b/packages/layout/src/components/cards/trustee/trustee.mdx
@@ -115,7 +115,7 @@ import { TrusteeCard } from '@tpr/layout';
 				onDetailsSave={callbackFn}
 				onRemove={callbackFn}
 				trustee={trustee}
-				isRssCard={true}
+				enableContactDetails={false}
 			/>
 		);
 	}}
@@ -125,16 +125,16 @@ import { TrusteeCard } from '@tpr/layout';
 
 ### Props
 
-| Property         | Required | Type             | Description                                                                              |
-| ---------------- | -------- | ---------------- | ---------------------------------------------------------------------------------------- |
-| addressAPI       | true     | addressAPIType   | the required API params for the address search                                           |
-| complete         | true     | boolean          | changes the state of the card when All details are correct                               |
-| i18n             | false    | TrusteeI18nProps | allows to override specific text in the card                                             |
-| onAddressSave    | true     | function         | actions for when the user updates the Trustee's Address                                  |
-| onContactSave    | true     | function         | actions for when the user updates the Contact Details                                    |
-| onCorrect        | true     | function         | actions for when the user clicks the "Confirm details are correct" checkbox                  |
-| onDetailsSave    | true     | function         | actions for when the user updates the Name of the Trustee                                |
-| onRemove         | true     | function         | actions for when the trustee is removed                                                  |
-| prevalidatedData | false    | boolean          | allows to ignore the state of the "Confirm details are correct" checkbox & shows "No issues" |
-| trustee          | true     | Trustee          | the Trustee object                                                                       |
-| isRssCard        | false    | boolean          | turns off the Contact details section for RSS trustee		                                |
+| Property             | Required | Type             | Description                                                                                  |
+| -------------------- | -------- | ---------------- | -------------------------------------------------------------------------------------------- |
+| addressAPI           | true     | addressAPIType   | the required API params for the address search                                               |
+| complete             | true     | boolean          | changes the state of the card when All details are correct                                   |
+| i18n                 | false    | TrusteeI18nProps | allows to override specific text in the card                                                 |
+| onAddressSave        | true     | function         | actions for when the user updates the Trustee's Address                                      |
+| onContactSave        | true     | function         | actions for when the user updates the Contact Details                                        |
+| onCorrect            | true     | function         | actions for when the user clicks the "Confirm details are correct" checkbox                  |
+| onDetailsSave        | true     | function         | actions for when the user updates the Name of the Trustee                                    |
+| onRemove             | true     | function         | actions for when the trustee is removed                                                      |
+| prevalidatedData     | false    | boolean          | allows to ignore the state of the "Confirm details are correct" checkbox & shows "No issues" |
+| trustee              | true     | Trustee          | the Trustee object                                                                           |
+| enableContactDetails | false    | boolean          | turns off the Contact details section for RSS trustee                                        |

--- a/packages/layout/src/components/cards/trustee/trustee.tsx
+++ b/packages/layout/src/components/cards/trustee/trustee.tsx
@@ -26,12 +26,14 @@ import {
 } from '../../../utils';
 import styles from '../cards.module.scss';
 
-const CardContent: React.FC<CardContentProps> = ({ isRssCard = false }) => {
+const CardContent: React.FC<CardContentProps> = ({
+	enableContactDetails = true,
+}) => {
 	const { current, i18n, send, addressAPI } = useTrusteeContext();
 	const { trustee } = current.context;
 
 	if (current.matches('preview')) {
-		return <Preview isRssCard={isRssCard} />;
+		return <Preview enableContactDetails={enableContactDetails} />;
 	} else if (current.matches({ edit: { trustee: 'name' } })) {
 		return <Name />;
 	} else if (
@@ -139,7 +141,7 @@ const isComplete = (context: TrusteeContext) => {
 
 export const TrusteeCard: React.FC<Omit<TrusteeCardProps, 'children'>> = ({
 	cfg,
-	isRssCard = false,
+	enableContactDetails = true,
 	...props
 }) => {
 	return (
@@ -185,7 +187,7 @@ export const TrusteeCard: React.FC<Omit<TrusteeCardProps, 'children'>> = ({
 								: i18n.preview.statusText.unconfirmed
 						}
 					/>
-					<CardContent isRssCard={isRssCard} />
+					<CardContent enableContactDetails={enableContactDetails} />
 				</Section>
 			)}
 		</TrusteeProvider>

--- a/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
@@ -10,7 +10,9 @@ import {
 import styles from '../../../cards.module.scss';
 import { CardContentProps } from 'components/cards/common/interfaces';
 
-export const Preview: React.FC<CardContentProps> = ({ isRssCard = false }) => {
+export const Preview: React.FC<CardContentProps> = ({
+	enableContactDetails = true,
+}) => {
 	const { current, send, onCorrect, i18n } = useTrusteeContext();
 	const { trustee, complete, preValidatedData } = current.context;
 
@@ -48,7 +50,7 @@ export const Preview: React.FC<CardContentProps> = ({ isRssCard = false }) => {
 				</Flex>
 
 				{/* Contact details section: open for editing	 */}
-				{!isRssCard && (
+				{enableContactDetails && (
 					<Flex
 						cfg={{ width: 5, flex: '0 0 auto', flexDirection: 'column', pl: 4 }}
 					>


### PR DESCRIPTION
#### Fixes [AB#84201](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/84201)

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable Azure Pipelines for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Renaming `isRss` prop from Trustee card to `enableContactDetails`
