### PR TITLE
Add wrapperElement property to FFInputNumber

### DIFF
--- a/packages/forms/src/__tests__/number.spec.tsx
+++ b/packages/forms/src/__tests__/number.spec.tsx
@@ -59,6 +59,33 @@ describe('Number', () => {
 			expect(getByTestId(testId)).toHaveValue(123);
 		});
 
+		test('default wrapper element is label', () => {
+			const { getByText } = formSetup({
+				render: numberComponent,
+			});
+
+			const label = getByText(/Number/);
+
+			expect(label.parentElement.tagName).toBe('LABEL');
+		});
+
+		test('wrapper element can be changed', () => {
+			const { getByText } = formSetup({
+				render: (
+					<FFInputNumber
+						label="Number"
+						testId={testId}
+						name="number"
+						wrapperElement="div"
+					/>
+				),
+			});
+
+			const label = getByText(/Number/);
+
+			expect(label.parentElement.tagName).toBe('DIV');
+		});
+
 		test('label renders with an id attribute', () => {
 			const { getByText } = formSetup({
 				render: numberComponent,

--- a/packages/forms/src/elements/currency/currency.tsx
+++ b/packages/forms/src/elements/currency/currency.tsx
@@ -16,12 +16,12 @@ import {
 	getNumberOfCommas,
 	calculateCursorPosition,
 } from '../helpers';
-import { FieldWithAriaLabelExtenstionI18nProps } from 'types/FieldWithAriaLabelExtensionI18nProps';
+import { FieldWithAriaLabelExtensionI18nProps } from 'types/FieldWithAriaLabelExtensionI18nProps';
 import { FieldWithAriaLabelExtensionProps } from '../../types/FieldWithAriaLabelExtensionProps';
 import { RecursivePartial } from 'types/RecursivePartial';
 import AccessibilityHelper from '../accessibilityHelper';
 
-let currencyFieldI18nDefaults: FieldWithAriaLabelExtenstionI18nProps = {
+let currencyFieldI18nDefaults: FieldWithAriaLabelExtensionI18nProps = {
 	ariaLabelExtension: ', in pounds',
 };
 
@@ -33,7 +33,7 @@ interface InputCurrencyProps extends FieldRenderProps<number>, FieldExtraProps {
 	noLeftBorder?: boolean;
 	optionalText?: boolean;
 	maxInputLength?: number;
-	i18n?: RecursivePartial<FieldWithAriaLabelExtenstionI18nProps>;
+	i18n?: RecursivePartial<FieldWithAriaLabelExtensionI18nProps>;
 }
 
 const InputCurrency: React.FC<InputCurrencyProps> = React.memo(

--- a/packages/forms/src/elements/number/number.mdx
+++ b/packages/forms/src/elements/number/number.mdx
@@ -297,21 +297,22 @@ Accepted config props: FlexProps, SpaceProps
 
 ### Props
 
-| Property      | Required | Type                                  | Description                                                                                                                                      |
-| ------------- | -------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| after         | false    | string                                | emulates text passed to ::after pseudo-selector                                                                                                  |
-| before        | false    | string                                | emulates text passed to ::before pseudo-selector                                                                                                 |
-| callback      | false    | function                              | callback function to be executed after onChange                                                                                                  |
-| cfg           | false    | object                                | FlexProps & SpaceProps                                                                                                                           |
-| decimalPlaces | false    | number                                | the number of decimal places used for formatting the value                                                                                       |
-| disabled      | false    | boolean                               | Disable input field                                                                                                                              |
-| hint          | false    | string                                | More detailed description about the field                                                                                                        |
-| label         | true     | string                                | The visible label displayed above the input field                                                                                                |
-| aria-label    | true     | string                                | Use to provide descriptive labelling to assistive technology in situations where the visible label does not convey the full context of the input |
-| maxIntDigits  | false    | number                                | sets a maximum length for the integer part of the value                                                                                          |
-| maxLength     | false    | number                                | sets a maximum length for the input value (e.g. 123.00 &#x27A1; maxLength={6})                                                                   |
-| noLeftBorder  | false    | boolean                               | disables the left border when detecting error                                                                                                    |
-| optionalText  | false    | boolean                               | allows hiding "optional" text when field is not required                                                                                         |
-| testId        | false    | string                                | data attribute for testers                                                                                                                       |
-| readOnly      | false    | boolean                               | Sets whether the field is read only                                                                                                              |
-| i18n          | false    | FieldWithAriaLabelExtenstionI18nProps | allows the overridding of default text in the number input                                                                                       |
+| Property       | Required | Type                                  | Description                                                                                                                                      |
+| -------------- | -------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| after          | false    | string                                | emulates text passed to ::after pseudo-selector                                                                                                  |
+| before         | false    | string                                | emulates text passed to ::before pseudo-selector                                                                                                 |
+| callback       | false    | function                              | callback function to be executed after onChange                                                                                                  |
+| cfg            | false    | object                                | FlexProps & SpaceProps                                                                                                                           |
+| decimalPlaces  | false    | number                                | the number of decimal places used for formatting the value                                                                                       |
+| disabled       | false    | boolean                               | Disable input field                                                                                                                              |
+| hint           | false    | string                                | More detailed description about the field                                                                                                        |
+| label          | true     | string                                | The visible label displayed above the input field                                                                                                |
+| aria-label     | true     | string                                | Use to provide descriptive labelling to assistive technology in situations where the visible label does not convey the full context of the input |
+| maxIntDigits   | false    | number                                | sets a maximum length for the integer part of the value                                                                                          |
+| maxLength      | false    | number                                | sets a maximum length for the input value (e.g. 123.00 &#x27A1; maxLength={6})                                                                   |
+| noLeftBorder   | false    | boolean                               | disables the left border when detecting error                                                                                                    |
+| optionalText   | false    | boolean                               | allows hiding "optional" text when field is not required                                                                                         |
+| testId         | false    | string                                | data attribute for testers                                                                                                                       |
+| readOnly       | false    | boolean                               | Sets whether the field is read only                                                                                                              |
+| i18n           | false    | FieldWithAriaLabelExtenstionI18nProps | allows the overridding of default text in the number input                                                                                       |
+| wrapperElement | false    | string                                | replaces the `<label>` with a different element, for use in combination with an alternative labelling technique such as aria-labelledby          |

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -23,6 +23,7 @@ interface InputNumberProps extends FieldRenderProps<number>, FieldExtraProps {
 	maxLength?: number;
 	maxIntDigits?: number;
 	i18n?: RecursivePartial<FieldWithAriaLabelExtensionI18nProps>;
+	wrapperElement?: 'label' | 'div' | 'fieldset';
 }
 
 const InputNumber: React.FC<InputNumberProps> = ({
@@ -48,6 +49,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 	maxIntDigits,
 	i18n = numberFieldI18nDefaults,
 	initialValue,
+	wrapperElement = 'label',
 	...props
 }) => {
 	const digits = [
@@ -168,6 +170,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 			isError={meta && meta.touched && meta.error}
 			cfg={Object.assign({ flexDirection: 'column', mt: 1 }, cfg)}
 			noLeftBorder={noLeftBorder}
+			element={wrapperElement}
 		>
 			<InputElementHeading
 				label={label}
@@ -202,9 +205,11 @@ const InputNumber: React.FC<InputNumberProps> = ({
 	);
 };
 
-export const FFInputNumber: React.FC<FieldWithAriaLabelExtensionProps> = (
-	fieldProps,
-) => {
+export interface FFInputNumberProps extends FieldWithAriaLabelExtensionProps {
+	wrapperElement?: 'label' | 'div' | 'fieldset';
+}
+
+export const FFInputNumber: React.FC<FFInputNumberProps> = (fieldProps) => {
 	return (
 		<Field
 			{...fieldProps}

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -4,12 +4,12 @@ import { StyledInputLabel, InputElementHeading } from '../elements';
 import { FieldExtraProps } from '../../renderFields';
 import { Input } from '../input/input';
 import { adaptValueToFormat, fixToDecimals, validKeys as vk } from '../helpers';
-import { FieldWithAriaLabelExtenstionI18nProps } from 'types/FieldWithAriaLabelExtensionI18nProps';
+import { FieldWithAriaLabelExtensionI18nProps } from 'types/FieldWithAriaLabelExtensionI18nProps';
 import { FieldWithAriaLabelExtensionProps } from '../../types/FieldWithAriaLabelExtensionProps';
 import { RecursivePartial } from 'types/RecursivePartial';
 import AccessibilityHelper from '../accessibilityHelper';
 
-let numberFieldI18nDefaults: FieldWithAriaLabelExtenstionI18nProps = {
+let numberFieldI18nDefaults: FieldWithAriaLabelExtensionI18nProps = {
 	ariaLabelExtension: null,
 };
 
@@ -22,7 +22,7 @@ interface InputNumberProps extends FieldRenderProps<number>, FieldExtraProps {
 	optionalText?: boolean;
 	maxLength?: number;
 	maxIntDigits?: number;
-	i18n?: RecursivePartial<FieldWithAriaLabelExtenstionI18nProps>;
+	i18n?: RecursivePartial<FieldWithAriaLabelExtensionI18nProps>;
 }
 
 const InputNumber: React.FC<InputNumberProps> = ({

--- a/packages/forms/src/types/FieldWithAriaLabelExtensionI18nProps.ts
+++ b/packages/forms/src/types/FieldWithAriaLabelExtensionI18nProps.ts
@@ -1,3 +1,3 @@
-export type FieldWithAriaLabelExtenstionI18nProps = {
+export type FieldWithAriaLabelExtensionI18nProps = {
 	ariaLabelExtension: string;
 };

--- a/packages/forms/src/types/FieldWithAriaLabelExtensionProps.ts
+++ b/packages/forms/src/types/FieldWithAriaLabelExtensionProps.ts
@@ -1,7 +1,7 @@
 import { FieldProps } from '../renderFields';
-import { FieldWithAriaLabelExtenstionI18nProps } from './FieldWithAriaLabelExtensionI18nProps';
+import { FieldWithAriaLabelExtensionI18nProps as FieldWithAriaLabelExtensionI18nProps } from './FieldWithAriaLabelExtensionI18nProps';
 import { RecursivePartial } from './RecursivePartial';
 
 export interface FieldWithAriaLabelExtensionProps extends FieldProps {
-	i18n?: RecursivePartial<FieldWithAriaLabelExtenstionI18nProps>;
+	i18n?: RecursivePartial<FieldWithAriaLabelExtensionI18nProps>;
 }


### PR DESCRIPTION
[AB#106424](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/106424) requires `FFInputNumber` to support using an element other than `<label>` for its wrapper element. Internally the wrapper component already supports an `element` property, so expose that as `wrapperElement`. Default to the existing and most common element, `<label>`, making the change non-breaking.

Also fixes a typo found in existing code.