### PR TITLE
Add table styles for rich text content

### DIFF
--- a/packages/layout/src/components/hint/hint.mdx
+++ b/packages/layout/src/components/hint/hint.mdx
@@ -8,6 +8,7 @@ import { Playground } from '@playground';
 import { Props } from 'docz';
 import { useState } from 'react';
 import { Flex, Button } from '@tpr/core';
+import { EditorFonts } from '@tpr/theming';
 import { Hint } from './hint';
 
 # Hint
@@ -27,6 +28,7 @@ import { Hint } from '@tpr/layout';
 					Toggle visibility
 				</Button>
 				<Hint expanded={expanded}>
+					<EditorFonts>
 					<p>
 						Lucas ipsum dolor sit amet wookiee skywalker antilles yoda antilles
 						hutt luke grievous darth darth. Hutt obi-wan maul vader. Owen han
@@ -37,14 +39,43 @@ import { Hint } from '@tpr/layout';
 						palpatine dooku. Darth darth hutt k-3po tatooine. Padmé mandalore
 						wampa darth moff. Wampa hutt jabba binks luke
 					</p>
-				</Hint>
-				<p>
-					There should be default spacing between the Hint component and this
-					paragraph.
-				</p>
-			</>
-		);
-	}}
+					<table>
+						<caption>Assumed values for active and deferred members</caption>
+						<thead>
+								<tr>
+										<th scope="col">Service period</th>
+										<th scope="col">Active members</th>
+										<th scope="col">Deferred members</th>
+								</tr>
+						</thead>
+						<tbody>
+							<tr>
+									<th scope="row">Pre-6 April 1997</th>
+									<td>60%</td>
+									<td>80%</td>
+							</tr>
+							<tr>
+									<th scope="row">6 April 1997 to 5 April 2009</th>
+									<td>40%</td>
+									<td>20%</td>
+							</tr>
+							<tr>
+									<th scope="row">Post-5 April 2009</th>
+									<td>0%</td>
+									<td>0%</td>
+							</tr>
+						</tbody>
+    			</table>
+    			</EditorFonts>
+    			</Hint>
+    			<p>
+    				There should be default spacing between the Hint component and this
+    				paragraph.
+    			</p>
+    		</>
+    	);
+    }}
+
 </Playground>
 
 ## API

--- a/packages/theming/src/richTextEditor.module.scss
+++ b/packages/theming/src/richTextEditor.module.scss
@@ -91,4 +91,26 @@
 	blockquote {
 		background: $colors-neutral-2;
 	}
+	table {
+		border-collapse: collapse;
+		margin-bottom: 1rem;
+	}
+	caption,
+	td,
+	th {
+		padding: $space-2;
+		text-align: left;
+		border: 1px solid $colors-neutral-6;
+	}
+	caption {
+		border-bottom: none;
+		background: $colors-neutral-3;
+	}
+	caption,
+	th {
+		font-weight: $font-weight-4;
+	}
+	& > :last-child {
+		margin-bottom: 0;
+	}
 }


### PR DESCRIPTION
Demo styles using the hint component, which normally has rich text content in real-world use. Fixes [AB#106468](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/106468).
