### PR TITLE
Better checkboxes for declare and submit page

### DIFF
--- a/packages/forms/src/__tests__/checkbox.spec.tsx
+++ b/packages/forms/src/__tests__/checkbox.spec.tsx
@@ -50,6 +50,35 @@ describe('Checkbox input', () => {
 	`);
 	});
 
+	test('renders required attribute', () => {
+		const { getByLabelText } = formSetup({
+			render: (
+				<FFCheckbox
+					required
+					label="Click me"
+					name="important-checkbox"
+					testId="checkbox"
+				/>
+			),
+		});
+		const required = getByLabelText(/Click me/);
+		expect(required).toHaveAttribute('required');
+	});
+
+	test('does not render required attribute when optional', () => {
+		const { getByLabelText } = formSetup({
+			render: (
+				<FFCheckbox
+					label="Click me"
+					name="important-checkbox"
+					testId="checkbox"
+				/>
+			),
+		});
+		const optional = getByLabelText(/Click me/);
+		expect(optional).not.toHaveAttribute('required');
+	});
+
 	test('checking and unchecking the checkbox', () => {
 		const { getByLabelText, getByTestId } = formSetup({
 			render: (

--- a/packages/forms/src/__tests__/checkbox.spec.tsx
+++ b/packages/forms/src/__tests__/checkbox.spec.tsx
@@ -135,11 +135,11 @@ describe('Checkbox input', () => {
 		expect(getByTestId(container, 'my-span').innerText).toBe('true');
 	});
 
-	test('has correct describedby tag', () => {
+	test('renders hint within the label', () => {
 		const hint = 'This explains how to complete the field';
 		const labelText = 'My checkbox';
 		const id = 'test-checkbox';
-		const { getByLabelText } = formSetup({
+		const { getByText } = formSetup({
 			render: (
 				<FFCheckbox
 					id={id}
@@ -150,9 +150,11 @@ describe('Checkbox input', () => {
 				/>
 			),
 		});
-		const checkbox = getByLabelText(labelText);
-		expect(checkbox).not.toBeNull();
-		expect(checkbox).toHaveAttribute('aria-describedby', `${id}-hint`);
+		const hintElement = getByText(hint);
+		expect(hintElement).not.toBeNull();
+
+		const label = hintElement.closest('label');
+		expect(label).toBeDefined();
 	});
 
 	test('has correct label reference', () => {

--- a/packages/forms/src/__tests__/checkbox.spec.tsx
+++ b/packages/forms/src/__tests__/checkbox.spec.tsx
@@ -79,6 +79,25 @@ describe('Checkbox input', () => {
 		expect(optional).not.toHaveAttribute('required');
 	});
 
+	test('renders children within the label', () => {
+		const { getByText } = formSetup({
+			render: (
+				<FFCheckbox
+					label="Click me"
+					name="important-checkbox"
+					testId="checkbox"
+				>
+					<p>Child component</p>
+				</FFCheckbox>
+			),
+		});
+		const child = getByText(/Child component/);
+		expect(child).toBeDefined();
+
+		const label = child.closest('label');
+		expect(label).toBeDefined();
+	});
+
 	test('checking and unchecking the checkbox', () => {
 		const { getByLabelText, getByTestId } = formSetup({
 			render: (

--- a/packages/forms/src/__tests__/radio.spec.tsx
+++ b/packages/forms/src/__tests__/radio.spec.tsx
@@ -17,26 +17,24 @@ const basicProps: FieldProps = {
 };
 
 describe('Radio input', () => {
-	describe('rendering', () => {
-		test('renders correctly', () => {
-			const { queryByTestId } = formSetup({
-				render: <FFRadioButton {...basicProps} />,
-			});
-
-			const button = queryByTestId(testId);
-			expect(button).toBeDefined();
-			expect(button).toHaveAttribute('value', basicProps.value);
-			expect(button).not.toHaveAttribute('required');
+	test('renders correctly', () => {
+		const { queryByTestId } = formSetup({
+			render: <FFRadioButton {...basicProps} />,
 		});
 
-		test('can render with required attribute', () => {
-			const { queryByTestId } = formSetup({
-				render: <FFRadioButton {...basicProps} required={true} />,
-			});
+		const button = queryByTestId(testId);
+		expect(button).toBeDefined();
+		expect(button).toHaveAttribute('value', basicProps.value);
+		expect(button).not.toHaveAttribute('required');
+	});
 
-			const button = queryByTestId(testId);
-			expect(button).toHaveAttribute('required');
+	test('can render with required attribute', () => {
+		const { queryByTestId } = formSetup({
+			render: <FFRadioButton {...basicProps} required={true} />,
 		});
+
+		const button = queryByTestId(testId);
+		expect(button).toHaveAttribute('required');
 	});
 
 	test('is accessible', async () => {
@@ -176,11 +174,11 @@ describe('Radio input', () => {
 		);
 	});
 
-	test('has correct describedby tag', () => {
+	test('renders hint within the label', () => {
 		const hint = 'This explains how to complete the field';
 		const labelText = 'My radiobutton';
 		const id = 'test-radiobutton';
-		const { getByLabelText } = formSetup({
+		const { getByText } = formSetup({
 			render: (
 				<FFRadioButton
 					id={id}
@@ -191,9 +189,11 @@ describe('Radio input', () => {
 				/>
 			),
 		});
-		const radio = getByLabelText(labelText);
-		expect(radio).not.toBeNull();
-		expect(radio).toHaveAttribute('aria-describedby', `${id}-hint`);
+		const hintElement = getByText(hint);
+		expect(hintElement).not.toBeNull();
+
+		const label = hintElement.closest('label');
+		expect(label).toBeDefined();
 	});
 
 	test('has correct label reference', () => {

--- a/packages/forms/src/elements/checkbox/checkbox.mdx
+++ b/packages/forms/src/elements/checkbox/checkbox.mdx
@@ -9,6 +9,7 @@ import { Form } from 'react-final-form';
 import { FFCheckbox } from './checkbox';
 import { SeparatorY, SeparatorX } from '../separator';
 import styles from '../elements.module.scss';
+import { EditorFonts } from '@tpr/theming';
 
 # Checkbox
 
@@ -61,6 +62,21 @@ import { FFCheckbox } from '@tpr/forms';
 					label="Select option 2"
 					callback={(value) => console.log('callback:', value)}
 				/>
+				<FFCheckbox
+					name="checkbox-c"
+					label="Select option 3"
+					cfg={{ mb: 4 }}
+					callback={(value) => console.log('callback:', value)}
+				>
+					<EditorFonts>
+						<p>
+							This is a rich text child component
+							<a href="https://example.org">supporting links</a> and <strong>
+								important text
+							</strong> as part of the label.
+						</p>
+					</EditorFonts>
+				</FFCheckbox>
 				<button type="submit" style={{ display: 'none' }}>
 					Submit
 				</button>

--- a/packages/forms/src/elements/checkbox/checkbox.mdx
+++ b/packages/forms/src/elements/checkbox/checkbox.mdx
@@ -131,17 +131,21 @@ import { FFCheckbox } from '@tpr/forms';
 	</Form>
 </Playground>
 
-### Disabled
+### Disabled and required
 
 <Playground>
 	<Form onSubmit={console.log} initialValues={{ 'checkbox-c': true }}>
 		{({ handleSubmit }) => (
 			<form onSubmit={handleSubmit}>
-				<FFCheckbox name="checkbox-a" label="Select option 1" disabled={true} />
+				<FFCheckbox
+					name="checkbox-a"
+					label="Select disabled option 1"
+					disabled={true}
+				/>
 				<FFCheckbox
 					name="checkbox-b"
-					disabled={true}
-					label="Select option 2"
+					required={true}
+					label="Select required option 2"
 					hint="Lorem, ipsum dolor sit amet consectetur adipisicing elit. Ea obcaecati repellat molestias nemo deleniti eveniet vel similique nesciunt fugiat nisi?"
 				/>
 				<button type="submit" style={{ display: 'none' }}>
@@ -216,6 +220,7 @@ Accepted config props: FlexProps, SpaceProps
 | callback | false    | function             | callback function that runs after every onChange event, receives a boolean indicating if checked |
 | cfg      | false    | object               | FlexProps & SpaceProps                                                                           |
 | disabled | false    | boolean              | Disable checkbox                                                                                 |
+| required | false    | boolean              | Mark checkbox as required                                                                        |
 | testId   | false    | string               | data attribute for testers                                                                       |
 | checked  | true     | boolean              | Specifies whether the checkbox is selected.                                                      |
 | onChange | true     | function(evt: Event) | The callback function that is triggered when the state changes.                                  |

--- a/packages/forms/src/elements/checkbox/checkbox.module.scss
+++ b/packages/forms/src/elements/checkbox/checkbox.module.scss
@@ -2,12 +2,17 @@
 // typography.module.scss includes '@tpr/theming/lib/variables.scss'
 
 .wrapper {
-	display: flex;
-	flex: 0 0 auto;
-	align-items: center;
-	line-height: 1.4;
 	cursor: pointer;
 	user-select: none;
+
+	.innerWrapper {
+		display: flex;
+		flex: 0 0 auto;
+		align-items: center;
+		line-height: 1.4;
+		max-height: 2em;
+		overflow: visible;
+	}
 
 	input[type='checkbox']:focus + .checkbox {
 		box-shadow: 0 0 0 4px #ffd300;
@@ -18,7 +23,8 @@
 	}
 
 	.checkbox {
-		// outline: 1px dashed red;
+		min-width: 40px;
+		min-height: 40px;
 	}
 }
 
@@ -37,5 +43,6 @@
 }
 
 .label {
+	margin-left: $space-3;
 	@include removeMarginBottom;
 }

--- a/packages/forms/src/elements/checkbox/checkbox.tsx
+++ b/packages/forms/src/elements/checkbox/checkbox.tsx
@@ -20,6 +20,7 @@ export const Checkbox: React.FC<Partial<CheckboxIconProps>> = ({
 	label,
 	hint,
 	className,
+	children,
 }) => {
 	const msg = testId ? `${testId}-${checked ? 'checked' : 'unchecked'}` : null;
 	const helper = new AccessibilityHelper(id, !!label, !!hint);
@@ -66,6 +67,11 @@ export const Checkbox: React.FC<Partial<CheckboxIconProps>> = ({
 					<P id={helper.hintId} className={styles.hint}>
 						{hint}
 					</P>
+				)}
+				{children && (
+					<div id={helper.hintId} className={styles.hint}>
+						{children}
+					</div>
 				)}
 			</label>
 		</StyledInputLabel>

--- a/packages/forms/src/elements/checkbox/checkbox.tsx
+++ b/packages/forms/src/elements/checkbox/checkbox.tsx
@@ -44,29 +44,30 @@ export const Checkbox: React.FC<Partial<CheckboxIconProps>> = ({
 				className={styles.wrapper}
 				htmlFor={id}
 			>
-				<HiddenInput
-					id={id}
-					type="checkbox"
-					aria-describedby={helper && helper.hintId}
-					checked={checked}
-					disabled={disabled}
-					required={required}
-					onChange={onChange}
-				/>
-				{checked ? (
-					<CheckboxChecked className={styles.checkbox} />
-				) : (
-					<CheckboxBlank className={styles.checkbox} />
+				<div className={styles.innerWrapper}>
+					<HiddenInput
+						id={id}
+						type="checkbox"
+						checked={checked}
+						disabled={disabled}
+						required={required}
+						onChange={onChange}
+					/>
+					{checked ? (
+						<CheckboxChecked className={styles.checkbox} />
+					) : (
+						<CheckboxBlank className={styles.checkbox} />
+					)}
+					<P cfg={{ fontWeight: 3 }} className={styles.label}>
+						{label}
+					</P>
+				</div>
+				{hint && (
+					<P id={helper.hintId} className={styles.hint}>
+						{hint}
+					</P>
 				)}
-				<P cfg={{ ml: 3, fontWeight: 3 }} className={styles.label}>
-					{label}
-				</P>
 			</label>
-			{hint && (
-				<P id={helper.hintId} className={styles.hint}>
-					{hint}
-				</P>
-			)}
 		</StyledInputLabel>
 	);
 };

--- a/packages/forms/src/elements/checkbox/checkbox.tsx
+++ b/packages/forms/src/elements/checkbox/checkbox.tsx
@@ -15,6 +15,7 @@ export const Checkbox: React.FC<Partial<CheckboxIconProps>> = ({
 	disabled = false,
 	testId,
 	checked,
+	required,
 	onChange,
 	label,
 	hint,
@@ -49,6 +50,7 @@ export const Checkbox: React.FC<Partial<CheckboxIconProps>> = ({
 					aria-describedby={helper && helper.hintId}
 					checked={checked}
 					disabled={disabled}
+					required={required}
 					onChange={onChange}
 				/>
 				{checked ? (

--- a/packages/forms/src/elements/radio/radio.module.scss
+++ b/packages/forms/src/elements/radio/radio.module.scss
@@ -2,12 +2,15 @@
 // typography.module.scss includes '@tpr/theming/lib/variables.scss'
 
 .wrapper {
-	display: flex;
-	flex: 0 0 auto;
-	align-items: center;
 	cursor: pointer;
-	height: 25px;
 	user-select: none;
+
+	.innerWrapper {
+		display: flex;
+		flex: 0 0 auto;
+		align-items: center;
+		height: 25px;
+	}
 
 	input[type='radio']:focus + .radio {
 		box-shadow: 0 0 0 4px #ffd300;
@@ -15,6 +18,8 @@
 
 	.radio {
 		border-radius: 50%;
+		min-width: 40px;
+		min-height: 40px;
 	}
 }
 
@@ -24,6 +29,7 @@
 	line-height: $line-height-3;
 	padding-left: $space-1;
 	cursor: pointer;
+	margin-left: $space-2;
 	@include removeMarginBottom;
 }
 

--- a/packages/forms/src/elements/radio/radio.tsx
+++ b/packages/forms/src/elements/radio/radio.tsx
@@ -50,32 +50,33 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
 				data-testid={msg}
 				htmlFor={id}
 			>
-				<HiddenInput
-					type="radio"
-					id={id}
-					aria-describedby={helper && helper.hintId}
-					name={name}
-					checked={checked}
-					value={value}
-					disabled={disabled}
-					required={required}
-					onChange={onChange}
-					data-testid={testId}
-				/>
-				{checked ? (
-					<RadioButtonChecked className={styles.radio} />
-				) : (
-					<RadioButtonUnchecked className={styles.radio} />
+				<div className={styles.innerWrapper}>
+					<HiddenInput
+						type="radio"
+						id={id}
+						name={name}
+						checked={checked}
+						value={value}
+						disabled={disabled}
+						required={required}
+						onChange={onChange}
+						data-testid={testId}
+					/>
+					{checked ? (
+						<RadioButtonChecked className={styles.radio} />
+					) : (
+						<RadioButtonUnchecked className={styles.radio} />
+					)}
+					<P cfg={{ fontWeight: 3 }} className={styles.label}>
+						{label}
+					</P>
+				</div>
+				{hint && (
+					<P id={helper && helper.hintId} className={styles.hint}>
+						{hint}
+					</P>
 				)}
-				<P cfg={{ ml: 2, fontWeight: 3 }} className={styles.label}>
-					{label}
-				</P>
 			</label>
-			{hint && (
-				<P id={helper && helper.hintId} className={styles.hint}>
-					{hint}
-				</P>
-			)}
 		</StyledInputLabel>
 	);
 };


### PR DESCRIPTION
- Adds support for the required attribute on checkboxes.
- Updates checkboxes and radio buttons to render hint text as part of the label. This follows the principle of using native HTML rather than ARIA where possible, and also has the advantage of making the whole label clickable including the hint.
- Enabled checkbox to render children as part of its label, so that it can support rich text hint text as part of its labels.
- Prevents checkboxes and radio buttons shrinking when the window is narrowed.

Fixes [AB#106844](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/106844) 