### PR TITLE
Import minor fix on our contribution to accessible-autocomplete

### DIFF
--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -38,7 +38,7 @@
 		"react-dom": "^16.14.0"
 	},
 	"dependencies": {
-		"@financial-times/accessible-autocomplete": "^2.2.0",
+		"@financial-times/accessible-autocomplete": "^2.2.1",
 		"@types/lodash.isequal": "^4.5.5",
 		"@types/lodash.merge": "^4.6.6",
 		"@types/match-sorter": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1959,10 +1959,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@financial-times/accessible-autocomplete@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@financial-times/accessible-autocomplete/-/accessible-autocomplete-2.2.0.tgz#7c83af698f60f0984bf5b24a42ca9840e2d32a6b"
-  integrity sha512-vp8GFvl+8a0+5IT89SD/jRho8Wl/y8Vveb8Rf14pkpN/LLDphITXWASvCFPmp0xuC5E1pc8hDKCVmdwntYiszQ==
+"@financial-times/accessible-autocomplete@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@financial-times/accessible-autocomplete/-/accessible-autocomplete-2.2.1.tgz#96684e05e68ddf49ff381583d38ecf9a89608d6d"
+  integrity sha512-BPmSVTjXmAK0xk+hnzqrIb3Y7Z5J/11iYtLyvG4OU6FTSoYzoEYg3FhyhmvsLHVayKrL+/QFnd1qDP97elb6TA==
   dependencies:
     preact "^8.3.1"
 
@@ -3681,7 +3681,7 @@
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
 "@tpr/core@file:./packages/core":
-  version "2.6.0"
+  version "2.6.1"
   dependencies:
     "@xstate/react" "^1.2.2"
     final-form "^4.20.1"
@@ -3692,9 +3692,9 @@
     xstate "^4.16.2"
 
 "@tpr/forms@file:./packages/forms":
-  version "3.2.26"
+  version "3.2.28"
   dependencies:
-    "@financial-times/accessible-autocomplete" "^2.2.0"
+    "@financial-times/accessible-autocomplete" "^2.2.1"
     "@types/lodash.isequal" "^4.5.5"
     "@types/lodash.merge" "^4.6.6"
     "@types/match-sorter" "^4.0.0"
@@ -3711,14 +3711,14 @@
     tslib "^2.1.0"
 
 "@tpr/icons@file:./packages/icons":
-  version "3.1.0"
+  version "3.1.1"
   dependencies:
     node-sass "^5.0.0"
     normalize.css "^8.0.1"
     tslib "^2.1.0"
 
 "@tpr/layout@file:./packages/layout":
-  version "2.5.4"
+  version "2.5.6"
   dependencies:
     "@types/lodash.merge" "^4.6.6"
     "@xstate/react" "^1.2.2"


### PR DESCRIPTION
Import minor fix on our contribution to financial-times/accessible-autocomplete for [AB#99762](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/99762) [AB#99763](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/99763).

Doesn't need an immediate publish of a new version - can wait for the next change.