### PR TITLE
AB#106739 do not render dynamic required attribute 

### DIFF
--- a/packages/forms/src/__tests__/addressLookup.spec.tsx
+++ b/packages/forms/src/__tests__/addressLookup.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { formSetup } from '../__mocks__/setup';
-import { fireEvent, screen, findByText, cleanup } from '@testing-library/react';
+import { fireEvent, screen, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { AddressLookup } from '../elements/address/addressLookup';
@@ -88,14 +88,11 @@ describe('Address lookup', () => {
 			expect(changePostcode).not.toBeNull();
 		});
 		test('should validate the postcode when button is clicked', async () => {
-			const { container } = formSetup({
+			const { findByText } = formSetup({
 				render: <AddressLookup {...defaultProps} />,
 			});
 			await searchForAPostcode('AB12 3MV'); // invalid postcode due to MV in the incode
-			const errorMessage = findByText(
-				container,
-				defaultProps.invalidPostcodeMessage,
-			);
+			const errorMessage = findByText(defaultProps.invalidPostcodeMessage);
 			expect(errorMessage).not.toBeNull();
 		});
 		test('to have a required attribute', async () => {

--- a/packages/forms/src/__tests__/addressLookup.spec.tsx
+++ b/packages/forms/src/__tests__/addressLookup.spec.tsx
@@ -119,23 +119,21 @@ describe('Address lookup', () => {
 		});
 
 		test('should list matching addresses', async () => {
-			formSetup({
+			const { findByTestId, findByText, findAllByRole } = formSetup({
 				render: <AddressLookup {...defaultProps} />,
 			});
 
 			await searchForAPostcode(FakeAddressLookupProvider.tprAddress.postcode);
 
-			const displayedPostcode = await screen.findByText(
+			const displayedPostcode = await findByText(
 				FakeAddressLookupProvider.tprAddress.postcode,
 			);
 			expect(displayedPostcode).toBeDefined();
 
-			const selectAddressInput = await screen.findByTestId(
-				'select-address-list',
-			);
+			const selectAddressInput = await findByTestId('select-address-list');
 			selectAddressInput.click();
 
-			const addressOptions = await screen.findAllByRole('option');
+			const addressOptions = await findAllByRole('option');
 
 			expect(addressOptions[0].textContent).toMatch(
 				FakeAddressLookupProvider.tprAddress.addressLine1,
@@ -143,44 +141,36 @@ describe('Address lookup', () => {
 		});
 
 		test('should pass selected address to edit address view', async () => {
-			formSetup({
+			const { findByTestId, findByDisplayValue, findAllByRole } = formSetup({
 				render: <AddressLookup {...defaultProps} />,
 			});
 
 			await searchForAPostcode(FakeAddressLookupProvider.tprAddress.postcode);
 
-			const selectAddressInput = await screen.findByTestId(
-				'select-address-list',
-			);
+			const selectAddressInput = await findByTestId('select-address-list');
 			selectAddressInput.click();
 
-			const addressOptions = await screen.findAllByRole('option');
+			const addressOptions = await findAllByRole('option');
 			addressOptions[0].click();
-			const selectAddressButton = await screen.findByTestId(
-				'select-address-button',
-			);
+			const selectAddressButton = await findByTestId('select-address-button');
 			selectAddressButton.click();
 
-			const addressLine1Input = await screen.findByDisplayValue(
+			const addressLine1Input = await findByDisplayValue(
 				FakeAddressLookupProvider.tprAddress.addressLine1,
 			);
 			expect(addressLine1Input).toBeDefined();
 		});
 		test('should call onValidatePostcode when select address button is clicked', async () => {
-			formSetup({
+			const { findByTestId } = formSetup({
 				render: <AddressLookup {...defaultProps} />,
 			});
 			await searchForAPostcode(FakeAddressLookupProvider.tprAddress.postcode);
 
-			const selectAddressInput = await screen.findByTestId(
-				'select-address-list',
-			);
+			const selectAddressInput = await findByTestId('select-address-list');
 			selectAddressInput.click();
 			const addressOptions = await screen.findAllByRole('option');
 			addressOptions[0].click();
-			const selectAddressButton = await screen.findByTestId(
-				'select-address-button',
-			);
+			const selectAddressButton = await findByTestId('select-address-button');
 			selectAddressButton.click();
 			expect(defaultProps.onValidatePostcode).toHaveBeenCalled();
 		});

--- a/packages/forms/src/elements/select/select.tsx
+++ b/packages/forms/src/elements/select/select.tsx
@@ -140,11 +140,7 @@ export const FFSelect: React.FC<FieldProps & Omit<SelectProps, 'children'>> = (
 	return (
 		<Field
 			{...fieldProps}
-			required={
-				fieldProps.required ||
-				typeof fieldProps.validate === 'function' ||
-				fieldProps.error
-			}
+			required={fieldProps.required}
 			render={({
 				input,
 				initialSelectedItem,

--- a/packages/forms/src/elements/text/text.tsx
+++ b/packages/forms/src/elements/text/text.tsx
@@ -82,7 +82,7 @@ export const FFInputText: React.FC<FieldProps> = React.forwardRef(
 		return (
 			<Field
 				{...fieldProps}
-				required={typeof fieldProps.validate === 'function' || fieldProps.error}
+				required={fieldProps.required}
 				render={(props) => <InputText {...props} {...fieldProps} ref={ref} />}
 			/>
 		);

--- a/packages/layout/src/components/__tests__/actuary.spec.tsx
+++ b/packages/layout/src/components/__tests__/actuary.spec.tsx
@@ -167,9 +167,9 @@ describe('Actuary Card', () => {
 		test('renders name fields', () => {
 			expect(findByTestId('actuary-name-form')).not.toBe(null);
 
-			var titleHtmlElement = findByTestId('title') as HTMLElement;
-			var firstNameHtmlElement = findByTestId('first-name') as HTMLElement;
-			var lastNameHtmlElement = findByTestId('last-name') as HTMLElement;
+			const titleHtmlElement = findByTestId('title') as HTMLElement;
+			const firstNameHtmlElement = findByTestId('first-name') as HTMLElement;
+			const lastNameHtmlElement = findByTestId('last-name') as HTMLElement;
 
 			expect(titleHtmlElement).toBeDefined();
 			expect(titleHtmlElement).toHaveAttribute('maxlength', '35');

--- a/packages/layout/src/components/__tests__/actuary.spec.tsx
+++ b/packages/layout/src/components/__tests__/actuary.spec.tsx
@@ -152,7 +152,9 @@ describe('Actuary Card', () => {
 			findByText = getByText;
 			findByTestId = getByTestId;
 
-			findByText('Actuary').click();
+			act(() => {
+				findByText('Actuary').click();
+			});
 		});
 
 		afterEach(() => {

--- a/packages/layout/src/components/__tests__/actuary.spec.tsx
+++ b/packages/layout/src/components/__tests__/actuary.spec.tsx
@@ -38,45 +38,41 @@ const actuary: Actuary = {
 };
 
 describe('Actuary Card', () => {
-	let component,
-		findByText,
-		findAllByText,
-		findByTitle,
-		findByRole,
-		findByTestId;
-	let updatedActuary = null;
-	beforeEach(async () => {
-		const {
-			container,
-			getByText,
-			getAllByText,
-			queryByTitle,
-			getByRole,
-			getByTestId,
-		} = render(
-			<ActuaryCard
-				actuary={actuary}
-				complete={true}
-				onCorrect={() => {}}
-				onRemove={noop}
-				onSaveContacts={noop}
-				onSaveName={(values) => {
-					updatedActuary = values;
-					return noop();
-				}}
-				testId={actuary.schemeRoleId.toString()}
-			/>,
-		);
-
-		component = container;
-		findByText = getByText;
-		findAllByText = getAllByText;
-		findByTitle = queryByTitle;
-		findByRole = getByRole;
-		findByTestId = getByTestId;
-	});
-
 	describe('Preview', () => {
+		let component,
+			findByText,
+			findAllByText,
+			findByTitle,
+			findByRole,
+			findByTestId;
+		beforeEach(() => {
+			const {
+				container,
+				getByText,
+				getAllByText,
+				queryByTitle,
+				getByRole,
+				getByTestId,
+			} = render(
+				<ActuaryCard
+					actuary={actuary}
+					complete={true}
+					onCorrect={() => {}}
+					onRemove={noop}
+					onSaveContacts={noop}
+					onSaveName={noop}
+					testId={actuary.schemeRoleId.toString()}
+				/>,
+			);
+
+			component = container;
+			findByText = getByText;
+			findAllByText = getAllByText;
+			findByTitle = queryByTitle;
+			findByRole = getByRole;
+			findByTestId = getByTestId;
+		});
+
 		test('no Violations', async () => {
 			const results = await axe(component);
 			expect(results).toHaveNoViolations();
@@ -133,10 +129,30 @@ describe('Actuary Card', () => {
 	});
 
 	describe('update Actuary Name', () => {
+		let component, findByText, findByTestId;
+		let updatedActuary = null;
+
 		beforeEach(async () => {
-			act(() => {
-				findByText('Actuary').click();
-			});
+			const { container, getByText, getByTestId } = render(
+				<ActuaryCard
+					actuary={actuary}
+					complete={true}
+					onCorrect={() => {}}
+					onRemove={noop}
+					onSaveContacts={noop}
+					onSaveName={(values) => {
+						updatedActuary = values;
+						return noop();
+					}}
+					testId={actuary.schemeRoleId.toString()}
+				/>,
+			);
+
+			component = container;
+			findByText = getByText;
+			findByTestId = getByTestId;
+
+			findByText('Actuary').click();
 		});
 
 		afterEach(() => {
@@ -223,7 +239,24 @@ describe('Actuary Card', () => {
 	});
 
 	describe('updating Actuary Contact Details', () => {
+		let component, findByText, findByTestId;
 		beforeEach(async () => {
+			const { container, getByText, getByTestId } = render(
+				<ActuaryCard
+					actuary={actuary}
+					complete={true}
+					onCorrect={() => {}}
+					onRemove={noop}
+					onSaveContacts={noop}
+					onSaveName={noop}
+					testId={actuary.schemeRoleId.toString()}
+				/>,
+			);
+
+			component = container;
+			findByText = getByText;
+			findByTestId = getByTestId;
+
 			findByText('Contact details').click();
 		});
 
@@ -281,9 +314,25 @@ describe('Actuary Card', () => {
 	});
 
 	describe('Remove Actuary', () => {
+		let component, findByText, findByTestId;
 		beforeEach(async () => {
-			findByText('Remove').click();
+			const { container, getByText, getByTestId } = render(
+				<ActuaryCard
+					actuary={actuary}
+					complete={true}
+					onCorrect={() => {}}
+					onRemove={noop}
+					onSaveContacts={noop}
+					onSaveName={noop}
+					testId={actuary.schemeRoleId.toString()}
+				/>,
+			);
 
+			component = container;
+			findByText = getByText;
+			findByTestId = getByTestId;
+
+			findByText('Remove').click();
 			const results = await axe(component);
 			expect(results).toHaveNoViolations();
 		});

--- a/packages/layout/src/components/__tests__/actuary.spec.tsx
+++ b/packages/layout/src/components/__tests__/actuary.spec.tsx
@@ -167,49 +167,31 @@ describe('Actuary Card', () => {
 		test('renders name fields', () => {
 			expect(findByTestId('actuary-name-form')).not.toBe(null);
 
-			var titleHtmlElement = findByText('Title (optional)') as HTMLElement;
-			var firstNameHtmlElement = findByText('First name') as HTMLElement;
-			var lastNameHtmlElement = findByText('Last name') as HTMLElement;
+			var titleHtmlElement = findByTestId('title') as HTMLElement;
+			var firstNameHtmlElement = findByTestId('first-name') as HTMLElement;
+			var lastNameHtmlElement = findByTestId('last-name') as HTMLElement;
 
 			expect(titleHtmlElement).toBeDefined();
-			expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'maxlength',
-				'35',
-			);
-			expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+			expect(titleHtmlElement).toHaveAttribute('maxlength', '35');
+			expect(titleHtmlElement).toHaveAttribute(
 				'autocomplete',
 				'honorific-prefix',
 			);
-			expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'value',
-				actuary.title,
-			);
+			expect(titleHtmlElement).toHaveAttribute('value', actuary.title);
 			expect(firstNameHtmlElement).toBeDefined();
-			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'maxlength',
-				'70',
-			);
-			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+			expect(firstNameHtmlElement).toHaveAttribute('maxlength', '70');
+			expect(firstNameHtmlElement).toHaveAttribute(
 				'autocomplete',
 				'given-name',
 			);
-			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'value',
-				actuary.firstName,
-			);
+			expect(firstNameHtmlElement).toHaveAttribute('value', actuary.firstName);
 			expect(lastNameHtmlElement).toBeDefined();
-			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'maxlength',
-				'70',
-			);
-			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+			expect(lastNameHtmlElement).toHaveAttribute('maxlength', '70');
+			expect(lastNameHtmlElement).toHaveAttribute(
 				'autocomplete',
 				'family-name',
 			);
-			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'value',
-				actuary.lastName,
-			);
+			expect(lastNameHtmlElement).toHaveAttribute('value', actuary.lastName);
 			expect(findByText('Save and close')).toBeDefined();
 			assertThatButtonHasBeenRemovedFromTheTabFlow(findByText, 'Remove');
 		});

--- a/packages/layout/src/components/__tests__/actuary.spec.tsx
+++ b/packages/layout/src/components/__tests__/actuary.spec.tsx
@@ -185,6 +185,7 @@ describe('Actuary Card', () => {
 				'given-name',
 			);
 			expect(firstNameHtmlElement).toHaveAttribute('value', actuary.firstName);
+			expect(firstNameHtmlElement).toHaveAttribute('required');
 			expect(lastNameHtmlElement).toBeDefined();
 			expect(lastNameHtmlElement).toHaveAttribute('maxlength', '70');
 			expect(lastNameHtmlElement).toHaveAttribute(
@@ -192,6 +193,7 @@ describe('Actuary Card', () => {
 				'family-name',
 			);
 			expect(lastNameHtmlElement).toHaveAttribute('value', actuary.lastName);
+			expect(lastNameHtmlElement).toHaveAttribute('required');
 			expect(findByText('Save and close')).toBeDefined();
 			assertThatButtonHasBeenRemovedFromTheTabFlow(findByText, 'Remove');
 		});

--- a/packages/layout/src/components/__tests__/actuary.spec.tsx
+++ b/packages/layout/src/components/__tests__/actuary.spec.tsx
@@ -224,9 +224,7 @@ describe('Actuary Card', () => {
 
 	describe('updating Actuary Contact Details', () => {
 		beforeEach(async () => {
-			act(() => {
-				findByText('Contact details').click();
-			});
+			findByText('Contact details').click();
 		});
 
 		afterEach(() => {
@@ -284,9 +282,7 @@ describe('Actuary Card', () => {
 
 	describe('Remove Actuary', () => {
 		beforeEach(async () => {
-			act(() => {
-				findByText('Remove').click();
-			});
+			findByText('Remove').click();
 
 			const results = await axe(component);
 			expect(results).toHaveNoViolations();

--- a/packages/layout/src/components/__tests__/actuary.spec.tsx
+++ b/packages/layout/src/components/__tests__/actuary.spec.tsx
@@ -38,41 +38,45 @@ const actuary: Actuary = {
 };
 
 describe('Actuary Card', () => {
+	let component,
+		findByText,
+		findAllByText,
+		findByTitle,
+		findByRole,
+		findByTestId;
+	let updatedActuary = null;
+	beforeEach(async () => {
+		const {
+			container,
+			getByText,
+			getAllByText,
+			queryByTitle,
+			getByRole,
+			getByTestId,
+		} = render(
+			<ActuaryCard
+				actuary={actuary}
+				complete={true}
+				onCorrect={() => {}}
+				onRemove={noop}
+				onSaveContacts={noop}
+				onSaveName={(values) => {
+					updatedActuary = values;
+					return noop();
+				}}
+				testId={actuary.schemeRoleId.toString()}
+			/>,
+		);
+
+		component = container;
+		findByText = getByText;
+		findAllByText = getAllByText;
+		findByTitle = queryByTitle;
+		findByRole = getByRole;
+		findByTestId = getByTestId;
+	});
+
 	describe('Preview', () => {
-		let component,
-			findByText,
-			findAllByText,
-			findByTitle,
-			findByRole,
-			findByTestId;
-		beforeEach(() => {
-			const {
-				container,
-				getByText,
-				getAllByText,
-				queryByTitle,
-				getByRole,
-				getByTestId,
-			} = render(
-				<ActuaryCard
-					actuary={actuary}
-					complete={true}
-					onCorrect={() => {}}
-					onRemove={noop}
-					onSaveContacts={noop}
-					onSaveName={noop}
-					testId={actuary.schemeRoleId.toString()}
-				/>,
-			);
-
-			component = container;
-			findByText = getByText;
-			findAllByText = getAllByText;
-			findByTitle = queryByTitle;
-			findByRole = getByRole;
-			findByTestId = getByTestId;
-		});
-
 		test('no Violations', async () => {
 			const results = await axe(component);
 			expect(results).toHaveNoViolations();
@@ -129,29 +133,7 @@ describe('Actuary Card', () => {
 	});
 
 	describe('update Actuary Name', () => {
-		let component, findByText, findByTestId;
-		let updatedActuary = null;
-
 		beforeEach(async () => {
-			const { container, getByText, getByTestId } = render(
-				<ActuaryCard
-					actuary={actuary}
-					complete={true}
-					onCorrect={() => {}}
-					onRemove={noop}
-					onSaveContacts={noop}
-					onSaveName={(values) => {
-						updatedActuary = values;
-						return noop();
-					}}
-					testId={actuary.schemeRoleId.toString()}
-				/>,
-			);
-
-			component = container;
-			findByText = getByText;
-			findByTestId = getByTestId;
-
 			act(() => {
 				findByText('Actuary').click();
 			});
@@ -241,25 +223,10 @@ describe('Actuary Card', () => {
 	});
 
 	describe('updating Actuary Contact Details', () => {
-		let component, findByText, findByTestId;
 		beforeEach(async () => {
-			const { container, getByText, getByTestId } = render(
-				<ActuaryCard
-					actuary={actuary}
-					complete={true}
-					onCorrect={() => {}}
-					onRemove={noop}
-					onSaveContacts={noop}
-					onSaveName={noop}
-					testId={actuary.schemeRoleId.toString()}
-				/>,
-			);
-
-			component = container;
-			findByText = getByText;
-			findByTestId = getByTestId;
-
-			findByText('Contact details').click();
+			act(() => {
+				findByText('Contact details').click();
+			});
 		});
 
 		afterEach(() => {
@@ -316,25 +283,11 @@ describe('Actuary Card', () => {
 	});
 
 	describe('Remove Actuary', () => {
-		let component, findByText, findByTestId;
 		beforeEach(async () => {
-			const { container, getByText, getByTestId } = render(
-				<ActuaryCard
-					actuary={actuary}
-					complete={true}
-					onCorrect={() => {}}
-					onRemove={noop}
-					onSaveContacts={noop}
-					onSaveName={noop}
-					testId={actuary.schemeRoleId.toString()}
-				/>,
-			);
+			act(() => {
+				findByText('Remove').click();
+			});
 
-			component = container;
-			findByText = getByText;
-			findByTestId = getByTestId;
-
-			findByText('Remove').click();
 			const results = await axe(component);
 			expect(results).toHaveNoViolations();
 		});

--- a/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
+++ b/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
@@ -165,46 +165,34 @@ describe('Corporate Group Trustee Card', () => {
 
 		test('editing Name of the chair of the board', () => {
 			expect(findByTestId('corporateGroup-name-form')).not.toBe(null);
-			const titleHtmlElement = findByText('Title (optional)') as HTMLElement;
-			const firstNameHtmlElement = findByText('First name') as HTMLElement;
-			const lastNameHtmlElement = findByText('Last name') as HTMLElement;
+			var titleHtmlElement = findByTestId('title') as HTMLElement;
+			var firstNameHtmlElement = findByTestId('first-name') as HTMLElement;
+			var lastNameHtmlElement = findByTestId('last-name') as HTMLElement;
 
 			expect(titleHtmlElement).toBeDefined();
-			expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'maxlength',
-				'35',
-			);
-			expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+			expect(titleHtmlElement).toHaveAttribute('maxlength', '35');
+			expect(titleHtmlElement).toHaveAttribute(
 				'autocomplete',
 				'honorific-prefix',
 			);
-			expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'value',
-				corporateGroup.title,
-			);
+			expect(titleHtmlElement).toHaveAttribute('value', corporateGroup.title);
 			expect(firstNameHtmlElement).toBeDefined();
-			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'maxlength',
-				'70',
-			);
-			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+			expect(firstNameHtmlElement).toHaveAttribute('maxlength', '70');
+			expect(firstNameHtmlElement).toHaveAttribute(
 				'autocomplete',
 				'given-name',
 			);
-			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+			expect(firstNameHtmlElement).toHaveAttribute(
 				'value',
 				corporateGroup.firstName,
 			);
 			expect(lastNameHtmlElement).toBeDefined();
-			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'maxlength',
-				'70',
-			);
-			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+			expect(lastNameHtmlElement).toHaveAttribute('maxlength', '70');
+			expect(lastNameHtmlElement).toHaveAttribute(
 				'autocomplete',
 				'family-name',
 			);
-			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+			expect(lastNameHtmlElement).toHaveAttribute(
 				'value',
 				corporateGroup.lastName,
 			);

--- a/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
+++ b/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
@@ -165,9 +165,9 @@ describe('Corporate Group Trustee Card', () => {
 
 		test('editing Name of the chair of the board', () => {
 			expect(findByTestId('corporateGroup-name-form')).not.toBe(null);
-			var titleHtmlElement = findByTestId('title') as HTMLElement;
-			var firstNameHtmlElement = findByTestId('first-name') as HTMLElement;
-			var lastNameHtmlElement = findByTestId('last-name') as HTMLElement;
+			const titleHtmlElement = findByTestId('title') as HTMLElement;
+			const firstNameHtmlElement = findByTestId('first-name') as HTMLElement;
+			const lastNameHtmlElement = findByTestId('last-name') as HTMLElement;
 
 			expect(titleHtmlElement).toBeDefined();
 			expect(titleHtmlElement).toHaveAttribute('maxlength', '35');

--- a/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
+++ b/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
@@ -151,9 +151,7 @@ describe('Corporate Group Trustee Card', () => {
 			findByText = getByText;
 			findByTestId = getByTestId;
 
-			act(() => {
-				findByText('Chair of board').click();
-			});
+			findByText('Chair of board').click();
 		});
 
 		afterEach(() => {

--- a/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
+++ b/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
@@ -151,7 +151,9 @@ describe('Corporate Group Trustee Card', () => {
 			findByText = getByText;
 			findByTestId = getByTestId;
 
-			findByText('Chair of board').click();
+			act(() => {
+				findByText('Chair of board').click();
+			});
 		});
 
 		afterEach(() => {

--- a/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
+++ b/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
@@ -186,6 +186,7 @@ describe('Corporate Group Trustee Card', () => {
 				'value',
 				corporateGroup.firstName,
 			);
+			expect(firstNameHtmlElement).toHaveAttribute('required');
 			expect(lastNameHtmlElement).toBeDefined();
 			expect(lastNameHtmlElement).toHaveAttribute('maxlength', '70');
 			expect(lastNameHtmlElement).toHaveAttribute(
@@ -196,6 +197,7 @@ describe('Corporate Group Trustee Card', () => {
 				'value',
 				corporateGroup.lastName,
 			);
+			expect(lastNameHtmlElement).toHaveAttribute('required');
 			expect(findByText('Continue')).toBeDefined();
 		});
 

--- a/packages/layout/src/components/__tests__/inHouse.spec.tsx
+++ b/packages/layout/src/components/__tests__/inHouse.spec.tsx
@@ -114,7 +114,9 @@ describe('Update in-house trustee name', () => {
 		findByText = getByText;
 		findByTestId = getByTestId;
 
-		findByText('In House Administrator').click();
+		act(() => {
+			findByText('In House Administrator').click();
+		});
 	});
 
 	test('is accessible', async () => {

--- a/packages/layout/src/components/__tests__/inHouse.spec.tsx
+++ b/packages/layout/src/components/__tests__/inHouse.spec.tsx
@@ -124,9 +124,9 @@ describe('Update in-house trustee name', () => {
 
 	test('renders name fields', () => {
 		expect(findByTestId('inHouseAdmin-name-form')).not.toBe(null);
-		var titleHtmlElement = findByTestId('title') as HTMLElement;
-		var firstNameHtmlElement = findByTestId('first-name') as HTMLElement;
-		var lastNameHtmlElement = findByTestId('last-name') as HTMLElement;
+		const titleHtmlElement = findByTestId('title') as HTMLElement;
+		const firstNameHtmlElement = findByTestId('first-name') as HTMLElement;
+		const lastNameHtmlElement = findByTestId('last-name') as HTMLElement;
 
 		expect(titleHtmlElement).toBeDefined();
 		expect(titleHtmlElement).toHaveAttribute('maxlength', '35');

--- a/packages/layout/src/components/__tests__/inHouse.spec.tsx
+++ b/packages/layout/src/components/__tests__/inHouse.spec.tsx
@@ -124,49 +124,28 @@ describe('Update in-house trustee name', () => {
 
 	test('renders name fields', () => {
 		expect(findByTestId('inHouseAdmin-name-form')).not.toBe(null);
-		const titleHtmlElement = findByText('Title (optional)') as HTMLElement;
-		const firstNameHtmlElement = findByText('First name') as HTMLElement;
-		const lastNameHtmlElement = findByText('Last name') as HTMLElement;
+		var titleHtmlElement = findByTestId('title') as HTMLElement;
+		var firstNameHtmlElement = findByTestId('first-name') as HTMLElement;
+		var lastNameHtmlElement = findByTestId('last-name') as HTMLElement;
 
 		expect(titleHtmlElement).toBeDefined();
-		expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-			'maxlength',
-			'35',
-		);
-		expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+		expect(titleHtmlElement).toHaveAttribute('maxlength', '35');
+		expect(titleHtmlElement).toHaveAttribute(
 			'autocomplete',
 			'honorific-prefix',
 		);
-		expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-			'value',
-			inHouseAdmin.title,
-		);
+		expect(titleHtmlElement).toHaveAttribute('value', inHouseAdmin.title);
 		expect(firstNameHtmlElement).toBeDefined();
-		expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-			'maxlength',
-			'70',
-		);
-		expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-			'autocomplete',
-			'given-name',
-		);
-		expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+		expect(firstNameHtmlElement).toHaveAttribute('maxlength', '70');
+		expect(firstNameHtmlElement).toHaveAttribute('autocomplete', 'given-name');
+		expect(firstNameHtmlElement).toHaveAttribute(
 			'value',
 			inHouseAdmin.firstName,
 		);
 		expect(lastNameHtmlElement).toBeDefined();
-		expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-			'maxlength',
-			'70',
-		);
-		expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-			'autocomplete',
-			'family-name',
-		);
-		expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-			'value',
-			inHouseAdmin.lastName,
-		);
+		expect(lastNameHtmlElement).toHaveAttribute('maxlength', '70');
+		expect(lastNameHtmlElement).toHaveAttribute('autocomplete', 'family-name');
+		expect(lastNameHtmlElement).toHaveAttribute('value', inHouseAdmin.lastName);
 		expect(findByText('Save and close')).toBeDefined();
 
 		assertThatButtonHasBeenRemovedFromTheTabFlow(findByText, 'Remove');

--- a/packages/layout/src/components/__tests__/inHouse.spec.tsx
+++ b/packages/layout/src/components/__tests__/inHouse.spec.tsx
@@ -114,9 +114,7 @@ describe('Update in-house trustee name', () => {
 		findByText = getByText;
 		findByTestId = getByTestId;
 
-		act(() => {
-			findByText('In House Administrator').click();
-		});
+		findByText('In House Administrator').click();
 	});
 
 	test('is accessible', async () => {

--- a/packages/layout/src/components/__tests__/inHouse.spec.tsx
+++ b/packages/layout/src/components/__tests__/inHouse.spec.tsx
@@ -142,10 +142,12 @@ describe('Update in-house trustee name', () => {
 			'value',
 			inHouseAdmin.firstName,
 		);
+		expect(firstNameHtmlElement).toHaveAttribute('required');
 		expect(lastNameHtmlElement).toBeDefined();
 		expect(lastNameHtmlElement).toHaveAttribute('maxlength', '70');
 		expect(lastNameHtmlElement).toHaveAttribute('autocomplete', 'family-name');
 		expect(lastNameHtmlElement).toHaveAttribute('value', inHouseAdmin.lastName);
+		expect(lastNameHtmlElement).toHaveAttribute('required');
 		expect(findByText('Save and close')).toBeDefined();
 
 		assertThatButtonHasBeenRemovedFromTheTabFlow(findByText, 'Remove');

--- a/packages/layout/src/components/__tests__/trustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/trustee.spec.tsx
@@ -159,9 +159,7 @@ describe('TrusteeCard enableContactDetails == true', () => {
 		});
 
 		test('renders name fields', () => {
-			act(() => {
-				findByText('Trustee').click();
-			});
+			findByText('Trustee').click();
 
 			expect(findByTestId('trustee-name-form')).not.toBe(null);
 

--- a/packages/layout/src/components/__tests__/trustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/trustee.spec.tsx
@@ -182,6 +182,7 @@ describe('TrusteeCard enableContactDetails == true', () => {
 				'given-name',
 			);
 			expect(firstNameHtmlElement).toHaveAttribute('value', trustee.firstName);
+			expect(firstNameHtmlElement).toHaveAttribute('required');
 			expect(lastNameHtmlElement).toBeDefined();
 			expect(lastNameHtmlElement).toHaveAttribute('maxlength', '70');
 			expect(lastNameHtmlElement).toHaveAttribute(
@@ -189,6 +190,7 @@ describe('TrusteeCard enableContactDetails == true', () => {
 				'family-name',
 			);
 			expect(lastNameHtmlElement).toHaveAttribute('value', trustee.lastName);
+			expect(lastNameHtmlElement).toHaveAttribute('required');
 			expect(findByText('Continue')).toBeDefined();
 
 			assertThatButtonHasBeenRemovedFromTheTabFlow(findByText, 'Remove');

--- a/packages/layout/src/components/__tests__/trustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/trustee.spec.tsx
@@ -159,7 +159,9 @@ describe('TrusteeCard enableContactDetails == true', () => {
 		});
 
 		test('renders name fields', () => {
-			findByText('Trustee').click();
+			act(() => {
+				findByText('Trustee').click();
+			});
 
 			expect(findByTestId('trustee-name-form')).not.toBe(null);
 

--- a/packages/layout/src/components/__tests__/trustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/trustee.spec.tsx
@@ -163,9 +163,9 @@ describe('TrusteeCard enableContactDetails == true', () => {
 
 			expect(findByTestId('trustee-name-form')).not.toBe(null);
 
-			var titleHtmlElement = findByTestId('title') as HTMLElement;
-			var firstNameHtmlElement = findByTestId('first-name') as HTMLElement;
-			var lastNameHtmlElement = findByTestId('last-name') as HTMLElement;
+			const titleHtmlElement = findByTestId('title') as HTMLElement;
+			const firstNameHtmlElement = findByTestId('first-name') as HTMLElement;
+			const lastNameHtmlElement = findByTestId('last-name') as HTMLElement;
 
 			expect(titleHtmlElement).toBeDefined();
 			expect(titleHtmlElement).toHaveAttribute('maxlength', '35');

--- a/packages/layout/src/components/__tests__/trustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/trustee.spec.tsx
@@ -168,7 +168,6 @@ describe('TrusteeCard enableContactDetails == true', () => {
 			var lastNameHtmlElement = findByTestId('last-name') as HTMLElement;
 
 			expect(titleHtmlElement).toBeDefined();
-			console.log(titleHtmlElement);
 			expect(titleHtmlElement).toHaveAttribute('maxlength', '35');
 			expect(titleHtmlElement).toHaveAttribute(
 				'autocomplete',

--- a/packages/layout/src/components/__tests__/trustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/trustee.spec.tsx
@@ -163,49 +163,32 @@ describe('TrusteeCard enableContactDetails == true', () => {
 
 			expect(findByTestId('trustee-name-form')).not.toBe(null);
 
-			var titleHtmlElement = findByText('Title (optional)') as HTMLElement;
-			var firstNameHtmlElement = findByText('First name') as HTMLElement;
-			var lastNameHtmlElement = findByText('Last name') as HTMLElement;
+			var titleHtmlElement = findByTestId('title') as HTMLElement;
+			var firstNameHtmlElement = findByTestId('first-name') as HTMLElement;
+			var lastNameHtmlElement = findByTestId('last-name') as HTMLElement;
 
 			expect(titleHtmlElement).toBeDefined();
-			expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'maxlength',
-				'35',
-			);
-			expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+			console.log(titleHtmlElement);
+			expect(titleHtmlElement).toHaveAttribute('maxlength', '35');
+			expect(titleHtmlElement).toHaveAttribute(
 				'autocomplete',
 				'honorific-prefix',
 			);
-			expect(titleHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'value',
-				trustee.title,
-			);
+			expect(titleHtmlElement).toHaveAttribute('value', trustee.title);
 			expect(firstNameHtmlElement).toBeDefined();
-			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'maxlength',
-				'70',
-			);
-			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+			expect(firstNameHtmlElement).toHaveAttribute('maxlength', '70');
+			expect(firstNameHtmlElement).toHaveAttribute(
 				'autocomplete',
 				'given-name',
 			);
-			expect(firstNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'value',
-				trustee.firstName,
-			);
+			expect(firstNameHtmlElement).toHaveAttribute('value', trustee.firstName);
 			expect(lastNameHtmlElement).toBeDefined();
-			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'maxlength',
-				'70',
-			);
-			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
+			expect(lastNameHtmlElement).toHaveAttribute('maxlength', '70');
+			expect(lastNameHtmlElement).toHaveAttribute(
 				'autocomplete',
 				'family-name',
 			);
-			expect(lastNameHtmlElement.nextSibling.childNodes[0]).toHaveAttribute(
-				'value',
-				trustee.lastName,
-			);
+			expect(lastNameHtmlElement).toHaveAttribute('value', trustee.lastName);
 			expect(findByText('Continue')).toBeDefined();
 
 			assertThatButtonHasBeenRemovedFromTheTabFlow(findByText, 'Remove');

--- a/packages/layout/src/components/cards/actuary/views/name/index.tsx
+++ b/packages/layout/src/components/cards/actuary/views/name/index.tsx
@@ -32,6 +32,7 @@ const getFields = (
 		error: fields.firstName.error,
 		maxLength: fields.firstName.maxlength,
 		inputWidth: 6,
+		required: true,
 		testId: 'first-name',
 		cfg: { mb: 4 },
 	},
@@ -43,6 +44,7 @@ const getFields = (
 		error: fields.lastName.error,
 		maxLength: fields.lastName.maxlength,
 		testId: 'last-name',
+		required: true,
 		inputWidth: 6,
 	},
 ];

--- a/packages/layout/src/components/cards/actuary/views/name/index.tsx
+++ b/packages/layout/src/components/cards/actuary/views/name/index.tsx
@@ -21,6 +21,7 @@ const getFields = (
 		error: fields.title.error,
 		maxLength: fields.title.maxlength,
 		inputWidth: 1,
+		testId: 'title',
 		cfg: { mb: 4 },
 	},
 	{
@@ -31,6 +32,7 @@ const getFields = (
 		error: fields.firstName.error,
 		maxLength: fields.firstName.maxlength,
 		inputWidth: 6,
+		testId: 'first-name',
 		cfg: { mb: 4 },
 	},
 	{
@@ -40,6 +42,7 @@ const getFields = (
 		label: fields.lastName.label,
 		error: fields.lastName.error,
 		maxLength: fields.lastName.maxlength,
+		testId: 'last-name',
 		inputWidth: 6,
 	},
 ];

--- a/packages/layout/src/components/cards/common/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/date/date.tsx
@@ -41,7 +41,7 @@ const DateForm: React.FC<DateFormProps> = ({
 				}}
 			>
 				{({ handleSubmit, submitError }) => (
-					<form onSubmit={handleSubmit} data-testid={testId}>
+					<form onSubmit={handleSubmit} data-testid={testId} noValidate>
 						<div aria-describedby={errorMsg}>
 							<FFCheckbox
 								name="confirm"

--- a/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
@@ -42,7 +42,7 @@ export const Reason: React.FC<ReasonProps> = ({
 					const showError: boolean = !!submitError && !reason;
 					const leftScheme: boolean = reason === 'left_the_scheme';
 					return (
-						<form onSubmit={handleSubmit} data-testid={`remove-${type}-form`}>
+						<form onSubmit={handleSubmit} data-testid={`remove-${type}-form`} noValidate>
 							<div className={showError ? styles.labelError : null}>
 								<fieldset>
 									<legend>

--- a/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
@@ -42,7 +42,11 @@ export const Reason: React.FC<ReasonProps> = ({
 					const showError: boolean = !!submitError && !reason;
 					const leftScheme: boolean = reason === 'left_the_scheme';
 					return (
-						<form onSubmit={handleSubmit} data-testid={`remove-${type}-form`} noValidate>
+						<form
+							onSubmit={handleSubmit}
+							data-testid={`remove-${type}-form`}
+							noValidate
+						>
 							<div className={showError ? styles.labelError : null}>
 								<fieldset>
 									<legend>

--- a/packages/layout/src/components/cards/corporateGroup/views/name/name.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/name/name.tsx
@@ -31,6 +31,7 @@ const getFields = (
 		error: fields.firstName.error,
 		maxLength: fields.firstName.maxlength,
 		inputWidth: 6,
+		required: true,
 		testId: 'first-name',
 		cfg: { mb: 4 },
 	},
@@ -42,6 +43,7 @@ const getFields = (
 		error: fields.lastName.error,
 		maxLength: fields.lastName.maxlength,
 		inputWidth: 6,
+		required: true,
 		testId: 'last-name',
 	},
 ];

--- a/packages/layout/src/components/cards/corporateGroup/views/name/name.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/name/name.tsx
@@ -20,6 +20,7 @@ const getFields = (
 		error: fields.title.error,
 		maxLength: fields.title.maxlength,
 		inputWidth: 1,
+		testId: 'title',
 		cfg: { mb: 4 },
 	},
 	{
@@ -30,6 +31,7 @@ const getFields = (
 		error: fields.firstName.error,
 		maxLength: fields.firstName.maxlength,
 		inputWidth: 6,
+		testId: 'first-name',
 		cfg: { mb: 4 },
 	},
 	{
@@ -40,6 +42,7 @@ const getFields = (
 		error: fields.lastName.error,
 		maxLength: fields.lastName.maxlength,
 		inputWidth: 6,
+		testId: 'last-name',
 	},
 ];
 interface NameScreenProps {

--- a/packages/layout/src/components/cards/inHouse/views/name/index.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/name/index.tsx
@@ -33,6 +33,7 @@ const getFields = (
 		maxLength: fields.firstName.maxlength,
 		inputWidth: 6,
 		testId: 'first-name',
+		required: true,
 		cfg: { mb: 4 },
 	},
 	{
@@ -43,6 +44,7 @@ const getFields = (
 		error: fields.lastName.error,
 		maxLength: fields.lastName.maxlength,
 		inputWidth: 6,
+		required: true,
 		testId: 'last-name',
 	},
 ];

--- a/packages/layout/src/components/cards/inHouse/views/name/index.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/name/index.tsx
@@ -21,6 +21,7 @@ const getFields = (
 		error: fields.title.error,
 		maxLength: fields.title.maxlength,
 		inputWidth: 1,
+		testId: 'title',
 		cfg: { mb: 4 },
 	},
 	{
@@ -31,6 +32,7 @@ const getFields = (
 		error: fields.firstName.error,
 		maxLength: fields.firstName.maxlength,
 		inputWidth: 6,
+		testId: 'first-name',
 		cfg: { mb: 4 },
 	},
 	{
@@ -41,6 +43,7 @@ const getFields = (
 		error: fields.lastName.error,
 		maxLength: fields.lastName.maxlength,
 		inputWidth: 6,
+		testId: 'last-name',
 	},
 ];
 

--- a/packages/layout/src/components/cards/trustee/views/name/index.tsx
+++ b/packages/layout/src/components/cards/trustee/views/name/index.tsx
@@ -20,6 +20,7 @@ const getFields = (
 		label: fields.title.label,
 		error: fields.title.error,
 		maxLength: fields.title.maxlength,
+		testId: 'title',
 		inputWidth: 1,
 		cfg: { mb: 4 },
 	},
@@ -30,6 +31,7 @@ const getFields = (
 		label: fields.firstName.label,
 		error: fields.firstName.error,
 		maxLength: fields.firstName.maxlength,
+		testId: 'first-name',
 		inputWidth: 6,
 		cfg: { mb: 4 },
 	},
@@ -40,6 +42,7 @@ const getFields = (
 		label: fields.lastName.label,
 		error: fields.lastName.error,
 		maxLength: fields.lastName.maxlength,
+		testId: 'last-name',
 		inputWidth: 6,
 	},
 ];

--- a/packages/layout/src/components/cards/trustee/views/name/index.tsx
+++ b/packages/layout/src/components/cards/trustee/views/name/index.tsx
@@ -33,6 +33,7 @@ const getFields = (
 		maxLength: fields.firstName.maxlength,
 		testId: 'first-name',
 		inputWidth: 6,
+		required: true,
 		cfg: { mb: 4 },
 	},
 	{
@@ -43,6 +44,7 @@ const getFields = (
 		error: fields.lastName.error,
 		maxLength: fields.lastName.maxlength,
 		testId: 'last-name',
+		required: true,
 		inputWidth: 6,
 	},
 ];


### PR DESCRIPTION
Do not render the required attribute just because a component has a validation function assigned. The required attribute denotes a mandatory field; validation functions can be assigned to optional fields as well.