### PR TITLE
'Confirm details are correct' label on cards should be more specific

### DIFF
--- a/packages/layout/src/components/__tests__/actuary.spec.tsx
+++ b/packages/layout/src/components/__tests__/actuary.spec.tsx
@@ -91,7 +91,6 @@ describe('Actuary Card', () => {
 		test('initial status is correct', () => {
 			expect(findAllByText('Confirmed').length).toEqual(1);
 			expect(findByTitle('Confirmed')).toBeDefined();
-			expect(findByText('Confirm details are correct.')).toBeDefined();
 		});
 
 		test('displays Name Correctly', () => {
@@ -122,6 +121,10 @@ describe('Actuary Card', () => {
 				findByRole,
 				`${actuary.title} ${actuary.firstName} ${actuary.lastName} Actuary`,
 			);
+		});
+
+		test('replaces __NAME__ in the checkbox label', () => {
+			expect(findByText("Confirm 'Mr John Johnson' is correct.")).toBeDefined();
 		});
 	});
 

--- a/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
+++ b/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
@@ -94,7 +94,6 @@ describe('Corporate Group Trustee Card', () => {
 		test('initial status is correct', () => {
 			expect(findAllByText('Confirmed').length).toEqual(1);
 			expect(findByTitle('Confirmed')).toBeDefined();
-			expect(findByText('Confirm details are correct.')).toBeDefined();
 		});
 
 		test('Organisation block displays values correctly', () => {
@@ -124,6 +123,12 @@ describe('Corporate Group Trustee Card', () => {
 				findByRole,
 				`${corporateGroup.organisationName} Corporate Group trustee`,
 			);
+		});
+
+		test('replaces __NAME__ in the checkbox label', () => {
+			expect(
+				findByText(`Confirm '${corporateGroup.organisationName}' is correct.`),
+			).toBeDefined();
 		});
 	});
 

--- a/packages/layout/src/components/__tests__/employer.spec.tsx
+++ b/packages/layout/src/components/__tests__/employer.spec.tsx
@@ -64,6 +64,21 @@ describe('Employer Preview', () => {
 			employer.organisationName,
 		);
 	});
+
+	test('replaces __NAME__ in the checkbox label', () => {
+		const { findByText } = render(
+			<EmployerCard
+				onSaveType={noop}
+				onRemove={noop}
+				complete={true}
+				employer={employer}
+			/>,
+		);
+
+		expect(
+			findByText(`Confirm '${employer.organisationName}' is correct.`),
+		).toBeDefined();
+	});
 });
 
 describe('Employer type', () => {

--- a/packages/layout/src/components/__tests__/inHouse.spec.tsx
+++ b/packages/layout/src/components/__tests__/inHouse.spec.tsx
@@ -79,6 +79,10 @@ describe('InHouse Preview', () => {
 		assertThatButtonHasAriaExpanded(findByText, 'Contact details', false);
 	});
 
+	test('replaces __NAME__ in the checkbox label', () => {
+		expect(findByText(`Confirm 'Mr John Smoth' is correct.`)).toBeDefined();
+	});
+
 	test('editing in house name', () => {
 		findByText('In House Administrator').click();
 		expect(findByTestId('inHouseAdmin-name-form')).not.toBe(null);

--- a/packages/layout/src/components/__tests__/independentTrustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/independentTrustee.spec.tsx
@@ -85,7 +85,6 @@ describe('Professional / Independent Trustee Card', () => {
 		test('initial status is correct', () => {
 			expect(findAllByText('Confirmed').length).toEqual(1);
 			expect(findByTitle('Confirmed')).toBeDefined();
-			expect(findByText('Confirm details are correct.')).toBeDefined();
 		});
 
 		test('Organisation block displays values correctly', () => {
@@ -109,6 +108,14 @@ describe('Professional / Independent Trustee Card', () => {
 				findByRole,
 				`${independentTrustee.organisationName} Professional / Independent Trustee`,
 			);
+		});
+
+		test('replaces __NAME__ in the checkbox label', () => {
+			expect(
+				findByText(
+					`Confirm '${independentTrustee.organisationName}' is correct.`,
+				),
+			).toBeDefined();
 		});
 	});
 

--- a/packages/layout/src/components/__tests__/insurer.spec.tsx
+++ b/packages/layout/src/components/__tests__/insurer.spec.tsx
@@ -71,6 +71,22 @@ describe('Insurer Preview', () => {
 			`${insurer.organisationName} Insurer administrator`,
 		);
 	});
+
+	test('replaces __NAME__ in the checkbox label', () => {
+		const { findByText } = render(
+			<InsurerCard
+				onSaveRef={noop}
+				onRemove={noop}
+				onCorrect={noop}
+				complete={true}
+				insurer={insurer}
+			/>,
+		);
+
+		expect(
+			findByText(`Confirm '${insurer.organisationName}' is correct.`),
+		).toBeDefined();
+	});
 });
 
 describe('Insurer Remove', () => {

--- a/packages/layout/src/components/__tests__/thirdParty.spec.tsx
+++ b/packages/layout/src/components/__tests__/thirdParty.spec.tsx
@@ -54,6 +54,21 @@ describe('ThirdParty Preview', () => {
 			`${thirdPartyAdmin.organisationName} Third Party Administrator`,
 		);
 	});
+
+	test('replaces __NAME__ in the checkbox label', () => {
+		const { findByText } = render(
+			<ThirdPartyCard
+				onRemove={noop}
+				onCorrect={noop}
+				complete={true}
+				thirdParty={thirdPartyAdmin}
+			/>,
+		);
+
+		expect(
+			findByText(`Confirm '${thirdPartyAdmin.organisationName}' is correct.`),
+		).toBeDefined();
+	});
 });
 
 describe('ThirdParty Remove', () => {

--- a/packages/layout/src/components/__tests__/trustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/trustee.spec.tsx
@@ -121,7 +121,6 @@ describe('TrusteeCard enableContactDetails == true', () => {
 		test('initial status is correct', () => {
 			expect(findAllByText('Confirmed').length).toEqual(1);
 			expect(findByTitle('Confirmed')).toBeDefined();
-			expect(findByText('Confirm details are correct.')).toBeDefined();
 		});
 
 		test('address shows up correctly', () => {
@@ -145,6 +144,10 @@ describe('TrusteeCard enableContactDetails == true', () => {
 				findByRole,
 				`${trustee.title} ${trustee.firstName} ${trustee.lastName} ${trustee.trusteeType} Trustee`,
 			);
+		});
+
+		test('replaces __NAME__ in the checkbox label', () => {
+			expect(findByText(`Confirm 'Mr John Smith' is correct.`)).toBeDefined();
 		});
 	});
 

--- a/packages/layout/src/components/cards/actuary/i18n.ts
+++ b/packages/layout/src/components/cards/actuary/i18n.ts
@@ -103,7 +103,7 @@ export const i18n: ActuaryI18nProps = {
 			confirmed: 'Confirmed',
 			unconfirmed: 'Unconfirmed',
 		},
-		checkboxLabel: 'Confirm details are correct.',
+		checkboxLabel: "Confirm '__NAME__' is correct.",
 	},
 	name: {
 		title: 'Name of Actuary',

--- a/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
@@ -8,6 +8,7 @@ import {
 	ContactDetailsPreview,
 } from '../../../common/views/preview/components';
 import styles from '../../../cards.module.scss';
+import { concatenateStrings } from '../../../../../utils';
 
 export const Preview: React.FC<any> = () => {
 	const { current, send, onCorrect, i18n } = useActuaryContext();
@@ -68,7 +69,14 @@ export const Preview: React.FC<any> = () => {
 						send('COMPLETE', { value: !complete });
 						onCorrect(!complete);
 					}}
-					label={i18n.preview.checkboxLabel}
+					label={i18n.preview.checkboxLabel.replace(
+						'__NAME__',
+						concatenateStrings([
+							actuary.title,
+							actuary.firstName,
+							actuary.lastName,
+						]),
+					)}
 				/>
 			</Flex>
 		</div>

--- a/packages/layout/src/components/cards/corporateGroup/i18n.ts
+++ b/packages/layout/src/components/cards/corporateGroup/i18n.ts
@@ -102,7 +102,7 @@ export const i18n: CorporateGroupI18nProps = {
 			confirmed: 'Confirmed',
 			unconfirmed: 'Unconfirmed',
 		},
-		checkboxLabel: 'Confirm details are correct.',
+		checkboxLabel: "Confirm '__NAME__' is correct.",
 		trusteeType: 'Corporate Group trustee',
 	},
 	name: {

--- a/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
@@ -91,7 +91,10 @@ export const Preview: React.FC<any> = () => {
 						send('COMPLETE', { value: !complete });
 						onCorrect(!complete);
 					}}
-					label={i18n.preview.checkboxLabel}
+					label={i18n.preview.checkboxLabel.replace(
+						'__NAME__',
+						corporateGroup.organisationName,
+					)}
 				/>
 			</Flex>
 		</div>

--- a/packages/layout/src/components/cards/employer/i18n.ts
+++ b/packages/layout/src/components/cards/employer/i18n.ts
@@ -107,7 +107,7 @@ export const i18n: EmployerI18nProps = {
 			confirmed: 'Confirmed',
 			unconfirmed: 'Unconfirmed',
 		},
-		checkboxLabel: 'Confirm details are correct.',
+		checkboxLabel: "Confirm '__NAME__' is correct.",
 	},
 	type: {
 		title: 'Type of employer',

--- a/packages/layout/src/components/cards/employer/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/employer/views/preview/preview.tsx
@@ -81,7 +81,10 @@ export const Preview: React.FC<any> = () => {
 						send('COMPLETE', { value: !complete });
 						onCorrect(!complete);
 					}}
-					label={i18n.preview.checkboxLabel}
+					label={i18n.preview.checkboxLabel.replace(
+						'__NAME__',
+						employer.organisationName,
+					)}
 				/>
 			</Flex>
 		</div>

--- a/packages/layout/src/components/cards/inHouse/i18n.ts
+++ b/packages/layout/src/components/cards/inHouse/i18n.ts
@@ -111,7 +111,7 @@ export const i18n: InHouseAdminI18nProps = {
 			confirmed: 'Confirmed',
 			unconfirmed: 'Unconfirmed',
 		},
-		checkboxLabel: 'Confirm details are correct.',
+		checkboxLabel: "Confirm '__NAME__' is correct.",
 	},
 	name: {
 		title: 'Name of in house administrator',

--- a/packages/layout/src/components/cards/inHouse/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/preview/preview.tsx
@@ -8,6 +8,7 @@ import {
 	AddressPreview,
 } from '../../../common/views/preview/components';
 import styles from '../../../cards.module.scss';
+import { concatenateStrings } from '../../../../../utils';
 
 export const Preview: React.FC<any> = () => {
 	const { current, send, onCorrect, i18n } = useInHouseAdminContext();
@@ -74,7 +75,14 @@ export const Preview: React.FC<any> = () => {
 						send('COMPLETE', { value: !complete });
 						onCorrect(!complete);
 					}}
-					label={i18n.preview.checkboxLabel}
+					label={i18n.preview.checkboxLabel.replace(
+						'__NAME__',
+						concatenateStrings([
+							inHouseAdmin.title,
+							inHouseAdmin.firstName,
+							inHouseAdmin.lastName,
+						]),
+					)}
 				/>
 			</Flex>
 		</div>

--- a/packages/layout/src/components/cards/independentTrustee/i18n.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/i18n.tsx
@@ -60,7 +60,7 @@ export const i18n: IndependentTrusteeI18nProps = {
 			confirmed: 'Confirmed',
 			unconfirmed: 'Unconfirmed',
 		},
-		checkboxLabel: 'Confirm details are correct.',
+		checkboxLabel: "Confirm '__NAME__' is correct.",
 		trusteeType: 'Professional / Independent Trustee',
 	},
 	regulator: {

--- a/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
@@ -68,7 +68,10 @@ export const Preview: React.FC<any> = () => {
 						send('COMPLETE', { value: !complete });
 						onCorrect(!complete);
 					}}
-					label={i18n.preview.checkboxLabel}
+					label={i18n.preview.checkboxLabel.replace(
+						'__NAME__',
+						independentTrustee.organisationName,
+					)}
 				/>
 			</Flex>
 		</div>

--- a/packages/layout/src/components/cards/insurer/i18n.ts
+++ b/packages/layout/src/components/cards/insurer/i18n.ts
@@ -74,7 +74,7 @@ export const i18n: InsurerI18nProps = {
 			confirmed: 'Confirmed',
 			unconfirmed: 'Unconfirmed',
 		},
-		checkboxLabel: 'Confirm details are correct.',
+		checkboxLabel: "Confirm '__NAME__' is correct.",
 	},
 	reference: {
 		title: 'Reference details for this insurer',

--- a/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
@@ -64,7 +64,10 @@ export const Preview: React.FC<any> = () => {
 						send('COMPLETE', { value: !complete });
 						onCorrect(!complete);
 					}}
