### PR TITLE
Feature/99747 hint text for Link component

### DIFF
--- a/packages/core/src/components/links/links.mdx
+++ b/packages/core/src/components/links/links.mdx
@@ -27,25 +27,90 @@ import { Link } from '@tpr/core';
 ### Basic usage
 
 <Playground>
-	<Link onClick={() => console.log('Back clicked')} >Click to go back</Link>
+	<Link href="https://www.thepensionsregulator.gov.uk">Home</Link>
+	<br />
+	<Link onClick={() => console.log('Back clicked')}>Click to go back</Link>
 </Playground>
 
 ### Usage with props
 
 <Playground>
-	<Link cfg={{ mr: 3 }} href="https://www.thepensionsregulator.gov.uk">Home</Link>
-	<Link cfg={{ mr: 3 }} href="https://www.thepensionsregulator.gov.uk">Gallery</Link>
-	<Link cfg={{ mr: 3 }} onClick={() => console.log('Log out clicked')} underline={true}>
+	<Link
+		cfg={{ mr: 3 }}
+		href="https://www.thepensionsregulator.gov.uk"
+		target="_blank"
+	>
+		Home
+	</Link>
+	<br />
+	<Link
+		cfg={{ mr: 3 }}
+		onClick={() => console.log('Log out clicked')}
+		underline={true}
+	>
 		Log out
+	</Link>
+	<br />
+	<Link
+		cfg={{ mr: 3 }}
+		href="https://www.thepensionsregulator.gov.uk"
+		onClick={() => console.log('Go to page Scheme Name')}
+		taskList={true}
+	>
+		Scheme Name
 	</Link>
 </Playground>
 
 ### Usage with colours from the theme
 
 <Playground>
-	<Link cfg={{ mr: 3, color: 'danger.2' }} href="https://www.thepensionsregulator.gov.uk">Home</Link>
-	<Link cfg={{ mr: 3, color: 'warning.1' }} href="https://www.thepensionsregulator.gov.uk">Gallery</Link>
-	<Link cfg={{ mr: 3, color: 'success.1' }} onClick={() => console.log('Log out clicked')}>Log out</Link>
+	<Link
+		cfg={{ mr: 3, color: 'danger.2' }}
+		href="https://www.thepensionsregulator.gov.uk"
+	>
+		Home
+	</Link>
+	<Link
+		cfg={{ mr: 3, color: 'warning.1' }}
+		href="https://www.thepensionsregulator.gov.uk"
+	>
+		Gallery
+	</Link>
+	<Link
+		cfg={{ mr: 3, color: 'success.1' }}
+		onClick={() => console.log('Log out clicked')}
+	>
+		Log out
+	</Link>
+</Playground>
+
+### Usage with Hint text
+
+<Playground>
+	<Link
+		href="https://www.thepensionsregulator.gov.uk"
+		hint="(your progress will be lost)"
+		hintId="cancelHint"
+	>
+		Cancel
+	</Link>
+	<br />
+	<Link
+		cfg={{ color: 'primary.2' }}
+		href="https://www.thepensionsregulator.gov.uk"
+		hint="(your progress will be lost)"
+		hintCfg={{ color: 'primary.a2' }}
+	>
+		Cancel
+	</Link>
+	<br />
+	<Link
+		onClick={() => console.log('Cancel clicked')}
+		hint="(your progress will be lost)"
+		hintCfg={{ ml: 2, fontWeight: '3' }}
+	>
+		Cancel
+	</Link>
 </Playground>
 
 ## API
@@ -56,7 +121,11 @@ Accepted config props: SpaceProps, ColorProps, TypographyProps, LayoutProps
 
 <Props of={Link} />
 
