### PR TITLE
Most field types were announcing errors twice, due to a fix for the date field

### DIFF
--- a/packages/forms/src/elements/date/date.mdx
+++ b/packages/forms/src/elements/date/date.mdx
@@ -42,35 +42,58 @@ import { FFInputDate } from '@tpr/forms';
 
 [CodeSandbox](https://codesandbox.io/s/nice-dream-xs3zp)
 
+The first example shows all fields, and validation for a specific date range. Any date in 2021 is valid.
+
 <Playground>
-	{() => {
-		const fields = [
-			{
-				id: 'sample-date1',
-				type: 'date',
-				name: 'passport-issued1',
-				label: 'When was your passport issued?',
-				hint: 'For example, 12 11 2007',
-				error: 'The date your passport was issued must be in the past',
-			},
-		];
-		return (
-			<Form
-				onSubmit={(val) => console.log(val)}
-				initialValues={{ 'passport-issued1': null }}
-				validate={validate(fields)}
-			>
-				{({ handleSubmit }) => (
-					<form onSubmit={handleSubmit} style={{ padding: 10 }}>
-						{renderFields(fields)}
-						<button type="submit" style={{ display: 'none' }}>
-							Submit
-						</button>
-					</form>
-				)}
-			</Form>
-		);
-	}}
+
+    {() => {
+    	function isValidDate(d) {
+    		return d instanceof Date && !isNaN(d);
+    	}
+    	const fields = [
+    		{
+    			id: 'sample-date1',
+    			type: 'date',
+    			name: 'passport-issued1',
+    			label: 'When was your passport issued?',
+    			hint: 'For example, 12 11 2021',
+    			error: 'The date your passport was issued must be in the past',
+    			validate: (value) => {
+    				const now = new Date();
+    				const d = new Date(value);
+    				if (!isValidDate(d)) {
+    					return "That's an invalid date";
+    				} else {
+    					if (d.getFullYear() == '2021') {
+    						return undefined;
+    					}
+    					if (d < now) {
+    						return 'That date is in the past';
+    					}
+    					if (d > now) {
+    						return 'That date is in the future';
+    					}
+    				}
+    			},
+    		},
+    	];
+    	return (
+    		<Form
+    			onSubmit={(val) => console.log(val)}
+    			initialValues={{ 'passport-issued1': null }}
+    		>
+    			{({ handleSubmit }) => (
+    				<form onSubmit={handleSubmit} style={{ padding: 10 }}>
+    					{renderFields(fields)}
+    					<button type="submit" style={{ display: 'none' }}>
+    						Submit
+    					</button>
+    				</form>
+    			)}
+    		</Form>
+    	);
+    }}
+
 </Playground>
 
 ### hiding Day and only displaying Month & Year

--- a/packages/forms/src/elements/date/date.tsx
+++ b/packages/forms/src/elements/date/date.tsx
@@ -210,7 +210,9 @@ export const InputDate: React.FC<InputDateComponentProps> = memo(
 					hint={hint}
 					meta={meta}
 					accessibilityHelper={helper}
+					errorRole="alert"
 				/>
+
 				<Flex>
 					{!hideDay && (
 						<DateInputField

--- a/packages/forms/src/elements/elements.tsx
+++ b/packages/forms/src/elements/elements.tsx
@@ -74,14 +74,21 @@ export const FormLabelText: React.FC<FormLabelTextProps> = ({
 	);
 };
 
-export const ErrorMessage: React.FC<ErrorMessageProps> = ({ id, children }) => (
-	<p id={id} className={styles.errorMessage} role="alert">
+export const ErrorMessage: React.FC<ErrorMessageProps> = ({
+	id,
+	children,
+	role,
+}) => (
+	<p id={id} className={styles.errorMessage} role={role}>
 		{children}
 	</p>
 );
 
+// `role` is optional because, for an error related to a single field, linking it to the error using aria-describedby works best.
+// For a multi-field entry with a combined error (date) it works better to use role="alert".
 type ErrorMessageProps = {
 	id?: string;
+	role?: 'alert' | undefined;
 	children: ReactNode;
 };
 
@@ -93,6 +100,7 @@ type InputElementHeadingProps = {
 	meta?: any;
 	accessibilityHelper: AccessibilityHelper;
 	labelNotBold?: boolean;
+	errorRole?: 'alert' | undefined;
 };
 export const InputElementHeading: React.FC<InputElementHeadingProps> = ({
 	element = 'div',
@@ -102,6 +110,7 @@ export const InputElementHeading: React.FC<InputElementHeadingProps> = ({
 	meta,
 	accessibilityHelper,
 	labelNotBold,
+	errorRole,
 }) => {
 	return (
 		<>
@@ -124,7 +133,7 @@ export const InputElementHeading: React.FC<InputElementHeadingProps> = ({
 				</Span>
 			)}
 			{meta && meta.touched && meta.error && (
-				<ErrorMessage id={accessibilityHelper.errorId}>
+				<ErrorMessage id={accessibilityHelper.errorId} role={errorRole}>
 					{meta.error}
 				</ErrorMessage>
 			)}

--- a/packages/forms/src/elements/number/number.mdx
+++ b/packages/forms/src/elements/number/number.mdx
@@ -43,9 +43,9 @@ import { FFInputNumber } from '@tpr/forms';
 [CodeSandbox](https://codesandbox.io)
 
 <Playground>
-	<Form 
+	<Form
 		onSubmit={(values) => console.log(values)}
-		initialValues={{rpiIncrease: 2.5}}
+		initialValues={{ rpiIncrease: 2.5 }}
 	>
 		{({ handleSubmit }) => (
 			<form onSubmit={handleSubmit}>
@@ -58,10 +58,12 @@ import { FFInputNumber } from '@tpr/forms';
 					required={true}
 					maxLength={2}
 					validate={(value) => {
-						if (value < 1 || value > 20 || !value || value === 0) {
+						if (!value) {
+							return 'This field is required ';
+						}
+						if (value < 1 || value > 20) {
 							return 'Must be between 1 and 20';
 						}
-						return undefined;
 					}}
 					callback={(e) => console.log(e.target.value)}
 				/>
@@ -212,6 +214,7 @@ import { Form, validate, renderFields } from '@tpr/forms';
 </Playground>
 
 ### With aria label extension
+
 ```js
 i18n={{ ariaLabelExtension: 'in years' }}
 ```
@@ -249,8 +252,9 @@ i18n={{ ariaLabelExtension: 'in years' }}
 </Playground>
 
 ### With customised aria label
+
 ```js
-aria-label="Age of the applicant in years.  Use whole numbers only."
+aria - label = 'Age of the applicant in years.  Use whole numbers only.';
 ```
 
 <Playground>
@@ -293,8 +297,8 @@ Accepted config props: FlexProps, SpaceProps
 
 ### Props
 
-| Property      | Required | Type     | Description                                                                                                                                                                   |
-| ------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Property      | Required | Type                                  | Description                                                                                                                                      |
+| ------------- | -------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | after         | false    | string                                | emulates text passed to ::after pseudo-selector                                                                                                  |
 | before        | false    | string                                | emulates text passed to ::before pseudo-selector                                                                                                 |
 | callback      | false    | function                              | callback function to be executed after onChange                                                                                                  |


### PR DESCRIPTION
ErrorMessage with 'role=alert' were introduced to ensure the date field announced changes to its error message, but caused errors to be announced twice for other field types. 

#### Fixes [AB#103327](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/103327)