-					label={i18n.preview.checkboxLabel}
+					label={i18n.preview.checkboxLabel.replace(
+						'__NAME__',
+						insurer.organisationName,
+					)}
 				/>
 			</Flex>
 		</div>

--- a/packages/layout/src/components/cards/thirdParty/i18n.ts
+++ b/packages/layout/src/components/cards/thirdParty/i18n.ts
@@ -71,7 +71,7 @@ export const i18n: ThirdPartyI18nProps = {
 			confirmed: 'Confirmed',
 			unconfirmed: 'Unconfirmed',
 		},
-		checkboxLabel: 'Confirm details are correct.',
+		checkboxLabel: "Confirm '__NAME__' is correct.",
 	},
 	reference: {
 		title: 'Reference details for this third party admin',

--- a/packages/layout/src/components/cards/thirdParty/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/thirdParty/views/preview/preview.tsx
@@ -48,7 +48,10 @@ export const Preview: React.FC<any> = () => {
 						send('COMPLETE', { value: !complete });
 						onCorrect(!complete);
 					}}
-					label={i18n.preview.checkboxLabel}
+					label={i18n.preview.checkboxLabel.replace(
+						'__NAME__',
+						thirdParty.organisationName,
+					)}
 				/>
 			</Flex>
 		</div>

