### PR TITLE
Fix accessibility errors identified by MS accessibility insights

### DIFF
--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -42,7 +42,7 @@
 		"@types/lodash.merge": "^4.6.6",
 		"@types/match-sorter": "^4.0.0",
 		"@types/qs": "^6.9.5",
-		"accessible-autocomplete": "^2.0.3",
+		"@financial-times/accessible-autocomplete": "^2.1.2",
 		"date-fns": "^2.17.0",
 		"downshift": "^6.1.0",
 		"final-form": "^4.20.1",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -42,7 +42,7 @@
 		"@types/lodash.merge": "^4.6.6",
 		"@types/match-sorter": "^4.0.0",
 		"@types/qs": "^6.9.5",
-		"@financial-times/accessible-autocomplete": "^2.1.2",
+		"@financial-times/accessible-autocomplete": "^2.2.0",
 		"date-fns": "^2.17.0",
 		"downshift": "^6.1.0",
 		"final-form": "^4.20.1",

--- a/packages/forms/rollup.config.js
+++ b/packages/forms/rollup.config.js
@@ -10,7 +10,7 @@ export default rollup({
 		'@types/lodash.isequal',
 		'@types/match-sorter',
 		'@types/qs',
-		'accessible-autocomplete/react',
+		'@financial-times/accessible-autocomplete/react',
 		'date-fns',
 		'downshift',
 		'final-form',

--- a/packages/forms/src/elements/search/search.tsx
+++ b/packages/forms/src/elements/search/search.tsx
@@ -143,6 +143,7 @@ const Search: React.FC<SearchProps> = React.memo(
 							}}
 							testId={testId}
 							tNoResults={() => notFoundMessage}
+							ariaLabelledBy={helper.labelId}
 						/>
 					</Flex>
 				</StyledInputLabel>

--- a/packages/forms/src/elements/search/search.tsx
+++ b/packages/forms/src/elements/search/search.tsx
@@ -4,7 +4,7 @@ import { Flex } from '@tpr/core';
 import { StyledInputLabel, InputElementHeading } from '../elements';
 import { FieldProps, FieldExtraProps } from '../../renderFields';
 import AccessibilityHelper from '../accessibilityHelper';
-import Autocomplete from 'accessible-autocomplete/react';
+import Autocomplete from '@financial-times/accessible-autocomplete/react';
 import { filterResults, formatItemDefault } from './filterResults';
 import { act } from 'react-dom/test-utils';
 import styles from './search.module.scss';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1959,10 +1959,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@financial-times/accessible-autocomplete@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@financial-times/accessible-autocomplete/-/accessible-autocomplete-2.1.2.tgz#e60ca39c819e52a8dd8a347ddd4f3d273a90bc98"
-  integrity sha512-2vvJ0zqf/2hmGpUZfUAfgUyIYNhpyLfV5oo3GrrXIMZaX3kvxZav8QciLLkC9/OtY7IyEJLzXiGXEoKKJlrsZA==
+"@financial-times/accessible-autocomplete@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@financial-times/accessible-autocomplete/-/accessible-autocomplete-2.2.0.tgz#7c83af698f60f0984bf5b24a42ca9840e2d32a6b"
+  integrity sha512-vp8GFvl+8a0+5IT89SD/jRho8Wl/y8Vveb8Rf14pkpN/LLDphITXWASvCFPmp0xuC5E1pc8hDKCVmdwntYiszQ==
   dependencies:
     preact "^8.3.1"
 
@@ -3692,9 +3692,9 @@
     xstate "^4.16.2"
 
 "@tpr/forms@file:./packages/forms":
-  version "3.2.25"
+  version "3.2.26"
   dependencies:
-    "@financial-times/accessible-autocomplete" "^2.1.2"
+    "@financial-times/accessible-autocomplete" "^2.2.0"
     "@types/lodash.isequal" "^4.5.5"
     "@types/lodash.merge" "^4.6.6"
     "@types/match-sorter" "^4.0.0"
@@ -3718,7 +3718,7 @@
     tslib "^2.1.0"
 
 "@tpr/layout@file:./packages/layout":
-  version "2.5.3"
+  version "2.5.4"
   dependencies:
     "@types/lodash.merge" "^4.6.6"
     "@xstate/react" "^1.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1959,6 +1959,13 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@financial-times/accessible-autocomplete@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@financial-times/accessible-autocomplete/-/accessible-autocomplete-2.1.2.tgz#e60ca39c819e52a8dd8a347ddd4f3d273a90bc98"
+  integrity sha512-2vvJ0zqf/2hmGpUZfUAfgUyIYNhpyLfV5oo3GrrXIMZaX3kvxZav8QciLLkC9/OtY7IyEJLzXiGXEoKKJlrsZA==
+  dependencies:
+    preact "^8.3.1"
+
 "@graphql-tools/batch-execute@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/batch-execute/-/batch-execute-7.0.0.tgz#e79d11bd5b39f29172f6ec2eafa71103c6a6c85b"
@@ -3687,11 +3694,11 @@
 "@tpr/forms@file:./packages/forms":
   version "3.2.25"
   dependencies:
+    "@financial-times/accessible-autocomplete" "^2.1.2"
     "@types/lodash.isequal" "^4.5.5"
     "@types/lodash.merge" "^4.6.6"
     "@types/match-sorter" "^4.0.0"
     "@types/qs" "^6.9.5"
-    accessible-autocomplete "^2.0.3"
     date-fns "^2.17.0"
     downshift "^6.1.0"
     final-form "^4.20.1"
@@ -4403,13 +4410,6 @@ accepts@^1.3.7, accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   dependencies:
     mime-types "~2.1.24"
     negotiator "0.6.2"
-
-accessible-autocomplete@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-2.0.3.tgz#3ed8d529b227b77e99ab509eec5d2c8d1b8bea8b"
-  integrity sha512-bUswBs/mDH17dUFRAJMTtcGafJ++w1YLPPFjdfJj3lnuBsLpByAw2gmr8qxXX8oc7tzoKS3Ay5FKOPM+WMBxIw==
-  dependencies:
-    preact "^8.3.1"
 
 acorn-globals@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Fixes [AB#99763](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/99763) and [AB#99762](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/99762) by switching to a maintained fork of the GOV.UK accessible autocomplete which has bug fixes and to which we can contribute. Uses the new `ariaLabelledBy` property to connect the results list to the field label.
