### PR TITLE
AB#101581 adding hiddenLabel attribute to FFInputDate when not existing label

### DIFF
--- a/packages/forms/src/__tests__/date.spec.tsx
+++ b/packages/forms/src/__tests__/date.spec.tsx
@@ -3,6 +3,7 @@ import { renderFields, validate } from '../index';
 import { FieldProps } from '../renderFields';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
+import { HiddenLabelIdGenerator } from '../elements/date/services/HiddenLabelIdGenerator';
 
 // TODO: write more test when there are clear specs for date input validation
 
@@ -253,6 +254,48 @@ describe('Date input', () => {
 		expect(handleSubmit).toBeCalledTimes(1);
 		expect(form.getState().values).toEqual({
 			'month-year-only': '2020-01-01',
+		});
+	});
+
+	describe('testing hiddenLabel prop', () => {
+		let dateContainer, findByText, hiddenLabelId;
+		const fields: FieldProps[] = [
+			{
+				name: 'date-1',
+				type: 'date',
+				id: 'date-id',
+				hint: 'For example, 12 11 2007',
+				hiddenLabel: 'When was your passport issued',
+			},
+		];
+
+		beforeEach(() => {
+			const handleSubmit = jest.fn();
+
+			const { container, getByText } = formSetup({
+				render: renderFields(fields),
+				validate: validate(fields),
+				onSubmit: handleSubmit,
+			});
+
+			dateContainer = container;
+			findByText = getByText;
+
+			hiddenLabelId = HiddenLabelIdGenerator(fields[0].hiddenLabel);
+		});
+
+		test('hidden div with correct Id contains hiddenLabel text', () => {
+			const theDiv = findByText(fields[0].hiddenLabel);
+
+			expect(theDiv).toBeDefined();
+
+			expect(theDiv).toHaveAttribute('id', hiddenLabelId);
+		});
+
+		test('aria-describedby has Id of hidden label div', () => {
+			const fieldSet = dateContainer.getElementsByTagName('fieldset')[0];
+
+			expect(fieldSet).toHaveAttribute('aria-describedby', hiddenLabelId);
 		});
 	});
 });

