### PR TITLE
Add support for the autocomplete HTML attribute 

### DIFF
--- a/packages/forms/src/__tests__/addressLookup.spec.tsx
+++ b/packages/forms/src/__tests__/addressLookup.spec.tsx
@@ -70,6 +70,13 @@ describe('Address lookup', () => {
 			const results = await axe(container);
 			expect(results).toHaveNoViolations();
 		});
+		test('should use autocomplete="postal-code"', () => {
+			const { getByTestId } = formSetup({
+				render: <AddressLookup {...defaultProps} />,
+			});
+			const input = getByTestId('postcode-lookup-edit');
+			expect(input).toHaveAttribute('autocomplete', 'postal-code');
+		});
 		test('should go to select address view when button is clicked', async () => {
 			const { container } = formSetup({
 				render: <AddressLookup {...defaultProps} />,
@@ -197,6 +204,21 @@ describe('Address lookup', () => {
 			});
 			const results = await axe(container);
 			expect(results).toHaveNoViolations();
+		});
+		test('should use autocomplete attribute for address lines 1 & 2', () => {
+			const { getByTestId } = formSetup({
+				render: (
+					<AddressLookup
+						{...defaultProps}
+						initialValue={FakeAddressLookupProvider.tprAddress}
+					/>
+				),
+			});
+
+			const addressLine1 = getByTestId('addressLine1');
+			const addressLine2 = getByTestId('addressLine2');
+			expect(addressLine1).toHaveAttribute('autocomplete', 'address-line1');
+			expect(addressLine2).toHaveAttribute('autocomplete', 'address-line2');
 		});
 		test('to go to postcode lookup view when button clicked', async () => {
 			const { container } = formSetup({

--- a/packages/forms/src/__tests__/date.spec.tsx
+++ b/packages/forms/src/__tests__/date.spec.tsx
@@ -175,6 +175,32 @@ describe('Date input', () => {
 		expect(yyyy).toHaveAttribute('readonly');
 	});
 
+	test('date fields do not set autocomplete', () => {
+		const fields: FieldProps[] = [
+			{
+				id: 'test-date',
+				name: 'date-1',
+				label: 'passport-expiry',
+				hint: 'For example, 12 11 2007',
+				type: 'date',
+				required: true,
+			},
+		];
+		const { container } = formSetup({
+			render: renderFields(fields),
+			validate: validate(fields),
+			onSubmit: jest.fn(),
+		});
+
+		const dd = container.querySelector(`input[data-testid="dd-field"]`);
+		const mm = container.querySelector(`input[data-testid="mm-field"]`);
+		const yyyy = container.querySelector(`input[data-testid="yyyy-field"]`);
+
+		expect(dd).not.toHaveAttribute('autocomplete');
+		expect(mm).not.toHaveAttribute('autocomplete');
+		expect(yyyy).not.toHaveAttribute('autocomplete');
+	});
+
 	test('using the hideDay prop', () => {
 		const id = 'test-date';
 		const fields: FieldProps[] = [

--- a/packages/forms/src/__tests__/email.spec.tsx
+++ b/packages/forms/src/__tests__/email.spec.tsx
@@ -78,6 +78,24 @@ describe('Email input', () => {
 		expect(label).toHaveAttribute('readonly');
 	});
 
+	test('renders autocomplete', () => {
+		const { queryByTestId } = formSetup({
+			render: <FFInputEmail {...basicProps} />,
+		});
+
+		const label = queryByTestId(emailTestId);
+		expect(label).toHaveAttribute('autocomplete', 'email');
+	});
+
+	test('renders type="email"', () => {
+		const { queryByTestId } = formSetup({
+			render: <FFInputEmail {...basicProps} />,
+		});
+
+		const label = queryByTestId(emailTestId);
+		expect(label).toHaveAttribute('type', 'email');
+	});
+
 	test('has correct describedby tag when an error is shown', () => {
 		const { getByText, getByTestId } = formSetup({
 			render: <FFInputEmail {...basicProps} required={true} />,

--- a/packages/forms/src/__tests__/phone.spec.tsx
+++ b/packages/forms/src/__tests__/phone.spec.tsx
@@ -81,6 +81,24 @@ describe('Phone input', () => {
 		expect(label).toHaveAttribute('readonly');
 	});
 
+	test('renders autocomplete', () => {
+		const { queryByTestId } = formSetup({
+			render: <FFInputPhone {...basicProps} />,
+		});
+
+		const label = queryByTestId(phoneTestId);
+		expect(label).toHaveAttribute('autocomplete', 'tel');
+	});
+
+	test('renders type="tel"', () => {
+		const { queryByTestId } = formSetup({
+			render: <FFInputPhone {...basicProps} />,
+		});
+
+		const label = queryByTestId(phoneTestId);
+		expect(label).toHaveAttribute('type', 'tel');
+	});
+
 	test('has correct describedby tag when an error is shown', () => {
 		const { getByTestId, getByText } = formSetup({
 			render: <FFInputPhone {...basicProps} required={true} />,

--- a/packages/forms/src/elements/address/editAddress.tsx
+++ b/packages/forms/src/elements/address/editAddress.tsx
@@ -94,6 +94,7 @@ export const EditAddress: React.FC<EditAddressProps> = React.memo(
 				<FFInputText
 					ref={address1ref}
 					name="addressLine1"
+					autoComplete="address-line1"
 					label={addressLine1Label}
 					disabled={loading}
 					testId={(testId ? testId + '-' : '') + 'addressLine1'}
@@ -112,6 +113,7 @@ export const EditAddress: React.FC<EditAddressProps> = React.memo(
 				<FFInputText
 					ref={address2ref}
 					name="addressLine2"
+					autoComplete="address-line2"
 					label={addressLine2Label}
 					disabled={loading}
 					testId={(testId ? testId + '-' : '') + 'addressLine2'}

--- a/packages/forms/src/elements/address/postcodeLookup.tsx
+++ b/packages/forms/src/elements/address/postcodeLookup.tsx
@@ -48,6 +48,7 @@ export const PostcodeLookup: React.FC<PostcodeLookupProps> = ({
 			<FFInputText
 				ref={searchFieldRef}
 				name="postcodeLookup"
+				autoComplete="postal-code"
 				value={postcode}
 				label={postcodeLookupLabel}
 				validate={(value) => validatePostcode(value)}

--- a/packages/forms/src/elements/date/date.tsx
+++ b/packages/forms/src/elements/date/date.tsx
@@ -121,7 +121,6 @@ const DateInputField: React.FC<DateInputFieldProps> = ({
 					}
 				}}
 				meta={meta}
-				autoComplete="off"
 				maxLength={maxLength}
 				isError={meta && meta.touched && meta.error}
 				accessibilityHelper={!hasFocus ? helper : null}

--- a/packages/forms/src/elements/email/email.tsx
+++ b/packages/forms/src/elements/email/email.tsx
@@ -40,6 +40,7 @@ const InputEmail: React.FC<InputEmailProps> = ({
 			<Input
 				id={id}
 				type="email"
+				autoComplete="email"
 				width={width}
 				testId={testId}
 				label={label}

--- a/packages/forms/src/elements/input/input.tsx
+++ b/packages/forms/src/elements/input/input.tsx
@@ -18,6 +18,7 @@ export type InputProps = {
 	ariaLabelExtension?: string;
 	[key: string]: any;
 	accessibilityHelper?: AccessibilityHelper;
+	autoComplete?: string;
 };
 
 export const Input: React.FC<InputProps> = ({
@@ -30,6 +31,7 @@ export const Input: React.FC<InputProps> = ({
 	isError = false,
 	className,
 	readOnly,
+	autoComplete,
 	after: After,
 	before: Before,
 	decimalPlaces,
@@ -72,6 +74,7 @@ export const Input: React.FC<InputProps> = ({
 				type={type}
 				data-testid={testId}
 				readOnly={readOnly}
+				autoComplete={autoComplete}
 				step={
 					type !== 'number'
 						? null

--- a/packages/forms/src/elements/phone/phone.tsx
+++ b/packages/forms/src/elements/phone/phone.tsx
@@ -39,7 +39,7 @@ const InputPhone: React.FC<InputPhoneProps> = ({
 			/>
 			<Input
 				id={id}
-				type="tel"
+				autoComplete="tel"
 				width={width}
 				testId={testId}
 				label={label}
@@ -49,6 +49,7 @@ const InputPhone: React.FC<InputPhoneProps> = ({
 				required={required}
 				accessibilityHelper={helper}
 				{...input}
+				type="tel"
 			/>
 		</StyledInputLabel>
 	);

--- a/packages/forms/src/elements/text/text.mdx
+++ b/packages/forms/src/elements/text/text.mdx
@@ -134,3 +134,4 @@ Although neither `label` or `ariaLabel` are required props, you should always us
 | hint           | false    | string  | More detailed description about the text field |
 | readOnly       | false    | boolean | Sets whether the field is read only            |
 | inputClassName | false    | string  | Sets a class to apply to the input element     |
+| autoComplete   | false    | string  | Sets the HTML autocomplete attribute           |

--- a/packages/forms/src/elements/text/text.tsx
+++ b/packages/forms/src/elements/text/text.tsx
@@ -26,6 +26,7 @@ const InputText: React.FC<InputTextProps> = React.forwardRef(
 			placeholder,
 			disabled,
 			readOnly,
+			autoComplete,
 			inputWidth: width,
 			cfg,
 			updatedValue,
@@ -63,6 +64,7 @@ const InputText: React.FC<InputTextProps> = React.forwardRef(
 					placeholder={placeholder}
 					disabled={disabled}
 					readOnly={readOnly}
+					autoComplete={autoComplete}
 					isError={meta && meta.touched && meta.error}
 					className={inputClassName}
 					maxLength={maxLength}

--- a/packages/forms/src/renderFields.tsx
+++ b/packages/forms/src/renderFields.tsx
@@ -39,6 +39,7 @@ export type FieldExtraProps = {
 	/** for radio buttons */
 	checked?: boolean;
 	readOnly?: boolean;
+	autoComplete?: string;
 	/** argument for tests */
 	testId?: string;
 	/** options for Select input field */

--- a/packages/icons/src/components/spinners/spinners.tsx
+++ b/packages/icons/src/components/spinners/spinners.tsx
@@ -10,7 +10,7 @@ export const LoadingSpinnerCircle: React.FC<SpinnerProps> = ({
 			className={styles.spinnerCircle}
 			data-testid="spinner-circle"
 			role="status"
-			aria-live="polite" 
+			aria-live="polite"
 		>
 			<div className={styles.spinner}>
 				<div></div>

--- a/packages/layout/src/components/__tests__/actuary.spec.tsx
+++ b/packages/layout/src/components/__tests__/actuary.spec.tsx
@@ -128,7 +128,7 @@ describe('Actuary Card', () => {
 		});
 	});
 
-	describe('updating Actuary Name', () => {
+	describe('update Actuary Name', () => {
 		let component, findByText, findByTestId;
 		let updatedActuary = null;
 
@@ -153,15 +153,18 @@ describe('Actuary Card', () => {
 			findByTestId = getByTestId;
 
 			findByText('Actuary').click();
-			const results = await axe(component);
-			expect(results).toHaveNoViolations();
 		});
 
 		afterEach(() => {
 			cleanup();
 		});
 
-		test('editing actuary Name', () => {
+		test('passes AXE accessibility testing', async () => {
+			const results = await axe(component);
+			expect(results).toHaveNoViolations();
+		});
+
+		test('renders name fields', () => {
 			expect(findByTestId('actuary-name-form')).not.toBe(null);
 
 			var titleHtmlElement = findByText('Title (optional)') as HTMLElement;
@@ -173,15 +176,39 @@ describe('Actuary Card', () => {
 				'maxlength',
 				'35',
 			);
+			expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'autocomplete',
+				'honorific-prefix',
+			);
+			expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'value',
+				actuary.title,
+			);
 			expect(firstNameHtmlElement).toBeDefined();
 			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
 				'maxlength',
 				'70',
 			);
+			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'autocomplete',
+				'given-name',
+			);
+			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'value',
+				actuary.firstName,
+			);
 			expect(lastNameHtmlElement).toBeDefined();
 			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
 				'maxlength',
 				'70',
+			);
+			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'autocomplete',
+				'family-name',
+			);
+			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'value',
+				actuary.lastName,
 			);
 			expect(findByText('Save and close')).toBeDefined();
 			assertThatButtonHasBeenRemovedFromTheTabFlow(findByText, 'Remove');
@@ -231,18 +258,47 @@ describe('Actuary Card', () => {
 			findByTestId = getByTestId;
 
 			findByText('Contact details').click();
-			const results = await axe(component);
-			expect(results).toHaveNoViolations();
 		});
 
 		afterEach(() => {
 			cleanup();
 		});
 
-		test('editing contact details', () => {
+		test('passes AXE accessibility testing', async () => {
+			const results = await axe(component);
+			expect(results).toHaveNoViolations();
+		});
+
+		test('renders phone and email fields', () => {
 			expect(findByTestId('actuary-contact-form')).not.toBe(null);
-			expect(findByText('Telephone number')).toBeDefined();
-			expect(findByText('Email address')).toBeDefined();
+			const telHtmlElement = findByText('Telephone number');
+			const emailHtmlElement = findByText('Email address');
+			expect(telHtmlElement).toBeDefined();
+			expect(telHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'type',
+				'tel',
+			);
+			expect(telHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'autocomplete',
+				'tel',
+			);
+			expect(telHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'value',
+				actuary.telephoneNumber,
+			);
+			expect(emailHtmlElement).toBeDefined();
+			expect(emailHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'type',
+				'email',
+			);
+			expect(emailHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'autocomplete',
+				'email',
+			);
+			expect(emailHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'value',
+				actuary.emailAddress,
+			);
 			expect(findByText('Save and close')).toBeDefined();
 		});
 

--- a/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
+++ b/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
@@ -134,7 +134,7 @@ describe('Corporate Group Trustee Card', () => {
 
 	describe('editing Chair-of-board', () => {
 		let component, findByText, findByTestId;
-		beforeEach(async () => {
+		beforeEach(() => {
 			const { container, getByText, getByTestId } = render(
 				<CorporateGroupCard
 					corporateGroup={corporateGroup}
@@ -152,42 +152,62 @@ describe('Corporate Group Trustee Card', () => {
 			findByTestId = getByTestId;
 
 			findByText('Chair of board').click();
-			const results = await axe(component);
-			expect(results).toHaveNoViolations();
-
-			expect(getByTestId('corporateGroup-name-form')).not.toBe(null);
-
-			var titleHtmlElement = getByText('Title (optional)') as HTMLElement;
-			var firstNameHtmlElement = getByText('First name') as HTMLElement;
-			var lastNameHtmlElement = getByText('Last name') as HTMLElement;
-
-			expect(titleHtmlElement).toBeDefined();
-			expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'maxlength',
-				'35',
-			);
-			expect(firstNameHtmlElement).toBeDefined();
-			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'maxlength',
-				'70',
-			);
-			expect(lastNameHtmlElement).toBeDefined();
-			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'maxlength',
-				'70',
-			);
-			expect(getByText('Continue')).toBeDefined();
 		});
 
 		afterEach(() => {
 			cleanup();
 		});
 
+		test('editing Name of the chair of the board passes AXE accessibility testing', async () => {
+			const results = await axe(component);
+			expect(results).toHaveNoViolations();
+		});
+
 		test('editing Name of the chair of the board', () => {
 			expect(findByTestId('corporateGroup-name-form')).not.toBe(null);
-			expect(findByText('Title (optional)')).toBeDefined();
-			expect(findByText('First name')).toBeDefined();
-			expect(findByText('Last name')).toBeDefined();
+			const titleHtmlElement = findByText('Title (optional)') as HTMLElement;
+			const firstNameHtmlElement = findByText('First name') as HTMLElement;
+			const lastNameHtmlElement = findByText('Last name') as HTMLElement;
+
+			expect(titleHtmlElement).toBeDefined();
+			expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'maxlength',
+				'35',
+			);
+			expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'autocomplete',
+				'honorific-prefix',
+			);
+			expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'value',
+				corporateGroup.title,
+			);
+			expect(firstNameHtmlElement).toBeDefined();
+			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'maxlength',
+				'70',
+			);
+			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'autocomplete',
+				'given-name',
+			);
+			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'value',
+				corporateGroup.firstName,
+			);
+			expect(lastNameHtmlElement).toBeDefined();
+			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'maxlength',
+				'70',
+			);
+			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'autocomplete',
+				'family-name',
+			);
+			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'value',
+				corporateGroup.lastName,
+			);
 			expect(findByText('Continue')).toBeDefined();
 		});
 
@@ -196,8 +216,34 @@ describe('Corporate Group Trustee Card', () => {
 				findByText('Continue').click();
 				const results = await axe(component);
 				expect(results).toHaveNoViolations();
-				expect(findByText('Telephone number')).toBeDefined();
-				expect(findByText('Email address')).toBeDefined();
+				const telHtmlElement = findByText('Telephone number');
+				expect(telHtmlElement).toBeDefined();
+				expect(telHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+					'type',
+					'tel',
+				);
+				expect(telHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+					'autocomplete',
+					'tel',
+				);
+				expect(telHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+					'value',
+					corporateGroup.telephoneNumber,
+				);
+				const emailHtmlElement = findByText('Email address');
+				expect(emailHtmlElement).toBeDefined();
+				expect(emailHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+					'type',
+					'email',
+				);
+				expect(emailHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+					'autocomplete',
+					'email',
+				);
+				expect(emailHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+					'value',
+					corporateGroup.emailAddress,
+				);
 				expect(findByText('Save and close')).toBeDefined();
 			});
 

--- a/packages/layout/src/components/__tests__/inHouse.spec.tsx
+++ b/packages/layout/src/components/__tests__/inHouse.spec.tsx
@@ -36,23 +36,19 @@ const inHouseAdmin: InHouseAdminNoApi = {
 };
 
 describe('InHouse Preview', () => {
-	let component, findByText, findByTestId, findByRole;
-	let updatedInHouseAdmin = null;
+	let component, findByText, findByRole;
 
 	beforeEach(async () => {
-		const { container, getByText, getByTestId, getByRole } = render(
+		const { container, getByText, getByRole } = render(
 			<InHouseCard
 				onSaveContacts={noop}
 				onSaveAddress={noop}
-				onSaveName={(values) => {
-					updatedInHouseAdmin = values;
-					return noop();
-				}}
+				onSaveName={noop}
 				onRemove={noop}
 				onCorrect={(_value) => {}}
 				complete={true}
 				addressAPI={{
-					get: (_endpont) => Promise.resolve(),
+					get: (_endpoint) => Promise.resolve(),
 					limit: 100,
 				}}
 				inHouseAdmin={inHouseAdmin}
@@ -61,7 +57,6 @@ describe('InHouse Preview', () => {
 
 		component = container;
 		findByText = getByText;
-		findByTestId = getByTestId;
 		findByRole = getByRole;
 	});
 
@@ -83,27 +78,94 @@ describe('InHouse Preview', () => {
 		expect(findByText(`Confirm 'Mr John Smoth' is correct.`)).toBeDefined();
 	});
 
-	test('editing in house name', () => {
+	test('renders with a section containing an aria label', () => {
+		assertThatASectionExistsWithAnAriaLabel(
+			findByRole,
+			`${inHouseAdmin.title} ${inHouseAdmin.firstName} ${inHouseAdmin.lastName} In House Administrator`,
+		);
+	});
+});
+
+describe('Update in-house trustee name', () => {
+	let component, findByText, findByTestId;
+	let updatedInHouseAdmin = null;
+
+	beforeEach(async () => {
+		const { container, getByText, getByTestId } = render(
+			<InHouseCard
+				onSaveContacts={noop}
+				onSaveAddress={noop}
+				onSaveName={(values) => {
+					updatedInHouseAdmin = values;
+					return noop();
+				}}
+				onRemove={noop}
+				onCorrect={(_value) => {}}
+				complete={true}
+				addressAPI={{
+					get: (_endpont) => Promise.resolve(),
+					limit: 100,
+				}}
+				inHouseAdmin={inHouseAdmin}
+			/>,
+		);
+
+		component = container;
+		findByText = getByText;
+		findByTestId = getByTestId;
+
 		findByText('In House Administrator').click();
+	});
+
+	test('is accessible', async () => {
+		const results = await axe(component);
+		expect(results).toHaveNoViolations();
+	});
+
+	test('renders name fields', () => {
 		expect(findByTestId('inHouseAdmin-name-form')).not.toBe(null);
-		var titleHtmlElement = findByText('Title (optional)') as HTMLElement;
-		var firstNameHtmlElement = findByText('First name') as HTMLElement;
-		var lastNameHtmlElement = findByText('Last name') as HTMLElement;
+		const titleHtmlElement = findByText('Title (optional)') as HTMLElement;
+		const firstNameHtmlElement = findByText('First name') as HTMLElement;
+		const lastNameHtmlElement = findByText('Last name') as HTMLElement;
 
 		expect(titleHtmlElement).toBeDefined();
 		expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
 			'maxlength',
 			'35',
 		);
+		expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+			'autocomplete',
+			'honorific-prefix',
+		);
+		expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+			'value',
+			inHouseAdmin.title,
+		);
 		expect(firstNameHtmlElement).toBeDefined();
 		expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
 			'maxlength',
 			'70',
 		);
+		expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+			'autocomplete',
+			'given-name',
+		);
+		expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+			'value',
+			inHouseAdmin.firstName,
+		);
 		expect(lastNameHtmlElement).toBeDefined();
 		expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
 			'maxlength',
 			'70',
+		);
+		expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+			'autocomplete',
+			'family-name',
+		);
+		expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+			'value',
+			inHouseAdmin.lastName,
 		);
 		expect(findByText('Save and close')).toBeDefined();
 
@@ -112,8 +174,6 @@ describe('InHouse Preview', () => {
 
 	test('in house title can be left empty when name is updated', async () => {
 		await act(async () => {
-			findByText(/In House Administrator/).click();
-			await axe(component);
 			clearTitleField(findByText);
 			findByText(/Save and close/).click();
 		});
@@ -124,12 +184,70 @@ describe('InHouse Preview', () => {
 			updatedInHouseAdmin,
 		);
 	});
+});
 
-	test('renders with a section containing an aria label', () => {
-		assertThatASectionExistsWithAnAriaLabel(
-			findByRole,
-			`${inHouseAdmin.title} ${inHouseAdmin.firstName} ${inHouseAdmin.lastName} In House Administrator`,
+describe('Update in-house trustee contact details', () => {
+	let component, findByText;
+
+	beforeEach(async () => {
+		const { container, getByText } = render(
+			<InHouseCard
+				onSaveContacts={noop}
+				onSaveAddress={noop}
+				onSaveName={noop}
+				onRemove={noop}
+				onCorrect={(_value) => {}}
+				complete={true}
+				addressAPI={{
+					get: (_endpoint) => Promise.resolve(),
+					limit: 100,
+				}}
+				inHouseAdmin={inHouseAdmin}
+			/>,
 		);
+
+		component = container;
+		findByText = getByText;
+
+		findByText('Contact details').click();
+	});
+
+	test('is accessible', async () => {
+		const results = await axe(component);
+		expect(results).toHaveNoViolations();
+	});
+
+	test('renders contact fields', () => {
+		const telHtmlElement = findByText('Telephone number');
+		expect(telHtmlElement).toBeDefined();
+		expect(telHtmlElement.nextSibling.firstChild).toHaveAttribute(
+			'type',
+			'tel',
+		);
+		expect(telHtmlElement.nextSibling.firstChild).toHaveAttribute(
+			'autocomplete',
+			'tel',
+		);
+		expect(telHtmlElement.nextSibling.firstChild).toHaveAttribute(
+			'value',
+			inHouseAdmin.telephoneNumber,
+		);
+
+		const emailHtmlElement = findByText('Email address');
+		expect(emailHtmlElement).toBeDefined();
+		expect(emailHtmlElement.nextSibling.firstChild).toHaveAttribute(
+			'type',
+			'email',
+		);
+		expect(emailHtmlElement.nextSibling.firstChild).toHaveAttribute(
+			'autocomplete',
+			'email',
+		);
+		expect(emailHtmlElement.nextSibling.firstChild).toHaveAttribute(
+			'value',
+			inHouseAdmin.emailAddress,
+		);
+		expect(findByText('Save and close')).toBeDefined();
 	});
 });
 

--- a/packages/layout/src/components/__tests__/trustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/trustee.spec.tsx
@@ -156,6 +156,10 @@ describe('TrusteeCard enableContactDetails == true', () => {
 			findByText('Trustee').click();
 			const results = await axe(component);
 			expect(results).toHaveNoViolations();
+		});
+
+		test('renders name fields', () => {
+			findByText('Trustee').click();
 
 			expect(findByTestId('trustee-name-form')).not.toBe(null);
 
@@ -168,15 +172,39 @@ describe('TrusteeCard enableContactDetails == true', () => {
 				'maxlength',
 				'35',
 			);
+			expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'autocomplete',
+				'honorific-prefix',
+			);
+			expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'value',
+				trustee.title,
+			);
 			expect(firstNameHtmlElement).toBeDefined();
 			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
 				'maxlength',
 				'70',
 			);
+			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'autocomplete',
+				'given-name',
+			);
+			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'value',
+				trustee.firstName,
+			);
 			expect(lastNameHtmlElement).toBeDefined();
 			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
 				'maxlength',
 				'70',
+			);
+			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'autocomplete',
+				'family-name',
+			);
+			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+				'value',
+				trustee.lastName,
 			);
 			expect(findByText('Continue')).toBeDefined();
 
@@ -216,6 +244,40 @@ describe('TrusteeCard enableContactDetails == true', () => {
 
 			const results = await axe(component);
 			expect(results).toHaveNoViolations();
+		});
+
+		test('renders contact fields', () => {
+			findByText('Contact details').click();
+
+			const telHtmlElement = findByText('Telephone number');
+			expect(telHtmlElement).toBeDefined();
+			expect(telHtmlElement.nextSibling.firstChild).toHaveAttribute(
+				'type',
+				'tel',
+			);
+			expect(telHtmlElement.nextSibling.firstChild).toHaveAttribute(
+				'autocomplete',
+				'tel',
+			);
+			expect(telHtmlElement.nextSibling.firstChild).toHaveAttribute(
+				'value',
+				trustee.telephoneNumber,
+			);
+			const emailHtmlElement = findByText('Email address');
+			expect(emailHtmlElement).toBeDefined();
+			expect(emailHtmlElement.nextSibling.firstChild).toHaveAttribute(
+				'type',
+				'email',
+			);
+			expect(emailHtmlElement.nextSibling.firstChild).toHaveAttribute(
+				'autocomplete',
+				'email',
+			);
+			expect(emailHtmlElement.nextSibling.firstChild).toHaveAttribute(
+				'value',
+				trustee.emailAddress,
+			);
+			expect(findByText('Save and close')).toBeDefined();
 		});
 	});
 

--- a/packages/layout/src/components/cards/actuary/views/contacts/index.tsx
+++ b/packages/layout/src/components/cards/actuary/views/contacts/index.tsx
@@ -38,7 +38,6 @@ export const Contacts: React.FC = () => {
 	const { current, send, i18n, onSaveContacts } = useActuaryContext();
 	const { actuary } = current.context;
 	const fields = getFields(i18n?.contacts?.fields);
-
 	const onSubmit = async (values) => {
 		setLoading(true);
 		try {

--- a/packages/layout/src/components/cards/actuary/views/name/index.tsx
+++ b/packages/layout/src/components/cards/actuary/views/name/index.tsx
@@ -16,6 +16,7 @@ const getFields = (
 	{
 		name: 'title',
 		type: 'text',
+		autoComplete: 'honorific-prefix',
 		label: fields.title.label,
 		error: fields.title.error,
 		maxLength: fields.title.maxlength,
@@ -25,6 +26,7 @@ const getFields = (
 	{
 		name: 'firstName',
 		type: 'text',
+		autoComplete: 'given-name',
 		label: fields.firstName.label,
 		error: fields.firstName.error,
 		maxLength: fields.firstName.maxlength,
@@ -34,6 +36,7 @@ const getFields = (
 	{
 		name: 'lastName',
 		type: 'text',
+		autoComplete: 'family-name',
 		label: fields.lastName.label,
 		error: fields.lastName.error,
 		maxLength: fields.lastName.maxlength,

--- a/packages/layout/src/components/cards/components/content.tsx
+++ b/packages/layout/src/components/cards/components/content.tsx
@@ -26,7 +26,6 @@ export const Content: React.FC<ContentProps> = ({
 	subSectionHeaderText,
 	send,
 }) => {
-	console.log('section title', sectionTitle);
 	return (
 		<div className={styles.content}>
 			{loading && <Loading />}

--- a/packages/layout/src/components/cards/corporateGroup/views/name/name.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/name/name.tsx
@@ -15,6 +15,7 @@ const getFields = (
 	{
 		name: 'title',
 		type: 'text',
+		autoComplete: 'honorific-prefix',
 		label: fields.title.label,
 		error: fields.title.error,
 		maxLength: fields.title.maxlength,
@@ -24,6 +25,7 @@ const getFields = (
 	{
 		name: 'firstName',
 		type: 'text',
+		autoComplete: 'given-name',
 		label: fields.firstName.label,
 		error: fields.firstName.error,
 		maxLength: fields.firstName.maxlength,
@@ -33,6 +35,7 @@ const getFields = (
 	{
 		name: 'lastName',
 		type: 'text',
+		autoComplete: 'family-name',
 		label: fields.lastName.label,
 		error: fields.lastName.error,
 		maxLength: fields.lastName.maxlength,
@@ -60,7 +63,7 @@ export const NameScreen: React.FC<NameScreenProps> = ({
 			setLoading(false);
 			send('SAVE', { values });
 		} catch (error) {
-			console.log(error);
+			console.error(error);
 			setLoading(false);
 		}
 	};

--- a/packages/layout/src/components/cards/inHouse/views/name/index.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/name/index.tsx
@@ -16,6 +16,7 @@ const getFields = (
 	{
 		name: 'title',
 		type: 'text',
+		autoComplete: 'honorific-prefix',
 		label: fields.title.label,
 		error: fields.title.error,
 		maxLength: fields.title.maxlength,
@@ -25,6 +26,7 @@ const getFields = (
 	{
 		name: 'firstName',
 		type: 'text',
+		autoComplete: 'given-name',
 		label: fields.firstName.label,
 		error: fields.firstName.error,
 		maxLength: fields.firstName.maxlength,
@@ -34,6 +36,7 @@ const getFields = (
 	{
 		name: 'lastName',
 		type: 'text',
+		autoComplete: 'family-name',
 		label: fields.lastName.label,
 		error: fields.lastName.error,
 		maxLength: fields.lastName.maxlength,

--- a/packages/layout/src/components/cards/trustee/views/name/index.tsx
+++ b/packages/layout/src/components/cards/trustee/views/name/index.tsx
@@ -16,6 +16,7 @@ const getFields = (
 	{
 		name: 'title',
 		type: 'text',
+		autoComplete: 'honorific-prefix',
 		label: fields.title.label,
 		error: fields.title.error,
 		maxLength: fields.title.maxlength,
@@ -25,6 +26,7 @@ const getFields = (
 	{
 		name: 'firstName',
 		type: 'text',
+		autoComplete: 'given-name',
 		label: fields.firstName.label,
 		error: fields.firstName.error,
 		maxLength: fields.firstName.maxlength,
@@ -34,6 +36,7 @@ const getFields = (
 	{
 		name: 'lastName',
 		type: 'text',
+		autoComplete: 'family-name',
 		label: fields.lastName.label,
 		error: fields.lastName.error,
 		maxLength: fields.lastName.maxlength,


### PR DESCRIPTION
- Removes the disabling of autocomplete on the date fields, and adds tests to ensure it stays removed
- Adds autocomplete support to title, firstname, lastname, phone, email and address fields on cards
- Adds autocomplete support to address fields in the address lookup
- Adds/tidies up tests to cover the autocomplete attribute and generally for the fields where it is applied

Fixes [AB#106458](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/106458) (for the parts in the repo).