### PR TITLE
Add default spacing after button, hint and helplink

### DIFF
--- a/packages/core/src/components/buttons/buttons.module.scss
+++ b/packages/core/src/components/buttons/buttons.module.scss
@@ -4,6 +4,7 @@
 	display: inline-block;
 	position: relative;
 	cursor: pointer;
+	margin-bottom: $space-3;
 }
 
 .button + .button {

--- a/packages/layout/src/components/helplink/helplink.mdx
+++ b/packages/layout/src/components/helplink/helplink.mdx
@@ -19,9 +19,24 @@ import { HelpLink } from '@tpr/layout';
 
 <Playground>
 	<HelpLink title="This is a title passed by props">
-		<p>Help text will go here, <a href="/record-keeping?psr=10000754">Link in help text</a>. Lucas ipsum dolor sit amet wookiee skywalker antilles yoda antilles hutt luke grievous darth darth. Hutt obi-wan maul vader. Owen han skywalker moff obi-wan kashyyyk bespin moff darth. Palpatine organa qui-gon lars darth. Gamorrean jango fett amidala luuke jawa. Hutt moff darth grievous coruscant jar ben skywalker. Jabba organa cade windu lars mon. Darth fisto dantooine qui-gon jabba qui-gon sidious palpatine dooku. Darth darth hutt k-3po tatooine. Padmé mandalore wampa darth moff. Wampa hutt jabba binks luke</p>
+		<p>
+			Help text will go here,{' '}
+			<a href="/record-keeping?psr=10000754">Link in help text</a>. Lucas ipsum
+			dolor sit amet wookiee skywalker antilles yoda antilles hutt luke grievous
+			darth darth. Hutt obi-wan maul vader. Owen han skywalker moff obi-wan
+			kashyyyk bespin moff darth. Palpatine organa qui-gon lars darth. Gamorrean
+			jango fett amidala luuke jawa. Hutt moff darth grievous coruscant jar ben
+			skywalker. Jabba organa cade windu lars mon. Darth fisto dantooine qui-gon
+			jabba qui-gon sidious palpatine dooku. Darth darth hutt k-3po tatooine.
+			Padmé mandalore wampa darth moff. Wampa hutt jabba binks luke
+		</p>
 	</HelpLink>
+	<p>
+		There should be default spacing between the HelpLink component and this
+		paragraph.
+	</p>
 </Playground>
 
 ## API
+
 <Props of={HelpLink} />

--- a/packages/layout/src/components/helplink/helplink.module.scss
+++ b/packages/layout/src/components/helplink/helplink.module.scss
@@ -1,6 +1,10 @@
 @import '@tpr/theming/lib/variables.scss';
 @import '@tpr/theming/lib/accessibility.module.scss';
 
+.helpLink {
+	margin-bottom: $space-4;
+}
+
 .helpLink button[aria-expanded] {
 	display: inline-block;
 	border: none;

--- a/packages/layout/src/components/helplink/helplink.tsx
+++ b/packages/layout/src/components/helplink/helplink.tsx
@@ -21,15 +21,12 @@ export const HelpLink: React.FC<HelpLinkProps> = (props) => {
 		</button>
 	);
 
-	// Create an alert when the component is expanded/collapsed, because the trigger button loses focus which prevents the change to aria-expanded being announced.
+	// Update a status to announce when the component is expanded/collapsed, because the trigger button loses focus which prevents the change to aria-expanded being announced.
 	// Using a ref to get the button element and call its focus() method doesn't work.
-	const [accessibleAlert, setAccessibleAlert] = React.useState<JSX.Element>();
-	function createAccessibleAlert() {
-		return (
-			<p role="alert" className={Styles.visuallyHidden}>
-				{expanded ? 'collapsed' : 'expanded'}
-			</p>
-		);
+	const [accessibleStatus, setAccessibleStatus] = React.useState<string>();
+	function updateStatus() {
+		setAccessibleStatus(expanded ? 'collapsed' : 'expanded');
+		setTimeout(() => setAccessibleStatus(''), 4000);
 	}
 
 	return (
@@ -41,16 +38,18 @@ export const HelpLink: React.FC<HelpLinkProps> = (props) => {
 				overflowWhenOpen="visible"
 				onOpening={() => {
 					setExpanded(true);
-					setAccessibleAlert(createAccessibleAlert());
+					updateStatus();
 				}}
 				onClosing={() => {
 					setExpanded(false);
-					setAccessibleAlert(createAccessibleAlert());
+					updateStatus();
 				}}
 			>
 				<Hint expanded={expanded}>{props.children}</Hint>
+				<p role="status" className={Styles.visuallyHidden}>
+					{accessibleStatus}
+				</p>
 			</Collapsible>
-			{accessibleAlert}
 		</>
 	);
 };

--- a/packages/layout/src/components/hint/hint.mdx
+++ b/packages/layout/src/components/hint/hint.mdx
@@ -5,6 +5,7 @@ route: /layout/hint
 ---
 
 import { Playground } from '@playground';
+import { Props } from 'docz';
 import { useState } from 'react';
 import { Flex, Button } from '@tpr/core';
 import { Hint } from './hint';
@@ -22,25 +23,30 @@ import { Hint } from '@tpr/layout';
 		const [expanded, setExpanded] = useState(false);
 		return (
 			<>
-				<Button onClick={() => setExpanded(!expanded)}>
+				<Button onClick={() => setExpanded(!expanded)} cfg={{ mb: 4 }}>
 					Toggle visibility
 				</Button>
-				<Flex cfg={{ mt: 5 }}>
-					<Hint expanded={expanded}>
-						<p>
-							Lucas ipsum dolor sit amet wookiee skywalker antilles yoda
-							antilles hutt luke grievous darth darth. Hutt obi-wan maul vader.
-							Owen han skywalker moff obi-wan kashyyyk bespin moff darth.
-							Palpatine organa qui-gon lars darth. Gamorrean jango fett amidala
-							luuke jawa. Hutt moff darth grievous coruscant jar ben skywalker.
-							Jabba organa cade windu lars mon. Darth fisto dantooine qui-gon
-							jabba qui-gon sidious palpatine dooku. Darth darth hutt k-3po
-							tatooine. Padmé mandalore wampa darth moff. Wampa hutt jabba binks
-							luke
-						</p>
-					</Hint>
-				</Flex>
+				<Hint expanded={expanded}>
+					<p>
+						Lucas ipsum dolor sit amet wookiee skywalker antilles yoda antilles
+						hutt luke grievous darth darth. Hutt obi-wan maul vader. Owen han
+						skywalker moff obi-wan kashyyyk bespin moff darth. Palpatine organa
+						qui-gon lars darth. Gamorrean jango fett amidala luuke jawa. Hutt
+						moff darth grievous coruscant jar ben skywalker. Jabba organa cade
+						windu lars mon. Darth fisto dantooine qui-gon jabba qui-gon sidious
+						palpatine dooku. Darth darth hutt k-3po tatooine. Padmé mandalore
+						wampa darth moff. Wampa hutt jabba binks luke
+					</p>
+				</Hint>
+				<p>
+					There should be default spacing between the Hint component and this
+					paragraph.
+				</p>
 			</>
 		);
 	}}
 </Playground>
+
+## API
+
+<Props of={Hint} />

--- a/packages/layout/src/components/hint/hint.module.scss
+++ b/packages/layout/src/components/hint/hint.module.scss
@@ -3,8 +3,9 @@
 .root {
 	border-left: 4px solid $colors-neutral-4;
 	color: $colors-neutral-7;
-  line-height: $line-height-3;
+	line-height: $line-height-3;
+	margin-bottom: $space-4;
 }
-.collapsed{
+.collapsed {
 	display: none;
 }

--- a/packages/layout/src/components/hint/hint.tsx
+++ b/packages/layout/src/components/hint/hint.tsx
@@ -1,17 +1,22 @@
 import React from 'react';
 import { Flex } from '@tpr/core';
 import Styles from './hint.module.scss';
+import { render } from 'react-dom';
 
 type HintProps = {
+	className?: string;
 	children?: any;
 	expanded?: boolean;
 };
 
-export const Hint = (props: HintProps) => (
-	<Flex
-		cfg={{ pl: 3 }}
-		className={props.expanded ? Styles.root : Styles.collapsed}
-	>
-		{props.children}
-	</Flex>
-);
+export const Hint = (props: HintProps) => {
+	let className = props.expanded ? Styles.root : Styles.collapsed;
+	if (props.className) {
+		className += ' ' + props.className;
+	}
+	return (
+		<Flex cfg={{ pl: 3 }} className={className}>
+			{props.children}
+		</Flex>
+	);
+};

--- a/packages/layout/src/components/hint/hint.tsx
+++ b/packages/layout/src/components/hint/hint.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Flex } from '@tpr/core';
 import Styles from './hint.module.scss';
-import { render } from 'react-dom';
 
 type HintProps = {
 	className?: string;


### PR DESCRIPTION
This PR does three things:

- Adds default spacing after the `Button`, `Hint` and `HelpLink` components. We never want the next element to butt up against these, and we shouldn't have to set potentially-inconsistent inline styles every time we use them.
- Adds a `className` property to `Hint` so the spacing can be overridden if required. The others already support `className`.
- Improves the accessibility of the `HelpLink` component with an improved technique for announcing the status. Previously it used `role="alert"` which is meant for errors and warnings. Adding a timeout makes it less likely to be announced again as an assistive technology user moves down through the page.