--- a/packages/forms/src/elements/accessibilityHelper.ts
+++ b/packages/forms/src/elements/accessibilityHelper.ts
@@ -1,8 +1,6 @@
 import { toKebabCase } from '@tpr/core';
 
 export default class AccessibilityHelper {
-	//innerHiddenLabelId: string | null;
-
 	constructor(
 		private rootId: string,
 		private hasLabel: boolean,

--- a/packages/forms/src/elements/accessibilityHelper.ts
+++ b/packages/forms/src/elements/accessibilityHelper.ts
@@ -10,8 +10,6 @@ export default class AccessibilityHelper {
 		private hiddenLabelId: string | null = null,
 	) {
 		this.rootId = toKebabCase(rootId);
-		//this.innerHiddenLabelId =
-		//	this.hiddenLabelId && this.hiddenLabelId !== '' ? hiddenLabelId : null;
 	}
 
 	get labelId(): string {

--- a/packages/forms/src/elements/accessibilityHelper.ts
+++ b/packages/forms/src/elements/accessibilityHelper.ts
@@ -1,16 +1,24 @@
 import { toKebabCase } from '@tpr/core';
 
 export default class AccessibilityHelper {
+	//innerHiddenLabelId: string | null;
+
 	constructor(
 		private rootId: string,
 		private hasLabel: boolean,
 		private hasHint: boolean,
+		private hiddenLabelId: string | null = null,
 	) {
 		this.rootId = toKebabCase(rootId);
+		//this.innerHiddenLabelId =
+		//	this.hiddenLabelId && this.hiddenLabelId !== '' ? hiddenLabelId : null;
 	}
 
 	get labelId(): string {
-		return (this.rootId && this.hasLabel && `${this.rootId}-label`) || null;
+		return (
+			(this.rootId && this.hasLabel && `${this.rootId}-label`) ||
+			this.hiddenLabelId
+		);
 	}
 	get hintId(): string {
 		return (this.rootId && this.hasHint && `${this.rootId}-hint`) || null;

--- a/packages/forms/src/elements/date/date.mdx
+++ b/packages/forms/src/elements/date/date.mdx
@@ -142,6 +142,41 @@ import { FFInputDate } from '@tpr/forms';
 	}}
 </Playground>
 
+### not label, but including hiddenLabel
+
+<Playground>
+	{() => {
+		const fields = [
+			{
+				id: 'sample-date4',
+				type: 'date',
+				name: 'passport-issued4',
+				hiddenLabel: 'When was your passport issued?',
+				hint: 'For example, 2007',
+				error: 'The year must be in the past',
+				hideDay: true,
+				hideMonth: true,
+			},
+		];
+		return (
+			<Form
+				onSubmit={(val) => console.log(val)}
+				initialValues={{ 'passport-issued4': null }}
+				validate={validate(fields)}
+			>
+				{({ handleSubmit }) => (
+					<form onSubmit={handleSubmit} style={{ padding: 10 }}>
+						{renderFields(fields)}
+						<button type="submit" style={{ display: 'none' }}>
+							Submit
+						</button>
+					</form>
+				)}
+			</Form>
+		);
+	}}
+</Playground>
+
 ## API
 
 ```

--- a/packages/forms/src/elements/date/date.mdx
+++ b/packages/forms/src/elements/date/date.mdx
@@ -185,13 +185,14 @@ Accepted config props: FlexProps, SpaceProps
 
 ### Props
 
-| Property  | Required | Type    | Description                                                          |
-| --------- | -------- | ------- | -------------------------------------------------------------------- |
-| cfg       | false    | object  | FlexProps & SpaceProps                                               |
-| disabled  | false    | boolean | Disable date field                                                   |
-| testId    | false    | string  | data attribute for testers                                           |
-| label     | true     | string  | Date field description                                               |
-| hint      | false    | string  | More detailed description about the date field                       |
-| hideDay   | false    | boolean | hides the Day input and assigns a default value of 1 for the day     |
-| hideMonth | false    | boolean | hides the Month input and assigns a default value of 1 for the month |
-| readOnly  | false    | boolean | Sets whether the field is read only                                  |
+| Property    | Required | Type    | Description                                                                |
+| ----------- | -------- | ------- | -------------------------------------------------------------------------- |
+| cfg         | false    | object  | FlexProps & SpaceProps                                                     |
+| disabled    | false    | boolean | Disable date field                                                         |
+| testId      | false    | string  | data attribute for testers                                                 |
+| label       | true     | string  | Date field description                                                     |
+| hint        | false    | string  | More detailed description about the date field                             |
+| hideDay     | false    | boolean | hides the Day input and assigns a default value of 1 for the day           |
+| hideMonth   | false    | boolean | hides the Month input and assigns a default value of 1 for the month       |
+| readOnly    | false    | boolean | Sets whether the field is read only                                        |
+| hiddenLabel | false    | string  | allows passing text to be used in aria-describedby when no label specified |

--- a/packages/forms/src/elements/date/date.tsx
+++ b/packages/forms/src/elements/date/date.tsx
@@ -14,6 +14,7 @@ import { Input } from '../input/input';
 import { FieldProps, FieldExtraProps } from '../../renderFields';
 import { SameMonthDateValidator } from './services/SameMonthDateValidator';
 import AccessibilityHelper from '../accessibilityHelper';
+import { HiddenLabelIdGenerator } from './services/HiddenLabelIdGenerator';
 import styles from './date.module.scss';
 
 const handleChange = (onChange: Function, value: number) => ({
@@ -174,10 +175,8 @@ export const InputDate: React.FC<InputDateComponentProps> = memo(
 		}, [day, month, year, input]);
 
 		const isError: boolean = meta && meta.touched && meta.error;
-		const hiddenLabelId: string | null =
-			hiddenLabel !== ''
-				? `hiddenLabel-${hiddenLabel.replace(/\s/g, '').slice(-4)}`
-				: null;
+		const hiddenLabelId = HiddenLabelIdGenerator(hiddenLabel);
+
 		const helper = new AccessibilityHelper(id, !!label, !!hint, hiddenLabelId);
 
 		return (

--- a/packages/forms/src/elements/date/date.tsx
+++ b/packages/forms/src/elements/date/date.tsx
@@ -8,13 +8,13 @@ import React, {
 import { Field, FieldRenderProps } from 'react-final-form';
 import { isValid, toDate, format } from 'date-fns';
 import { P, Flex } from '@tpr/core';
+import isEqual from 'lodash.isequal';
 import { StyledInputLabel, InputElementHeading } from '../elements';
 import { Input } from '../input/input';
 import { FieldProps, FieldExtraProps } from '../../renderFields';
-import isEqual from 'lodash.isequal';
-import styles from './date.module.scss';
 import { SameMonthDateValidator } from './services/SameMonthDateValidator';
 import AccessibilityHelper from '../accessibilityHelper';
+import styles from './date.module.scss';
 
 const handleChange = (onChange: Function, value: number) => ({
 	target,
@@ -51,38 +51,39 @@ const transformDate = (initialDate: any) => {
 };
 
 type DateInputFieldProps = {
+	disabled?: boolean;
+	hideMonth?: boolean;
 	id?: string;
+	label: string;
+	maxInt: number;
+	maxLength?: number;
+	meta: any;
+	onBlur: Function;
 	parentId?: string;
+	readOnly?: boolean;
+	setMonth: Function;
 	small?: boolean;
 	testId?: string;
-	value: any;
 	updateFn: Function;
-	setMonth: Function;
-	onBlur: Function;
-	maxInt: number;
-	meta: any;
-	label: string;
-	disabled?: boolean;
-	readOnly?: boolean;
-	hideMonth?: boolean;
-	maxLength?: number;
+	value: any;
 };
+
 const DateInputField: React.FC<DateInputFieldProps> = ({
-	id,
-	parentId,
-	small = true,
-	label,
-	testId,
-	value,
-	updateFn,
-	maxInt,
-	setMonth,
-	onBlur,
-	meta,
 	disabled,
-	readOnly,
 	hideMonth,
+	id,
+	label,
+	maxInt,
 	maxLength,
+	meta,
+	onBlur,
+	parentId,
+	readOnly,
+	setMonth,
+	small = true,
+	testId,
+	updateFn,
+	value,
 }) => {
 	const [hasFocus, setHasFocus] = useState(false);
 	const helper = new AccessibilityHelper(parentId, false, false);
@@ -132,6 +133,7 @@ type InputDateProps = FieldRenderProps<string> & FieldExtraProps;
 interface InputDateComponentProps extends InputDateProps {
 	hideDay?: boolean;
 	hideMonth?: boolean;
+	hiddenLabel?: string;
 }
 export const InputDate: React.FC<InputDateComponentProps> = memo(
 	({
@@ -147,6 +149,7 @@ export const InputDate: React.FC<InputDateComponentProps> = memo(
 		readOnly,
 		hideDay,
 		hideMonth,
+		hiddenLabel = '',
 	}) => {
 		// react-final-form types says it's a string, incorrect, it's a date object.
 		const { dd, mm, yyyy } = transformDate(meta.initial);
@@ -171,7 +174,11 @@ export const InputDate: React.FC<InputDateComponentProps> = memo(
 		}, [day, month, year, input]);
 
 		const isError: boolean = meta && meta.touched && meta.error;
-		const helper = new AccessibilityHelper(id, !!label, !!hint);
+		const hiddenLabelId: string | null =
+			hiddenLabel !== ''
+				? `hiddenLabel-${hiddenLabel.replace(/\s/g, '').slice(-4)}`
+				: null;
+		const helper = new AccessibilityHelper(id, !!label, !!hint, hiddenLabelId);
 
 		return (
 			<StyledInputLabel
@@ -181,11 +188,21 @@ export const InputDate: React.FC<InputDateComponentProps> = memo(
 				onBlur={input.onBlur}
 				data-testid={`date-input-${testId}`}
 				aria-labelledby={helper.labelId}
-				aria-describedby={helper.formatAriaDescribedBy(isError)}
+				aria-describedby={
+					isError
+						? helper.formatAriaDescribedBy(isError)
+						: !label && hiddenLabel !== ''
+						? hiddenLabelId
+						: hint
+						? helper.hintId
+						: helper.labelId
+				}
 				cfg={Object.assign(
 					{ mt: 1, py: 1, alignItems: 'flex-start', flexDirection: 'column' },
 					cfg,
 				)}
+				hiddenLabel={hiddenLabel}
+				hiddenLabelId={hiddenLabelId}
 			>
 				<InputElementHeading
 					element="legend"

--- a/packages/forms/src/elements/date/services/HiddenLabelIdGenerator.ts
+++ b/packages/forms/src/elements/date/services/HiddenLabelIdGenerator.ts
@@ -1,0 +1,4 @@
+export const HiddenLabelIdGenerator = (hiddenLabel: string): string | null =>
+	hiddenLabel !== ''
+		? `hiddenLabel-${hiddenLabel.replace(/\s/g, '').slice(-4)}`
+		: null;

--- a/packages/forms/src/elements/elements.module.scss
+++ b/packages/forms/src/elements/elements.module.scss
@@ -48,8 +48,13 @@ fieldset {
 .errorMessage {
 	color: $colors-danger-2;
 	font-size: $font-size-2;
-	font-weight: $font-weight-3!important;
+	font-weight: $font-weight-3 !important;
 	margin-bottom: $space-2;
 	max-width: 100%;
 	white-space: pre-line;
+}
+
+.hiddenLabel {
+	display: none;
+	visibility: hidden;
 }

--- a/packages/forms/src/elements/elements.tsx
+++ b/packages/forms/src/elements/elements.tsx
@@ -1,8 +1,7 @@
-import React, { createElement } from 'react';
+import React, { createElement, ReactNode } from 'react';
 import { SpaceProps, FlexProps, useClassNames, Span } from '@tpr/core';
-import styles from './elements.module.scss';
-import { ReactNode } from 'react';
 import AccessibilityHelper from './accessibilityHelper';
+import styles from './elements.module.scss';
 
 interface StyledInputLabelProps {
 	element?: 'label' | 'div' | 'fieldset';
@@ -11,6 +10,8 @@ interface StyledInputLabelProps {
 	cfg?: FlexProps | SpaceProps;
 	[key: string]: any;
 	noLeftBorder?: boolean;
+	hiddenLabel?: string;
+	hiddenLabelId?: string;
 }
 export const StyledInputLabel: React.FC<StyledInputLabelProps> = ({
 	element = 'label',
@@ -19,6 +20,8 @@ export const StyledInputLabel: React.FC<StyledInputLabelProps> = ({
 	className,
 	children,
 	noLeftBorder,
+	hiddenLabel = '',
+	hiddenLabelId,
 	...props
 }) => {
 	const classNames = useClassNames(cfg, [
@@ -32,7 +35,15 @@ export const StyledInputLabel: React.FC<StyledInputLabelProps> = ({
 			className: classNames,
 			...props,
 		},
-		children,
+
+		<>
+			{hiddenLabel && (
+				<div className={styles.hiddenLabel} id={hiddenLabelId}>
+					{hiddenLabel}
+				</div>
+			)}
+			{children}
+		</>,
 	);
 };
 
@@ -64,7 +75,7 @@ export const FormLabelText: React.FC<FormLabelTextProps> = ({
 };
 
 export const ErrorMessage: React.FC<ErrorMessageProps> = ({ id, children }) => (
-	<p id={id} className={styles.errorMessage}>
+	<p id={id} className={styles.errorMessage} role="alert">
 		{children}
 	</p>
 );


### PR DESCRIPTION
#### Fixes [AB#101581](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/101581)

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable Azure Pipelines for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Adding `hiddenLabel` prop to `FFInputDate`.
When `FFInputDate` does not receive `label` property, we might want to add some content for `aria-describedby`, otherwise NVDA users might not have enough information.