### PR TITLE
AB#100972 adding aria-disabled to buttons styles

### DIFF
--- a/packages/core/src/components/buttons/buttons.mdx
+++ b/packages/core/src/components/buttons/buttons.mdx
@@ -132,6 +132,23 @@ import { Button } from '@tpr/core';
 	</div>
 </Playground>
 
+### With aria-disabled="true"
+
+<Playground>
+	<div>
+		<Button aria-disabled>Primary</Button>
+		<Button appearance="secondary" aria-disabled="true">
+			Secondary
+		</Button>
+		<Button intent="warning" aria-disabled={true}>
+			Warning
+		</Button>
+		<Button appearance="outlined" aria-disabled={true}>
+			Outlined
+		</Button>
+	</div>
+</Playground>
+
 ## API
 
 ```

--- a/packages/core/src/components/buttons/buttons.module.scss
+++ b/packages/core/src/components/buttons/buttons.module.scss
@@ -28,7 +28,8 @@
 		outline: none;
 	}
 
-	&:disabled {
+	&:disabled,
+	&[aria-disabled='true'] {
 		cursor: not-allowed !important;
 		background: $colors-primary-a1;
 
@@ -51,7 +52,8 @@
 		outline: none;
 	}
 
-	&:disabled {
+	&:disabled,
+	&[aria-disabled='true'] {
 		cursor: not-allowed !important;
 		background: $colors-primary-1 !important;
 	}
@@ -70,7 +72,8 @@
 		}
 	}
 
-	&:disabled {
+	&:disabled,
+	&[aria-disabled='true'] {
 		color: $colors-neutral-6;
 		cursor: not-allowed !important;
 		border: 2px solid $colors-neutral-6;
@@ -97,7 +100,8 @@
 	&.appearance-secondary:hover {
 		background: $colors-neutral-a1 !important;
 
-		&:disabled {
+		&:disabled,
+		&[aria-disabled='true'] {
 			background: $colors-primary-1 !important;
 		}
 	}
@@ -106,7 +110,8 @@
 		background: $colors-primary-a2 !important;
 		border-color: $colors-primary-a2 !important;
 
-		&:disabled {
+		&:disabled,
+		&[aria-disabled='true'] {
 			background: none !important;
 			border-color: $colors-neutral-6 !important;
 		}
@@ -138,7 +143,8 @@
 		color: $colors-neutral-8;
 	}
 
-	&:disabled {
+	&:disabled,
+	&[aria-disabled='true'] {
 		cursor: not-allowed !important;
 		background: $colors-danger-1;
 

--- a/packages/layout/src/components/buttons/buttons.mdx
+++ b/packages/layout/src/components/buttons/buttons.mdx
@@ -158,6 +158,14 @@ import { ArrowLink, ArrowButton, CrossButton } from '@tpr/layout';
 		title="Submit"
 		pointsTo="right"
 		onClick={() => console.log('clicked')}
+		cfg={{ mr: 3 }}
+		ariaDisabled={true}
+	/>
+	<ArrowButton
+		iconSide="right"
+		title="Submit"
+		pointsTo="right"
+		onClick={() => console.log('clicked')}
 		disabled
 		disabledText="Loading..."
 	/>

--- a/packages/layout/src/components/buttons/buttons.tsx
+++ b/packages/layout/src/components/buttons/buttons.tsx
@@ -12,10 +12,12 @@ export interface ArrowButtonProps extends ButtonProps {
 	pointsTo?: 'left' | 'up' | 'right' | 'down';
 	iconSide?: 'left' | 'right';
 	iconColor?: ColorProps['fill'];
+	ariaDisabled?: boolean;
 }
 export const ArrowButton: React.FC<ArrowButtonProps> = ({
 	intent,
 	appearance,
+	ariaDisabled = null,
 	type = 'button',
 	onClick = undefined,
 	disabled,
@@ -34,6 +36,7 @@ export const ArrowButton: React.FC<ArrowButtonProps> = ({
 			type={type}
 			onClick={onClick}
 			disabled={disabled}
+			aria-disabled={ariaDisabled}
 			cfg={cfg}
 			testId={testId}
 			className={styles.arrowButton}


### PR DESCRIPTION
#### Fixes [AB#100972](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/100972)

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable Azure Pipelines for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

when buttons have `aria-disabled` will display same style as `disabled`