### PR TITLE
fix failing tests for FFInputDate

### DIFF
--- a/packages/forms/src/__tests__/date.spec.tsx
+++ b/packages/forms/src/__tests__/date.spec.tsx
@@ -88,9 +88,9 @@ describe('Date input', () => {
 		expect(fieldset).not.toBeNull();
 		expect(fieldset).toHaveAttribute('aria-labelledby', `${id}-label`);
 		expect(fieldset).toHaveAttribute('aria-describedby', `${id}-hint`);
-		expect(dd).toHaveAttribute('type', 'string');
-		expect(mm).toHaveAttribute('type', 'string');
-		expect(yyyy).toHaveAttribute('type', 'string');
+		expect(dd).toHaveAttribute('type', 'number');
+		expect(mm).toHaveAttribute('type', 'number');
+		expect(yyyy).toHaveAttribute('type', 'number');
 
 		const submit = container.querySelector('button[type="submit"]');
 


### PR DESCRIPTION
#### Fixes [AB#106421](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/106421)

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable Azure Pipelines for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

fix tests failing after changing input type in FFinputDate