-| Property         | Required | Type             | Description                                                                              |
-| ---------------- | -------- | ---------------- | ---------------------------------------------------------------------------------------- |
-| href             | false    | string           | the href to navigate to when the link is clicked                                         |
-| onClick          | false    | function         | javascript function to execute on click, use instead of an href when required            |
+| Property | Required | Type      | Description                                                                                                                     |
+| -------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| href     | false    | string    | the href to navigate to when the link is clicked                                                                                |
+| onClick  | false    | function  | javascript function to execute on click, use instead of an href when required                                                   |
+| hint     | false    | string    | hint text to be displayed next to the Link                                                                                      |
+| hintCfg  | false    | cfg props | specific props for the hint text                                                                                                |
+| hintId   | false    | string    | id for the hint text, recommended to specify a unique id for accessibility (default value 'cancelHint')                         |
+| taskList | false    | boolean   | indicates if the link is used in the TaskList component (includes href attribute but will perform action indicated via onClick) |

--- a/packages/core/src/components/links/links.module.scss
+++ b/packages/core/src/components/links/links.module.scss
@@ -14,18 +14,18 @@
 	&:hover {
 		color: $colors-neutral-a1;
 	}
-	
+
 	&:disabled {
 		color: $colors-neutral-6;
 		text-decoration: none;
 		cursor: not-allowed;
 	}
-	
+
 	&:visited {
 		color: $colors-accents-2;
 		background-color: $colors-warning-1;
 	}
-	
+
 	&:focus {
 		color: $colors-neutral-8;
 		background: $colors-warning-1;
@@ -56,4 +56,8 @@
 	flex-direction: row-reverse;
 	justify-content: center;
 	align-items: center;
+}
+
+.hint {
+	margin-left: $space-1;
 }

--- a/packages/core/src/components/links/links.tsx
+++ b/packages/core/src/components/links/links.tsx
@@ -6,22 +6,32 @@ import {
 	LayoutProps,
 } from '../globals/globals';
 import { useClassNames } from '../../hooks/use-class-names';
+import { Span } from '../typography/typography';
 import styles from './links.module.scss';
 
-export type LinkProps = {
+export interface LinkProps {
 	cfg?: SpaceProps & ColorProps & TypographyProps & LayoutProps;
 	className?: string;
 	underline?: boolean;
 	testId?: string;
 	taskList?: boolean;
+	hint?: string;
+	hintCfg?: SpaceProps & ColorProps & TypographyProps & LayoutProps;
+	hintId?: string;
 	[key: string]: any;
-};
+}
+
+const defaultHintId = 'cancelHint';
+
 export const Link: React.FC<LinkProps> = ({
 	cfg: globalStyles,
 	underline = false,
 	className,
 	testId,
 	taskList = false,
+	hint,
+	hintCfg,
+	hintId = defaultHintId,
 	children,
 	...props
 }) => {
@@ -36,6 +46,7 @@ export const Link: React.FC<LinkProps> = ({
 		className: classNames,
 		href: props.href ? props.href : '#',
 		onClick: null,
+		'aria-describedby': hint ? hintId : null,
 		...props,
 	};
 
@@ -46,5 +57,17 @@ export const Link: React.FC<LinkProps> = ({
 		};
 	}
 
-	return React.createElement('a', anchorProps, children);
+	const Anchor: React.FC = () =>
+		React.createElement('a', anchorProps, children);
+
+	return (
+		<>
+			<Anchor />
+			{hint && (
+				<Span className={styles.hint} id={hintId} cfg={{ ...hintCfg }}>
+					{hint}
+				</Span>
+			)}
+		</>
+	);
 };


### PR DESCRIPTION
#### Fixes [AB#99747](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/99747)

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable Azure Pipelines for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Adding ability to pass a hint text to `@tpr/core` `<Link>` component.

The anchor tag now receives the '`aria-describedby`' attribute when the hint text exists.

It can receive the following props:
- `hint`: the text to be displayed
- `hintCfg`: additional format for the hint text.
- `hintId`: the id for the hint text to be used in the '`aria-describedby`' attribute that the link includes now.