--- a/packages/layout/src/components/cards/trustee/i18n.ts
+++ b/packages/layout/src/components/cards/trustee/i18n.ts
@@ -154,7 +154,7 @@ export const i18n: TrusteeI18nProps = {
 			confirmed: 'Confirmed',
 			unconfirmed: 'Unconfirmed',
 		},
-		checkboxLabel: 'Confirm details are correct.',
+		checkboxLabel: "Confirm '__NAME__' is correct.",
 	},
 	remove: {
 		confirm: {

--- a/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../../common/views/preview/components';
 import styles from '../../../cards.module.scss';
 import { CardContentProps } from 'components/cards/common/interfaces';
+import { concatenateStrings } from '../../../../../utils';
 
 export const Preview: React.FC<CardContentProps> = ({
 	enableContactDetails = true,
@@ -79,7 +80,14 @@ export const Preview: React.FC<CardContentProps> = ({
 						send('COMPLETE', { value: !complete });
 						onCorrect(!complete);
 					}}
-					label={i18n.preview.checkboxLabel}
+					label={i18n.preview.checkboxLabel.replace(
+						'__NAME__',
+						concatenateStrings([
+							trustee.title,
+							trustee.firstName,
+							trustee.lastName,
+						]),
+					)}
 				/>
 			</Flex>
 		</div>


### PR DESCRIPTION
Includes the person or organisation name as part of the 'Confirm details are correct' checkbox label on all cards. [AB#107436](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/107436)