### PR TITLE
Add a check for vulnerabilities to the build pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,12 @@ jobs:
       - task: Yarn@3
         inputs:
           projectDirectory: '$(Build.SourcesDirectory)\react-components'
+          arguments: 'audit --level moderate --groups dependencies'
+        displayName: yarn audit
+
+      - task: Yarn@3
+        inputs:
+          projectDirectory: '$(Build.SourcesDirectory)\react-components'
           arguments: '--frozen-lockfile'
         displayName: yarn install
 

--- a/package.json
+++ b/package.json
@@ -96,7 +96,10 @@
 		"jest-diff": "25.1.0",
 		"pretty-format": "25.1.0",
 		"react": "16.14.0",
-		"react-dom": "16.14.0"
+		"react-dom": "16.14.0",
+		"lodash": "4.17.21",
+		"hosted-git-info": "3.0.8",
+		"trim-newlines": "3.0.1"
 	},
 	"lint-staged": {
 		"*.{ts,tsx}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3674,7 +3674,7 @@
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
 "@tpr/core@file:./packages/core":
-  version "2.4.33"
+  version "2.6.0"
   dependencies:
     "@xstate/react" "^1.2.2"
     final-form "^4.20.1"
@@ -3685,7 +3685,7 @@
     xstate "^4.16.2"
 
 "@tpr/forms@file:./packages/forms":
-  version "3.2.14"
+  version "3.2.25"
   dependencies:
     "@types/lodash.isequal" "^4.5.5"
     "@types/lodash.merge" "^4.6.6"
@@ -3704,14 +3704,14 @@
     tslib "^2.1.0"
 
 "@tpr/icons@file:./packages/icons":
-  version "3.0.36"
+  version "3.1.0"
   dependencies:
     node-sass "^5.0.0"
     normalize.css "^8.0.1"
     tslib "^2.1.0"
 
 "@tpr/layout@file:./packages/layout":
-  version "2.4.16"
+  version "2.5.3"
   dependencies:
     "@types/lodash.merge" "^4.6.6"
     "@xstate/react" "^1.2.2"
@@ -3726,7 +3726,7 @@
     xstate "^4.16.2"
 
 "@tpr/theming@file:./packages/theming":
-  version "2.2.25"
+  version "2.2.28"
   dependencies:
     node-sass "^5.0.0"
     normalize.css "^8.0.1"
@@ -10586,15 +10586,10 @@ homedir-polyfill@^1.0.1:
   dependencies:
     parse-passwd "^1.0.0"
 
-hosted-git-info@^2.1.4, hosted-git-info@^2.7.1:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
-  integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
-
-hosted-git-info@^3.0.6:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.7.tgz#a30727385ea85acfcee94e0aad9e368c792e036c"
-  integrity sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==
+hosted-git-info@3.0.8, hosted-git-info@^2.1.4, hosted-git-info@^2.7.1, hosted-git-info@^3.0.6:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.8.tgz#6e35d4cc87af2c5f816e4cb9ce350ba87a3f370d"
+  integrity sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -12912,15 +12907,10 @@ lodash.without@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
   integrity sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=
 
-lodash@4.17.14:
-  version "4.17.14"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
-  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
-
-lodash@4.x, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.10:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+lodash@4.17.14, lodash@4.17.21, lodash@4.x, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.10:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^2.1.0, log-symbols@^2.2.0:
   version "2.2.0"
@@ -19198,20 +19188,10 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
-trim-newlines@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
-  integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
-
-trim-newlines@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
-  integrity sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=
-
-trim-newlines@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.0.tgz#79726304a6a898aa8373427298d54c2ee8b1cb30"
-  integrity sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==
+trim-newlines@3.0.1, trim-newlines@^1.0.0, trim-newlines@^2.0.0, trim-newlines@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
+  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
 trim-off-newlines@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Add a check for vulnerabilities to the build pipeline, so that the pipeline fails if we have vulnerable dependencies.

Address the vulnerabilities we currently have (except those which are only used for the Netlify site - which is a lot).