### PR TITLE
Bugfix/105814 cards wrong focus

### DIFF
--- a/packages/layout/src/components/cards/actuary/actuary.tsx
+++ b/packages/layout/src/components/cards/actuary/actuary.tsx
@@ -55,6 +55,7 @@ const ActuaryButton: React.FC = () => {
 		<UnderlinedButton
 			isOpen={onOfStatesIsActive}
 			onClick={() => {
+				current.context.lastBtnClicked = 1;
 				if (onOfStatesIsActive) {
 					send('CANCEL');
 				} else {
@@ -80,6 +81,7 @@ const RemoveButton: React.FC<{ title: string; tabIndex?: number }> = ({
 				current.matches({ remove: 'confirm' })
 			}
 			onClick={() => {
+				current.context.lastBtnClicked = 2;
 				if (
 					current.matches({ remove: 'date' }) ||
 					current.matches({ remove: 'confirm' })
@@ -100,57 +102,55 @@ const isComplete = (context: ActuaryContext) => {
 	return context.preValidatedData ? true : context.complete;
 };
 
-export const ActuaryCard: React.FC<ActuaryProviderProps> = ({
-	testId,
-	cfg,
-	...rest
-}) => {
-	return (
-		<ActuaryProvider {...rest}>
-			{({ current, i18n }) => {
-				return (
-					<Section
-						cfg={cfg}
-						data-testid={testId}
-						className={styles.card}
-						ariaLabel={concatenateStrings([
-							current.context.actuary.title,
-							current.context.actuary.firstName,
-							current.context.actuary.lastName,
-							i18n.preview.buttons.one,
-						])}
-					>
-						<Toolbar
-							complete={isComplete(current.context)}
-							subtitle={() => (
-								<Subtitle
-									main={concatenateStrings([
-										current.context.actuary.title,
-										current.context.actuary.firstName,
-										current.context.actuary.lastName,
-									])}
-									secondary={current.context.actuary.organisationName}
-								/>
-							)}
-							statusText={
-								isComplete(current.context)
-									? i18n.preview.statusText.confirmed
-									: i18n.preview.statusText.unconfirmed
-							}
-							buttonLeft={() => <ActuaryButton />}
-							buttonRight={() => (
-								<RemoveButton
-									title={i18n.preview.buttons.two}
-									tabIndex={removeFromTabFlowIfMatches(current, {
-										edit: 'name',
-									})}
-								/>
-							)}
-						/>
-						<CardContentSwitch />
-					</Section>
-				);
-			}}
-		</ActuaryProvider>
-	);
-};
+export const ActuaryCard: React.FC<ActuaryProviderProps> = React.memo(
+	({ testId, cfg, ...rest }) => {
+		return (
+			<ActuaryProvider {...rest}>
+				{({ current, i18n }) => {
+					return (
+						<Section
+							cfg={cfg}
+							data-testid={testId}
+							className={styles.card}
+							ariaLabel={concatenateStrings([
+								current.context.actuary.title,
+								current.context.actuary.firstName,
+								current.context.actuary.lastName,
+								i18n.preview.buttons.one,
+							])}
+						>
+							<Toolbar
+								complete={isComplete(current.context)}
+								subtitle={() => (
+									<Subtitle
+										main={concatenateStrings([
+											current.context.actuary.title,
+											current.context.actuary.firstName,
+											current.context.actuary.lastName,
+										])}
+										secondary={current.context.actuary.organisationName}
+									/>
+								)}
+								statusText={
+									isComplete(current.context)
+										? i18n.preview.statusText.confirmed
+										: i18n.preview.statusText.unconfirmed
+								}
+								buttonLeft={() => <ActuaryButton />}
+								buttonRight={() => (
+									<RemoveButton
+										title={i18n.preview.buttons.two}
+										tabIndex={removeFromTabFlowIfMatches(current, {
+											edit: 'name',
+										})}
+									/>
+								)}
+							/>
+							<CardContentSwitch />
+						</Section>
+					);
+				}}
+			</ActuaryProvider>
+		);
+	},
+);

--- a/packages/layout/src/components/cards/actuary/actuaryMachine.tsx
+++ b/packages/layout/src/components/cards/actuary/actuaryMachine.tsx
@@ -38,6 +38,7 @@ export interface ActuaryContext {
 	remove: { confirm: boolean; date: string } | null;
 	actuary: Partial<Actuary>;
 	preValidatedData?: boolean | null;
+	lastBtnClicked?: number | null;
 }
 
 const actuaryMachine = Machine<ActuaryContext, ActuaryStates, ActuaryEvents>({
@@ -47,6 +48,7 @@ const actuaryMachine = Machine<ActuaryContext, ActuaryStates, ActuaryEvents>({
 		complete: false,
 		remove: null,
 		actuary: {},
+		lastBtnClicked: null,
 	},
 	states: {
 		preview: {

--- a/packages/layout/src/components/cards/actuary/context.tsx
+++ b/packages/layout/src/components/cards/actuary/context.tsx
@@ -60,6 +60,7 @@ export const ActuaryProvider = ({
 	complete,
 	preValidatedData,
 	actuary,
+	lastBtnClicked = null,
 	children,
 	i18n: i18nOverrides = {},
 	...rest
@@ -70,6 +71,7 @@ export const ActuaryProvider = ({
 			complete,
 			preValidatedData,
 			actuary,
+			lastBtnClicked,
 		},
 	});
 

--- a/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Checkbox } from '@tpr/forms';
 import { Flex, Hr, classNames } from '@tpr/core';
 import { UnderlinedButton } from '../../../components/button';
@@ -7,12 +7,23 @@ import {
 	AddressPreview,
 	ContactDetailsPreview,
 } from '../../../common/views/preview/components';
-import styles from '../../../cards.module.scss';
 import { concatenateStrings } from '../../../../../utils';
+import styles from '../../../cards.module.scss';
 
-export const Preview: React.FC<any> = () => {
+export const Preview: React.FC<any> = React.memo(() => {
 	const { current, send, onCorrect, i18n } = useActuaryContext();
 	const { actuary, complete, preValidatedData } = current.context;
+
+	const contactsBtn = useRef(null);
+
+	const onClickContactsBtn = () => {
+		current.context.lastBtnClicked = 3;
+		send('EDIT_CONTACTS');
+	};
+
+	const onCollapseContacts = () => {
+		current.context.lastBtnClicked === 3 && contactsBtn.current.focus();
+	};
 
 	return (
 		<div
@@ -46,9 +57,11 @@ export const Preview: React.FC<any> = () => {
 					cfg={{ width: 5, flex: '0 0 auto', flexDirection: 'column', pl: 4 }}
 				>
 					<UnderlinedButton
-						onClick={() => send('EDIT_CONTACTS')}
+						onClick={onClickContactsBtn}
 						isOpen={current.matches({ edit: 'contacts' })}
 						isEditButton={true}
+						onCollapseCallback={onCollapseContacts}
+						btnRef={contactsBtn}
 					>
 						{i18n.preview.buttons.four}
 					</UnderlinedButton>
@@ -81,4 +94,4 @@ export const Preview: React.FC<any> = () => {
 			</Flex>
 		</div>
 	);
-};
+});

--- a/packages/layout/src/components/cards/common/interfaces.ts
+++ b/packages/layout/src/components/cards/common/interfaces.ts
@@ -76,6 +76,7 @@ export interface CardProviderProps {
 	testId?: string | number;
 	/** cfg space props */
 	cfg?: SpaceProps;
+	lastBtnClicked?: number | null;
 }
 
 export interface RemoveReasonProps {

--- a/packages/layout/src/components/cards/components/button.tsx
+++ b/packages/layout/src/components/cards/components/button.tsx
@@ -13,6 +13,18 @@ type UnderlinedButtonProps = {
 	btnRef?: MutableRefObject<any>;
 };
 
+/*
+	In all cards, we have 2 sections: Toolbar (containing at least the 'Remove' button) & Content (changes depending on the data being edited).
+	Because the 'content' section changes, when clicking one of its buttons (on the Preview 'view') the focus needs to be added to the button rendered in the new view in the editing section.
+	And when collapsing the editing section, the focus needs to return to the button that was clicked in the 'Preview' view.
+
+	To solve this, 2 new properties need to be passed to the Underlinedbutton component.
+
+	btnRef: reference received for buttons from the 'Preview' view, but only for those which are part of the 'content' section (not the Toolbar buttons).
+
+	onCollapseCallback: callback function to be called when collapsing an editing section. This function is used to return the focus to the button from 'Preview'.
+	*/
+
 export const UnderlinedButton: React.FC<UnderlinedButtonProps> = ({
 	children,
 	isOpen,

--- a/packages/layout/src/components/cards/components/button.tsx
+++ b/packages/layout/src/components/cards/components/button.tsx
@@ -28,8 +28,8 @@ export const UnderlinedButton: React.FC<UnderlinedButtonProps> = ({
 	}
 	const buttonRef = useRef(null);
 	useEffect(() => {
-		buttonRef.current.focus();
-	});
+		isOpen && buttonRef.current.focus();
+	}, [isOpen]);
 	const getAppropriateButton = () => {
 		if (isOpen && isEditButton) {
 			return <EditArrowUp width="24px" fill={styles.arrowColor} />;

--- a/packages/layout/src/components/cards/components/button.tsx
+++ b/packages/layout/src/components/cards/components/button.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, MutableRefObject } from 'react';
 import { Flex, P } from '@tpr/core';
 import styles from './button.module.scss';
 import { EditArrowUp, EditArrowDown } from './arrowButton';
@@ -9,13 +9,18 @@ type UnderlinedButtonProps = {
 	onClick?: any;
 	tabIndex?: number;
 	isEditButton?: boolean;
+	onCollapseCallback?: () => void;
+	btnRef?: MutableRefObject<any>;
 };
+
 export const UnderlinedButton: React.FC<UnderlinedButtonProps> = ({
 	children,
 	isOpen,
 	onClick,
 	tabIndex,
 	isEditButton,
+	onCollapseCallback,
+	btnRef,
 }) => {
 	if (typeof onClick === 'undefined') {
 		return (
@@ -26,9 +31,11 @@ export const UnderlinedButton: React.FC<UnderlinedButtonProps> = ({
 			</div>
 		);
 	}
-	const buttonRef = useRef(null);
+
+	const noToolbarBtnRef = useRef(null);
 	useEffect(() => {
-		isOpen && buttonRef.current.focus();
+		isOpen && noToolbarBtnRef && noToolbarBtnRef.current.focus();
+		!isOpen && onCollapseCallback && onCollapseCallback();
 	}, [isOpen]);
 	const getAppropriateButton = () => {
 		if (isOpen && isEditButton) {
@@ -50,7 +57,7 @@ export const UnderlinedButton: React.FC<UnderlinedButtonProps> = ({
 			onClick={onClick}
 			aria-expanded={isOpen}
 			tabIndex={tabIndex}
-			ref={buttonRef}
+			ref={btnRef ? btnRef : noToolbarBtnRef}
 		>
 			<Flex
 				className={styles.arrowSpacing}

--- a/packages/layout/src/components/cards/components/card.tsx
+++ b/packages/layout/src/components/cards/components/card.tsx
@@ -1,25 +1,7 @@
 import React from 'react';
-import { classNames, Flex, H3, Hr, P } from '@tpr/core';
+import { Flex, H3, Hr, P } from '@tpr/core';
 import styles from './card.module.scss';
 import CardContentSectionHeader from './cardContentHeaderSection';
-
-type StyledCardProps = { complete: boolean };
-
-export const StyledCard: React.FC<StyledCardProps> = ({
-	complete = false,
-	children,
-}) => {
-	return (
-		<div
-			className={classNames([
-				styles.card,
-				{ [styles['card-completed']]: complete },
-			])}
-		>
-			{children}
-		</div>
-	);
-};
 
 export const StyledCardToolbar: React.FC = ({ children }) => {
 	return <div className={styles.cardToolbar}>{children}</div>;

--- a/packages/layout/src/components/cards/components/toolbar.tsx
+++ b/packages/layout/src/components/cards/components/toolbar.tsx
@@ -14,57 +14,61 @@ export type ToolbarProps = {
 	subSectionHeaderText?: string;
 };
 
-export const Toolbar: React.FC<ToolbarProps> = ({
-	complete,
-	subtitle,
-	buttonLeft,
-	buttonRight,
-	statusText,
-	subSectionHeaderText,
-}) => {
-	return (
-		<div
-			className={classNames([
-				{ [styles.complete]: complete },
-				styles.cardToolbar,
-			])}
-		>
-			{subSectionHeaderText && (
-				<Flex>
-					<CardContentSectionHeader sectionHeaderText={subSectionHeaderText} />
-				</Flex>
-			)}
-			<Flex
-				cfg={{
-					width: 5,
-					flex: '0 0 auto',
-					flexDirection: 'column',
-					justifyContent: 'flex-start',
-					pr: 4,
-				}}
+export const Toolbar: React.FC<ToolbarProps> = React.memo(
+	({
+		complete,
+		subtitle,
+		buttonLeft,
+		buttonRight,
+		statusText,
+		subSectionHeaderText,
+	}) => {
+		return (
+			<div
+				className={classNames([
+					{ [styles.complete]: complete },
+					styles.cardToolbar,
+				])}
 			>
-				{buttonLeft()}
-				{subtitle && (
-					<Flex cfg={{ mt: 1, flexDirection: 'column' }}>{subtitle()}</Flex>
+				{subSectionHeaderText && (
+					<Flex>
+						<CardContentSectionHeader
+							sectionHeaderText={subSectionHeaderText}
+						/>
+					</Flex>
 				)}
-			</Flex>
-			<Flex
-				cfg={{
-					width: 5,
-					flex: '0 0 auto',
-					justifyContent: 'flex-end',
-					alignItems: 'flex-start',
-					pl: 4,
-				}}
-			>
-				<StatusMessage
-					complete={complete}
-					icon={complete ? CheckedCircle : ErrorCircle}
-					text={statusText}
-				/>
-				<div className={styles.divider} />
-				<Flex cfg={{ alignItems: 'flex-start' }}>{buttonRight()}</Flex>
-			</Flex>
-		</div>
-	);
-};
+				<Flex
+					cfg={{
+						width: 5,
+						flex: '0 0 auto',
+						flexDirection: 'column',
+						justifyContent: 'flex-start',
+						pr: 4,
+					}}
+				>
+					{buttonLeft()}
+					{subtitle && (
+						<Flex cfg={{ mt: 1, flexDirection: 'column' }}>{subtitle()}</Flex>
+					)}
+				</Flex>
+				<Flex
+					cfg={{
+						width: 5,
+						flex: '0 0 auto',
+						justifyContent: 'flex-end',
+						alignItems: 'flex-start',
+						pl: 4,
+					}}
+				>
+					<StatusMessage
+						complete={complete}
+						icon={complete ? CheckedCircle : ErrorCircle}
+						text={statusText}
+					/>
+					<div className={styles.divider} />
+					<Flex cfg={{ alignItems: 'flex-start' }}>{buttonRight()}</Flex>
+				</Flex>
+			</div>
+		);
+	},
+);

--- a/packages/layout/src/components/cards/corporateGroup/context.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/context.tsx
@@ -56,6 +56,7 @@ export const CorporateGroupProvider = ({
 	complete,
 	preValidatedData,
 	corporateGroup,
+	lastBtnClicked = null,
 	children,
 	i18n: i18nOverrides = {},
 	...rest
@@ -66,6 +67,7 @@ export const CorporateGroupProvider = ({
 			complete,
 			preValidatedData,
 			corporateGroup,
+			lastBtnClicked,
 		},
 	});
 

--- a/packages/layout/src/components/cards/corporateGroup/corporateGroup.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/corporateGroup.tsx
@@ -53,6 +53,7 @@ const RemoveButton: React.FC<{ title: string }> = ({ title }) => {
 				current.matches({ remvve: 'confirm' })
 			}
 			onClick={() => {
+				current.context.lastBtnClicked = 2;
 				if (
 					current.matches({ remove: 'reason' }) ||
 					current.matches({ remove: 'confirm' })
@@ -72,48 +73,48 @@ const isComplete = (context: CorporateGroupContext) => {
 	return context.preValidatedData ? true : context.complete;
 };
 
-export const CorporateGroupCard: React.FC<CorporateGroupProviderProps> = ({
-	testId,
-	cfg,
-	...rest
-}) => {
-	return (
-		<CorporateGroupProvider {...rest}>
-			{({ current: { context }, i18n }) => {
-				return (
-					<Section
-						cfg={cfg}
-						data-testid={testId}
-						className={styles.card}
-						ariaLabel={concatenateStrings([
-							context.corporateGroup.organisationName,
-							i18n.preview.trusteeType,
-						])}
-					>
-						<Toolbar
-							complete={isComplete(context)}
-							subtitle={() => (
-								<Subtitle
-									main={context.corporateGroup.organisationName}
-									secondary={i18n.preview.trusteeType}
-								/>
-							)}
-							statusText={
-								isComplete(context)
-									? i18n.preview.statusText.confirmed
-									: i18n.preview.statusText.unconfirmed
-							}
-							buttonLeft={() => (
-								<UnderlinedButton>{i18n.preview.buttons.one}</UnderlinedButton>
-							)}
-							buttonRight={() => (
-								<RemoveButton title={i18n.preview.buttons.two} />
-							)}
-						/>
-						<CardContentSwitch />
-					</Section>
-				);
-			}}
-		</CorporateGroupProvider>
-	);
-};
+export const CorporateGroupCard: React.FC<CorporateGroupProviderProps> = React.memo(
+	({ testId, cfg, ...rest }) => {
+		return (
+			<CorporateGroupProvider {...rest}>
+				{({ current: { context }, i18n }) => {
+					return (
+						<Section
+							cfg={cfg}
+							data-testid={testId}
+							className={styles.card}
+							ariaLabel={concatenateStrings([
+								context.corporateGroup.organisationName,
+								i18n.preview.trusteeType,
+							])}
+						>
+							<Toolbar
+								complete={isComplete(context)}
+								subtitle={() => (
+									<Subtitle
+										main={context.corporateGroup.organisationName}
+										secondary={i18n.preview.trusteeType}
+									/>
+								)}
+								statusText={
+									isComplete(context)
+										? i18n.preview.statusText.confirmed
+										: i18n.preview.statusText.unconfirmed
+								}
+								buttonLeft={() => (
+									<UnderlinedButton>
+										{i18n.preview.buttons.one}
+									</UnderlinedButton>
+								)}
+								buttonRight={() => (
+									<RemoveButton title={i18n.preview.buttons.two} />
+								)}
+							/>
+							<CardContentSwitch />
+						</Section>
+					);
+				}}
+			</CorporateGroupProvider>
+		);
+	},
+);

--- a/packages/layout/src/components/cards/corporateGroup/corporateGroupMachine.ts
+++ b/packages/layout/src/components/cards/corporateGroup/corporateGroupMachine.ts
@@ -39,6 +39,7 @@ export interface CorporateGroupContext {
 	remove?: RemoveReasonProps;
 	corporateGroup: Partial<CorporateGroup>;
 	preValidatedData?: boolean | null;
+	lastBtnClicked?: number | null;
 }
 
 const corporateGroupMachine = Machine<
@@ -52,6 +53,7 @@ const corporateGroupMachine = Machine<
 		complete: false,
 		remove: null,
 		corporateGroup: {},
+		lastBtnClicked: null,
 	},
 	states: {
 		preview: {

--- a/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Checkbox } from '@tpr/forms';
 import { Flex, P, Hr, classNames } from '@tpr/core';
 import { UnderlinedButton } from '../../../components/button';
@@ -9,9 +9,30 @@ import {
 } from '../../../common/views/preview/components';
 import styles from '../../../cards.module.scss';
 
-export const Preview: React.FC<any> = () => {
+export const Preview: React.FC<any> = React.memo(() => {
 	const { current, send, onCorrect, i18n } = useCorporateGroupContext();
 	const { corporateGroup, complete, preValidatedData } = current.context;
+
+	const directorBtn = useRef(null);
+	const chairBtn = useRef(null);
+
+	const onClickDirectorBtn = () => {
+		current.context.lastBtnClicked = 5;
+		send('EDIT_PROFESSIONAL');
+	};
+
+	const onClickChairOfBoardBtn = () => {
+		current.context.lastBtnClicked = 4;
+		send('EDIT_NAME');
+	};
+
+	const onCollapseDirector = () => {
+		current.context.lastBtnClicked === 5 && directorBtn.current.focus();
+	};
+
+	const onCollapseChairOfBoard = () => {
+		current.context.lastBtnClicked === 4 && chairBtn.current.focus();
+	};
 
 	return (
 		<div
@@ -42,9 +63,11 @@ export const Preview: React.FC<any> = () => {
 					{/* Professional Trustee section: open for editing	 */}
 					<Flex cfg={{ flexDirection: 'column', mt: 5 }}>
 						<UnderlinedButton
-							onClick={() => send('EDIT_PROFESSIONAL')}
+							onClick={onClickDirectorBtn}
 							isOpen={current.matches({ edit: 'professional' })}
 							isEditButton={true}
+							btnRef={directorBtn}
+							onCollapseCallback={onCollapseDirector}
 						>
 							{i18n.preview.buttons.five}
 						</UnderlinedButton>
@@ -63,9 +86,11 @@ export const Preview: React.FC<any> = () => {
 					cfg={{ width: 5, flex: '0 0 auto', flexDirection: 'column', pr: 4 }}
 				>
 					<UnderlinedButton
-						onClick={() => send('EDIT_NAME')}
+						onClick={onClickChairOfBoardBtn}
 						isOpen={current.matches({ edit: 'contacts' })}
 						isEditButton={true}
+						btnRef={chairBtn}
+						onCollapseCallback={onCollapseChairOfBoard}
 					>
 						{i18n.preview.buttons.four}
 					</UnderlinedButton>
@@ -99,4 +124,4 @@ export const Preview: React.FC<any> = () => {
 			</Flex>
 		</div>
 	);
-};
+});

--- a/packages/layout/src/components/cards/employer/context.tsx
+++ b/packages/layout/src/components/cards/employer/context.tsx
@@ -58,6 +58,7 @@ export const EmployerProvider = ({
 	preValidatedData,
 	employer,
 	showStatutoryEmployerSection,
+	lastBtnClicked = null,
 	children,
 	i18n: i18nOverrides = {},
 	...rest
@@ -69,6 +70,7 @@ export const EmployerProvider = ({
 			showStatutoryEmployerSection,
 			preValidatedData,
 			employer,
+			lastBtnClicked,
 		},
 	});
 

--- a/packages/layout/src/components/cards/employer/employerMachine.ts
+++ b/packages/layout/src/components/cards/employer/employerMachine.ts
@@ -31,6 +31,7 @@ export interface EmployerContext {
 	remove: { confirm: boolean; date: string } | null;
 	employer: Partial<Employer>;
 	preValidatedData?: boolean | null;
+	lastBtnClicked?: number | null;
 }
 
 const employerMachine = Machine<
@@ -45,6 +46,7 @@ const employerMachine = Machine<
 		showStatutoryEmployerSection: true,
 		remove: null,
 		employer: {},
+		lastBtnClicked: null,
 	},
 	states: {
 		preview: {

--- a/packages/layout/src/components/cards/employer/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/employer/views/preview/preview.tsx
@@ -16,7 +16,7 @@ const IdentifiersItem: React.FC<IdentifiersItemProps> = ({ title, number }) => {
 	);
 };
 
-export const Preview: React.FC<any> = () => {
+export const Preview: React.FC<any> = React.memo(() => {
 	const { current, send, onCorrect, i18n } = useEmployerContext();
 	const { employer, complete, preValidatedData } = current.context;
 	const [items] = useState(
@@ -89,4 +89,4 @@ export const Preview: React.FC<any> = () => {
 			</Flex>
 		</div>
 	);
-};
+});

--- a/packages/layout/src/components/cards/inHouse/context.tsx
+++ b/packages/layout/src/components/cards/inHouse/context.tsx
@@ -65,6 +65,7 @@ export const InHouseAdminProvider = ({
 	complete,
 	preValidatedData,
 	inHouseAdmin,
+	lastBtnClicked = null,
 	children,
 	i18n: i18nOverrides = {},
 	...rest
@@ -75,6 +76,7 @@ export const InHouseAdminProvider = ({
 			complete,
 			preValidatedData,
 			inHouseAdmin,
+			lastBtnClicked,
 		},
 	});
 

--- a/packages/layout/src/components/cards/inHouse/inHouse.tsx
+++ b/packages/layout/src/components/cards/inHouse/inHouse.tsx
@@ -99,6 +99,7 @@ const InHouseAdminButton: React.FC = () => {
 		<UnderlinedButton
 			isOpen={onOfStatesIsActive}
 			onClick={() => {
+				current.context.lastBtnClicked = 1;
 				if (onOfStatesIsActive) {
 					send('CANCEL');
 				} else {
@@ -124,6 +125,7 @@ const RemoveButton: React.FC<{ title: string; tabIndex?: number }> = ({
 				current.matches({ remove: 'confirm' })
 			}
 			onClick={() => {
+				current.context.lastBtnClicked = 2;
 				if (
 					current.matches({ remove: 'date' }) ||
 					current.matches({ remove: 'confirm' })
@@ -144,56 +146,54 @@ const isComplete = (context: InHouseAdminContext) => {
 	return context.preValidatedData ? true : context.complete;
 };
 
-export const InHouseCard: React.FC<InHouseAdminProviderProps> = ({
-	testId,
-	cfg,
-	...rest
-}) => {
-	return (
-		<InHouseAdminProvider {...rest}>
-			{({ current, i18n }) => {
-				return (
-					<Section
-						cfg={cfg}
-						data-testid={testId}
-						className={styles.card}
-						ariaLabel={concatenateStrings([
-							current.context.inHouseAdmin.title,
-							current.context.inHouseAdmin.firstName,
-							current.context.inHouseAdmin.lastName,
-							i18n.preview.buttons.one,
-						])}
-					>
-						<Toolbar
-							complete={isComplete(current.context)}
-							subtitle={() => (
-								<Subtitle
-									main={concatenateStrings([
-										current.context.inHouseAdmin.title,
-										current.context.inHouseAdmin.firstName,
-										current.context.inHouseAdmin.lastName,
-									])}
-								/>
-							)}
-							statusText={
-								isComplete(current.context)
-									? i18n.preview.statusText.confirmed
-									: i18n.preview.statusText.unconfirmed
-							}
-							buttonLeft={() => <InHouseAdminButton />}
-							buttonRight={() => (
-								<RemoveButton
-									title={i18n.preview.buttons.two}
-									tabIndex={removeFromTabFlowIfMatches(current, {
-										edit: 'name',
-									})}
-								/>
-							)}
-						/>
-						<CardContentSwitch />
-					</Section>
-				);
-			}}
-		</InHouseAdminProvider>
-	);
-};
+export const InHouseCard: React.FC<InHouseAdminProviderProps> = React.memo(
+	({ testId, cfg, ...rest }) => {
+		return (
+			<InHouseAdminProvider {...rest}>
+				{({ current, i18n }) => {
+					return (
+						<Section
+							cfg={cfg}
+							data-testid={testId}
+							className={styles.card}
+							ariaLabel={concatenateStrings([
+								current.context.inHouseAdmin.title,
+								current.context.inHouseAdmin.firstName,
+								current.context.inHouseAdmin.lastName,
+								i18n.preview.buttons.one,
+							])}
+						>
+							<Toolbar
+								complete={isComplete(current.context)}
+								subtitle={() => (
+									<Subtitle
+										main={concatenateStrings([
+											current.context.inHouseAdmin.title,
+											current.context.inHouseAdmin.firstName,
+											current.context.inHouseAdmin.lastName,
+										])}
+									/>
+								)}
+								statusText={
+									isComplete(current.context)
+										? i18n.preview.statusText.confirmed
+										: i18n.preview.statusText.unconfirmed
+								}
+								buttonLeft={() => <InHouseAdminButton />}
+								buttonRight={() => (
+									<RemoveButton
+										title={i18n.preview.buttons.two}
+										tabIndex={removeFromTabFlowIfMatches(current, {
+											edit: 'name',
+										})}
+									/>
+								)}
+							/>
+							<CardContentSwitch />
+						</Section>
+					);
+				}}
+			</InHouseAdminProvider>
+		);
+	},
+);

--- a/packages/layout/src/components/cards/inHouse/inHouseMachine.ts
+++ b/packages/layout/src/components/cards/inHouse/inHouseMachine.ts
@@ -39,6 +39,7 @@ export interface InHouseAdminContext {
 	remove: { confirm: boolean; date: string } | null;
 	inHouseAdmin: Partial<InHouseAdmin>;
 	preValidatedData?: boolean | null;
+	lastBtnClicked?: number | null;
 }
 
 const inHouseAdminMachine = Machine<
@@ -52,6 +53,7 @@ const inHouseAdminMachine = Machine<
 		complete: false,
 		remove: null,
 		inHouseAdmin: {},
+		lastBtnClicked: null,
 	},
 	states: {
 		preview: {

--- a/packages/layout/src/components/cards/inHouse/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/preview/preview.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Checkbox } from '@tpr/forms';
 import { Flex, Hr, classNames } from '@tpr/core';
 import { UnderlinedButton } from '../../../components/button';
@@ -10,9 +10,30 @@ import {
 import styles from '../../../cards.module.scss';
 import { concatenateStrings } from '../../../../../utils';
 
-export const Preview: React.FC<any> = () => {
+export const Preview: React.FC<any> = React.memo(() => {
 	const { current, send, onCorrect, i18n } = useInHouseAdminContext();
 	const { inHouseAdmin, complete, preValidatedData } = current.context;
+
+	const addressBtn = useRef(null);
+	const contactsBtn = useRef(null);
+
+	const onClickAddressBtn = () => {
+		current.context.lastBtnClicked = 3;
+		send('EDIT_ADDRESS');
+	};
+
+	const onClickContactsBtn = () => {
+		current.context.lastBtnClicked = 4;
+		send('EDIT_CONTACTS');
+	};
+
+	const onCollapseAddress = () => {
+		current.context.lastBtnClicked === 3 && addressBtn.current.focus();
+	};
+
+	const onCollapseContacts = () => {
+		current.context.lastBtnClicked === 4 && contactsBtn.current.focus();
+	};
 
 	return (
 		<div
@@ -28,9 +49,11 @@ export const Preview: React.FC<any> = () => {
 					cfg={{ width: 5, flex: '0 0 auto', flexDirection: 'column', pr: 4 }}
 				>
 					<UnderlinedButton
-						onClick={() => send('EDIT_ADDRESS')}
+						onClick={onClickAddressBtn}
 						isOpen={current.matches({ edit: 'address' })}
 						isEditButton={true}
+						btnRef={addressBtn}
+						onCollapseCallback={onCollapseAddress}
 					>
 						{i18n.preview.buttons.three}
 					</UnderlinedButton>
@@ -52,9 +75,11 @@ export const Preview: React.FC<any> = () => {
 					cfg={{ width: 5, flex: '0 0 auto', flexDirection: 'column', pl: 4 }}
 				>
 					<UnderlinedButton
-						onClick={() => send('EDIT_CONTACTS')}
+						onClick={onClickContactsBtn}
 						isOpen={current.matches({ edit: 'contacts' })}
 						isEditButton={true}
+						btnRef={contactsBtn}
+						onCollapseCallback={onCollapseContacts}
 					>
 						{i18n.preview.buttons.four}
 					</UnderlinedButton>
@@ -87,4 +112,4 @@ export const Preview: React.FC<any> = () => {
 			</Flex>
 		</div>
 	);
-};
+});

--- a/packages/layout/src/components/cards/independentTrustee/context.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/context.tsx
@@ -51,6 +51,7 @@ export const IndependentTrusteeProvider = ({
 	complete,
 	preValidatedData,
 	independentTrustee,
+	lastBtnClicked = null,
 	children,
 	i18n: i18nOverrides = {},
 	...rest
@@ -61,6 +62,7 @@ export const IndependentTrusteeProvider = ({
 			complete,
 			preValidatedData,
 			independentTrustee,
+			lastBtnClicked,
 		},
 	});
 

--- a/packages/layout/src/components/cards/independentTrustee/independentTrustee.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/independentTrustee.tsx
@@ -47,6 +47,7 @@ const RemoveButton: React.FC<{ title: string }> = ({ title }) => {
 				current.matches({ remvve: 'confirm' })
 			}
 			onClick={() => {
+				current.context.lastBtnClicked = 2;
 				if (
 					current.matches({ remove: 'reason' }) ||
 					current.matches({ remove: 'confirm' })
@@ -66,48 +67,48 @@ const isComplete = (context: IndependentTrusteeContext) => {
 	return context.preValidatedData ? true : context.complete;
 };
 
-export const IndependentTrusteeCard: React.FC<IndependentTrusteeProviderProps> = ({
-	testId,
-	cfg,
-	...rest
-}) => {
-	return (
-		<IndependentTrusteeProvider {...rest}>
-			{({ current: { context }, i18n }) => {
-				return (
-					<Section
-						cfg={cfg}
-						data-testid={testId}
-						className={styles.card}
-						ariaLabel={concatenateStrings([
-							context.independentTrustee.organisationName,
-							i18n.preview.trusteeType,
-						])}
-					>
-						<Toolbar
-							complete={isComplete(context)}
-							subtitle={() => (
-								<Subtitle
-									main={context.independentTrustee.organisationName}
-									secondary={i18n.preview.trusteeType}
-								/>
-							)}
-							statusText={
-								isComplete(context)
-									? i18n.preview.statusText.confirmed
-									: i18n.preview.statusText.unconfirmed
-							}
-							buttonLeft={() => (
-								<UnderlinedButton>{i18n.preview.buttons.one}</UnderlinedButton>
-							)}
-							buttonRight={() => (
-								<RemoveButton title={i18n.preview.buttons.two} />
-							)}
-						/>
-						<CardContentSwitch />
-					</Section>
-				);
-			}}
-		</IndependentTrusteeProvider>
-	);
-};
+export const IndependentTrusteeCard: React.FC<IndependentTrusteeProviderProps> = React.memo(
+	({ testId, cfg, ...rest }) => {
+		return (
+			<IndependentTrusteeProvider {...rest}>
+				{({ current: { context }, i18n }) => {
+					return (
+						<Section
+							cfg={cfg}
+							data-testid={testId}
+							className={styles.card}
+							ariaLabel={concatenateStrings([
+								context.independentTrustee.organisationName,
+								i18n.preview.trusteeType,
+							])}
+						>
+							<Toolbar
+								complete={isComplete(context)}
+								subtitle={() => (
+									<Subtitle
+										main={context.independentTrustee.organisationName}
+										secondary={i18n.preview.trusteeType}
+									/>
+								)}
+								statusText={
+									isComplete(context)
+										? i18n.preview.statusText.confirmed
+										: i18n.preview.statusText.unconfirmed
+								}
+								buttonLeft={() => (
+									<UnderlinedButton>
+										{i18n.preview.buttons.one}
+									</UnderlinedButton>
+								)}
+								buttonRight={() => (
+									<RemoveButton title={i18n.preview.buttons.two} />
+								)}
+							/>
+							<CardContentSwitch />
+						</Section>
+					);
+				}}
+			</IndependentTrusteeProvider>
+		);
+	},
+);

--- a/packages/layout/src/components/cards/independentTrustee/independentTrusteeMachine.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/independentTrusteeMachine.tsx
@@ -35,6 +35,7 @@ export interface IndependentTrusteeContext {
 	remove?: RemoveReasonProps;
 	independentTrustee: Partial<IndependentTrustee>;
 	preValidatedData?: boolean | null;
+	lastBtnClicked?: number | null;
 }
 
 const independentTrusteeMachine = Machine<
@@ -48,6 +49,7 @@ const independentTrusteeMachine = Machine<
 		complete: false,
 		remove: null,
 		independentTrustee: {},
+		lastBtnClicked: null,
 	},
 	states: {
 		preview: {

--- a/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Checkbox } from '@tpr/forms';
 import { Flex, Hr, classNames, P } from '@tpr/core';
 import { UnderlinedButton } from '../../../components/button';
@@ -6,9 +6,20 @@ import { useIndependentTrusteeContext } from '../../context';
 import { AddressPreview } from '../../../common/views/preview/components';
 import styles from '../../../cards.module.scss';
 
-export const Preview: React.FC<any> = () => {
+export const Preview: React.FC<any> = React.memo(() => {
 	const { current, send, onCorrect, i18n } = useIndependentTrusteeContext();
 	const { independentTrustee, complete, preValidatedData } = current.context;
+
+	const regulatorBtn = useRef(null);
+
+	const onClickRegulatorBtn = () => {
+		current.context.lastBtnClicked = 4;
+		send('EDIT_REGULATOR');
+	};
+
+	const onCollapseRegulator = () => {
+		current.context.lastBtnClicked === 4 && regulatorBtn.current.focus();
+	};
 
 	return (
 		<div
@@ -42,9 +53,11 @@ export const Preview: React.FC<any> = () => {
 					cfg={{ width: 5, flex: '0 0 auto', flexDirection: 'column', pr: 4 }}
 				>
 					<UnderlinedButton
-						onClick={() => send('EDIT_REGULATOR')}
+						onClick={onClickRegulatorBtn}
 						isOpen={current.matches({ edit: 'regulator' })}
 						isEditButton={true}
+						btnRef={regulatorBtn}
+						onCollapseCallback={onCollapseRegulator}
 					>
 						{i18n.preview.buttons.four}
 					</UnderlinedButton>
@@ -76,4 +89,4 @@ export const Preview: React.FC<any> = () => {
 			</Flex>
 		</div>
 	);
-};
+});

--- a/packages/layout/src/components/cards/insurer/context.tsx
+++ b/packages/layout/src/components/cards/insurer/context.tsx
@@ -49,6 +49,7 @@ export const InsurerProvider = ({
 	complete,
 	preValidatedData,
 	insurer,
+	lastBtnClicked = null,
 	children,
 	i18n: i18nOverrides = {},
 	...rest
@@ -59,6 +60,7 @@ export const InsurerProvider = ({
 			complete,
 			preValidatedData,
 			insurer,
+			lastBtnClicked,
 		},
 	});
 

--- a/packages/layout/src/components/cards/insurer/insurer.tsx
+++ b/packages/layout/src/components/cards/insurer/insurer.tsx
@@ -37,7 +37,7 @@ const CardContentSwitch: React.FC = () => {
 	}
 };
 
-const ToolbarButton: React.FC<{ title: string }> = ({ title }) => {
+const RemoveButton: React.FC<{ title: string }> = ({ title }) => {
 	const { current, send } = useInsurerContext();
 	return (
 		<UnderlinedButton
@@ -46,6 +46,7 @@ const ToolbarButton: React.FC<{ title: string }> = ({ title }) => {
 				current.matches({ remove: 'confirm' })
 			}
 			onClick={() => {
+				current.context.lastBtnClicked = 2;
 				if (
 					current.matches({ remove: 'date' }) ||
 					current.matches({ remove: 'confirm' })
@@ -65,45 +66,45 @@ const isComplete = (context: InsurerContext) => {
 	return context.preValidatedData ? true : context.complete;
 };
 
-export const InsurerCard: React.FC<InsurerProviderProps> = ({
-	testId,
-	cfg,
-	...rest
-}) => {
-	return (
-		<InsurerProvider {...rest}>
-			{({ current: { context }, i18n }) => {
-				return (
-					<Section
-						cfg={cfg}
-						data-testid={testId}
-						className={styles.card}
-						ariaLabel={concatenateStrings([
-							context.insurer.organisationName,
-							i18n.preview.buttons.one,
-						])}
-					>
-						<Toolbar
-							complete={isComplete(context)}
-							subtitle={() => (
-								<Subtitle main={context.insurer.organisationName} />
-							)}
-							statusText={
-								isComplete(context)
-									? i18n.preview.statusText.confirmed
-									: i18n.preview.statusText.unconfirmed
-							}
-							buttonLeft={() => (
-								<UnderlinedButton>{i18n.preview.buttons.one}</UnderlinedButton>
-							)}
-							buttonRight={() => (
-								<ToolbarButton title={i18n.preview.buttons.two} />
-							)}
-						/>
-						<CardContentSwitch />
-					</Section>
-				);
-			}}
-		</InsurerProvider>
-	);
-};
+export const InsurerCard: React.FC<InsurerProviderProps> = React.memo(
+	({ testId, cfg, ...rest }) => {
+		return (
+			<InsurerProvider {...rest}>
+				{({ current: { context }, i18n }) => {
+					return (
+						<Section
+							cfg={cfg}
+							data-testid={testId}
+							className={styles.card}
+							ariaLabel={concatenateStrings([
+								context.insurer.organisationName,
+								i18n.preview.buttons.one,
+							])}
+						>
+							<Toolbar
+								complete={isComplete(context)}
+								subtitle={() => (
+									<Subtitle main={context.insurer.organisationName} />
+								)}
+								statusText={
+									isComplete(context)
+										? i18n.preview.statusText.confirmed
+										: i18n.preview.statusText.unconfirmed
+								}
+								buttonLeft={() => (
+									<UnderlinedButton>
+										{i18n.preview.buttons.one}
+									</UnderlinedButton>
+								)}
+								buttonRight={() => (
+									<RemoveButton title={i18n.preview.buttons.two} />
+								)}
+							/>
+							<CardContentSwitch />
+						</Section>
+					);
+				}}
+			</InsurerProvider>
+		);
+	},
+);

--- a/packages/layout/src/components/cards/insurer/insurerMachine.ts
+++ b/packages/layout/src/components/cards/insurer/insurerMachine.ts
@@ -34,6 +34,7 @@ export interface InsurerContext {
 	remove: { confirm: boolean; date: string } | null;
 	insurer: Partial<Insurer>;
 	preValidatedData?: boolean | null;
+	lastBtnClicked?: number | null;
 }
 
 const insurerMachine = Machine<InsurerContext, InsurerStates, InsurerEvents>({
@@ -43,6 +44,7 @@ const insurerMachine = Machine<InsurerContext, InsurerStates, InsurerEvents>({
 		complete: false,
 		remove: null,
 		insurer: {},
+		lastBtnClicked: null,
 	},
 	states: {
 		preview: {

--- a/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Checkbox } from '@tpr/forms';
 import { Flex, Hr, P, classNames } from '@tpr/core';
 import { UnderlinedButton } from '../../../components/button';
@@ -6,9 +6,20 @@ import { useInsurerContext } from '../../context';
 import { AddressPreview } from '../../../common/views/preview/components';
 import styles from '../../../cards.module.scss';
 
-export const Preview: React.FC<any> = () => {
+export const Preview: React.FC<any> = React.memo(() => {
 	const { current, send, onCorrect, i18n } = useInsurerContext();
 	const { insurer, complete, preValidatedData } = current.context;
+
+	const insurerBtn = useRef(null);
+
+	const onClickInsurerBtn = () => {
+		current.context.lastBtnClicked = 4;
+		send('EDIT_INSURER');
+	};
+
+	const onCollapseInsurer = () => {
+		current.context.lastBtnClicked === 4 && insurerBtn.current.focus();
+	};
 
 	return (
 		<div
@@ -43,8 +54,10 @@ export const Preview: React.FC<any> = () => {
 				>
 					<UnderlinedButton
 						isOpen={current.matches({ edit: 'reference' })}
-						onClick={() => send('EDIT_INSURER')}
+						onClick={onClickInsurerBtn}
 						isEditButton={true}
+						btnRef={insurerBtn}
+						onCollapseCallback={onCollapseInsurer}
 					>
 						{i18n.preview.buttons.four}
 					</UnderlinedButton>
@@ -72,4 +85,4 @@ export const Preview: React.FC<any> = () => {
 			</Flex>
 		</div>
 	);
-};
+});

--- a/packages/layout/src/components/cards/thirdParty/context.tsx
+++ b/packages/layout/src/components/cards/thirdParty/context.tsx
@@ -46,6 +46,7 @@ export const ThirdPartyProvider = ({
 	complete,
 	preValidatedData,
 	thirdParty,
+	lastBtnClicked = null,
 	children,
 	i18n: i18nOverrides = {},
 	...rest
@@ -56,6 +57,7 @@ export const ThirdPartyProvider = ({
 			complete,
 			preValidatedData,
 			thirdParty,
+			lastBtnClicked,
 		},
 	});
 

--- a/packages/layout/src/components/cards/thirdParty/thirdParty.tsx
+++ b/packages/layout/src/components/cards/thirdParty/thirdParty.tsx
@@ -34,7 +34,7 @@ const CardContentSwitch: React.FC = () => {
 	}
 };
 
-const ToolbarButton: React.FC<{ title: string }> = ({ title }) => {
+const RemoveButton: React.FC<{ title: string }> = ({ title }) => {
 	const { current, send } = useThirdPartyContext();
 	return (
 		<UnderlinedButton
@@ -43,6 +43,7 @@ const ToolbarButton: React.FC<{ title: string }> = ({ title }) => {
 				current.matches({ remove: 'confirm' })
 			}
 			onClick={() => {
+				current.context.lastBtnClicked = 2;
 				if (
 					current.matches({ remove: 'date' }) ||
 					current.matches({ remove: 'confirm' })
@@ -62,45 +63,45 @@ const isComplete = (context: ThirdPartyContext) => {
 	return context.preValidatedData ? true : context.complete;
 };
 
-export const ThirdPartyCard: React.FC<ThirdPartyProviderProps> = ({
-	testId,
-	cfg,
-	...rest
-}) => {
-	return (
-		<ThirdPartyProvider {...rest}>
-			{({ current: { context }, i18n }) => {
-				return (
-					<Section
-						cfg={cfg}
-						data-testid={testId}
-						className={styles.card}
-						ariaLabel={concatenateStrings([
-							context.thirdParty.organisationName,
-							i18n.preview.buttons.one,
-						])}
-					>
-						<Toolbar
-							complete={isComplete(context)}
-							subtitle={() => (
-								<Subtitle main={context.thirdParty.organisationName} />
-							)}
-							statusText={
-								isComplete(context)
-									? i18n.preview.statusText.confirmed
-									: i18n.preview.statusText.unconfirmed
-							}
-							buttonLeft={() => (
-								<UnderlinedButton>{i18n.preview.buttons.one}</UnderlinedButton>
-							)}
-							buttonRight={() => (
-								<ToolbarButton title={i18n.preview.buttons.two} />
-							)}
-						/>
-						<CardContentSwitch />
-					</Section>
-				);
-			}}
-		</ThirdPartyProvider>
-	);
-};
+export const ThirdPartyCard: React.FC<ThirdPartyProviderProps> = React.memo(
+	({ testId, cfg, ...rest }) => {
+		return (
+			<ThirdPartyProvider {...rest}>
+				{({ current: { context }, i18n }) => {
+					return (
+						<Section
+							cfg={cfg}
+							data-testid={testId}
+							className={styles.card}
+							ariaLabel={concatenateStrings([
+								context.thirdParty.organisationName,
+								i18n.preview.buttons.one,
+							])}
+						>
+							<Toolbar
+								complete={isComplete(context)}
+								subtitle={() => (
+									<Subtitle main={context.thirdParty.organisationName} />
+								)}
+								statusText={
+									isComplete(context)
+										? i18n.preview.statusText.confirmed
+										: i18n.preview.statusText.unconfirmed
+								}
+								buttonLeft={() => (
+									<UnderlinedButton>
+										{i18n.preview.buttons.one}
+									</UnderlinedButton>
+								)}
+								buttonRight={() => (
+									<RemoveButton title={i18n.preview.buttons.two} />
+								)}
+							/>
+							<CardContentSwitch />
+						</Section>
+					);
+				}}
+			</ThirdPartyProvider>
+		);
+	},
+);

--- a/packages/layout/src/components/cards/thirdParty/thirdPartyMachine.ts
+++ b/packages/layout/src/components/cards/thirdParty/thirdPartyMachine.ts
@@ -27,6 +27,7 @@ export interface ThirdPartyContext {
 	remove: { confirm: boolean; date: string } | null;
 	thirdParty: Partial<ThirdPartyProps>;
 	preValidatedData?: boolean | null;
+	lastBtnClicked?: number | null;
 }
 
 const thirdPartyMachine = Machine<
@@ -40,6 +41,7 @@ const thirdPartyMachine = Machine<
 		complete: false,
 		remove: null,
 		thirdParty: {},
+		lastBtnClicked: null,
 	},
 	states: {
 		preview: {

--- a/packages/layout/src/components/cards/thirdParty/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/thirdParty/views/preview/preview.tsx
@@ -6,7 +6,7 @@ import { useThirdPartyContext } from '../../context';
 import { AddressPreview } from '../../../common/views/preview/components';
 import styles from '../../../cards.module.scss';
 
-export const Preview: React.FC<any> = () => {
+export const Preview: React.FC<any> = React.memo(() => {
 	const { current, send, onCorrect, i18n } = useThirdPartyContext();
 	const { thirdParty, complete, preValidatedData } = current.context;
 
@@ -56,4 +56,4 @@ export const Preview: React.FC<any> = () => {
 			</Flex>
 		</div>
 	);
-};
+});

--- a/packages/layout/src/components/cards/trustee/context.tsx
+++ b/packages/layout/src/components/cards/trustee/context.tsx
@@ -76,12 +76,14 @@ export interface TrusteeCardProps extends CardContentProps {
 	testId?: string | number;
 	children?: RenderProps | ReactElement;
 	cfg?: SpaceProps;
+	lastBtnClicked?: number | null;
 }
 
 export const TrusteeProvider = ({
 	trustee,
 	preValidatedData,
 	complete,
+	lastBtnClicked = null,
 	children,
 	onDetailsSave,
 	onContactSave,
@@ -103,6 +105,7 @@ export const TrusteeProvider = ({
 				...modifiedTrustee,
 				address: trusteeAddress,
 			},
+			lastBtnClicked,
 		},
 		services: {
 			onDetailsSave: ({ trustee }) => {

--- a/packages/layout/src/components/cards/trustee/trustee.tsx
+++ b/packages/layout/src/components/cards/trustee/trustee.tsx
@@ -93,6 +93,7 @@ const TrusteeButton: React.FC = () => {
 				current.matches({ edit: { trustee: 'save' } })
 			}
 			onClick={() => {
+				current.context.lastBtnClicked = 1;
 				if (
 					current.matches({ edit: { trustee: 'name' } }) ||
 					current.matches({ edit: { trustee: 'kind' } })
@@ -119,6 +120,7 @@ const RemoveButton: React.FC<{ tabIndex?: number }> = ({ tabIndex }) => {
 				current.matches({ remove: 'confirm' })
 			}
 			onClick={() => {
+				current.context.lastBtnClicked = 2;
 				if (
 					current.matches({ remove: 'reason' }) ||
 					current.matches({ remove: 'confirm' })
@@ -139,11 +141,9 @@ const isComplete = (context: TrusteeContext) => {
 	return context.preValidatedData ? true : context.complete;
 };
 
-export const TrusteeCard: React.FC<Omit<TrusteeCardProps, 'children'>> = ({
-	cfg,
-	enableContactDetails = true,
-	...props
-}) => {
+export const TrusteeCard: React.FC<
+	Omit<TrusteeCardProps, 'children'>
+> = React.memo(({ cfg, enableContactDetails = true, ...props }) => {
 	return (
 		<TrusteeProvider {...props}>
 			{({ current, i18n }) => (
@@ -192,4 +192,4 @@ export const TrusteeCard: React.FC<Omit<TrusteeCardProps, 'children'>> = ({
 			)}
 		</TrusteeProvider>
 	);
-};
+});

--- a/packages/layout/src/components/cards/trustee/trusteeMachine.ts
+++ b/packages/layout/src/components/cards/trustee/trusteeMachine.ts
@@ -81,6 +81,7 @@ export interface TrusteeContext {
 		reason: null | string;
 		date: null | string;
 	};
+	lastBtnClicked?: number | null;
 }
 
 const trusteeMachine = Machine<TrusteeContext, TrusteeStates, TrusteeEvents>({
@@ -112,6 +113,7 @@ const trusteeMachine = Machine<TrusteeContext, TrusteeStates, TrusteeEvents>({
 			emailAddress: '',
 		},
 		remove: null,
+		lastBtnClicked: null,
 	},
 	states: {
 		preview: {

--- a/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Flex, Hr, classNames } from '@tpr/core';
 import { useTrusteeContext } from '../../context';
 import { UnderlinedButton } from '../../../components/button';
@@ -7,89 +7,119 @@ import {
 	ContactDetailsPreview,
 	AddressPreview,
 } from '../../../common/views/preview/components';
-import styles from '../../../cards.module.scss';
 import { CardContentProps } from 'components/cards/common/interfaces';
 import { concatenateStrings } from '../../../../../utils';
+import styles from '../../../cards.module.scss';
 
-export const Preview: React.FC<CardContentProps> = ({
-	enableContactDetails = true,
-}) => {
-	const { current, send, onCorrect, i18n } = useTrusteeContext();
-	const { trustee, complete, preValidatedData } = current.context;
+export const Preview: React.FC<CardContentProps> = React.memo(
+	({ enableContactDetails = true }) => {
+		const { current, send, onCorrect, i18n } = useTrusteeContext();
+		const { trustee, complete, preValidatedData } = current.context;
 
-	return (
-		<div
-			className={
-				preValidatedData
-					? classNames([styles.content, styles.complete])
-					: classNames([{ [styles.complete]: complete }, styles.content])
-			}
-		>
-			<Flex>
-				{/* Addres section: open for editing	 */}
-				<Flex
-					cfg={{ width: 5, flex: '0 0 auto', flexDirection: 'column', pr: 4 }}
-				>
-					<UnderlinedButton
-						onClick={() => send('EDIT_ORG')}
-						isOpen={current.matches({ edit: 'company' })}
-						isEditButton={true}
-					>
-						{i18n.preview.buttons.three}
-					</UnderlinedButton>
-					<AddressPreview
-						name={trustee.address.addressLine1}
-						address={{
-							addressLine2: trustee.address.addressLine2,
-							addressLine3: trustee.address.addressLine3,
-							postTown: trustee.address.postTown,
-							county: trustee.address.county,
-							postcode: trustee.address.postcode,
-							country: trustee.address.country,
-						}}
-					/>
-				</Flex>
+		const correspondenceBtn = useRef(null);
+		const contactsBtn = useRef(null);
 
-				{/* Contact details section: open for editing	 */}
-				{enableContactDetails && (
+		const onClickCorrespondenceBtn = () => {
+			current.context.lastBtnClicked = 3;
+			send('EDIT_ORG');
+		};
+
+		const onClickContactsBtn = () => {
+			current.context.lastBtnClicked = 4;
+			send('EDIT_CONTACTS');
+		};
+
+		const onCollapseCorrespondence = () => {
+			current.context.lastBtnClicked === 3 && correspondenceBtn.current.focus();
+		};
+
+		const onCollapseContacts = () => {
+			current.context.lastBtnClicked === 4 && contactsBtn.current.focus();
+		};
+
+		return (
+			<div
+				className={
+					preValidatedData
+						? classNames([styles.content, styles.complete])
+						: classNames([{ [styles.complete]: complete }, styles.content])
+				}
+			>
+				<Flex>
+					{/* Addres section: open for editing	 */}
 					<Flex
-						cfg={{ width: 5, flex: '0 0 auto', flexDirection: 'column', pl: 4 }}
+						cfg={{ width: 5, flex: '0 0 auto', flexDirection: 'column', pr: 4 }}
 					>
 						<UnderlinedButton
-							onClick={() => send('EDIT_CONTACTS')}
-							isOpen={current.matches({ edit: 'contact' })}
+							onClick={onClickCorrespondenceBtn}
+							isOpen={current.matches({ edit: 'company' })}
 							isEditButton={true}
+							btnRef={correspondenceBtn}
+							onCollapseCallback={onCollapseCorrespondence}
 						>
-							{i18n.preview.buttons.four}
+							{i18n.preview.buttons.three}
 						</UnderlinedButton>
-						<ContactDetailsPreview
-							phone={{ value: trustee.telephoneNumber }}
-							email={{ value: trustee.emailAddress }}
+						<AddressPreview
+							name={trustee.address.addressLine1}
+							address={{
+								addressLine2: trustee.address.addressLine2,
+								addressLine3: trustee.address.addressLine3,
+								postTown: trustee.address.postTown,
+								county: trustee.address.county,
+								postcode: trustee.address.postcode,
+								country: trustee.address.country,
+							}}
 						/>
 					</Flex>
-				)}
-			</Flex>
 
-			{/*  All details correct - Checkbox	 */}
-			<Flex cfg={{ flexDirection: 'column' }}>
-				<Hr cfg={{ my: 4 }} />
-				<Checkbox
-					value={complete}
-					checked={complete}
-					onChange={() => {
-						send('COMPLETE', { value: !complete });
-						onCorrect(!complete);
-					}}
-					label={i18n.preview.checkboxLabel.replace(
-						'__NAME__',
-						concatenateStrings([
-							trustee.title,
-							trustee.firstName,
-							trustee.lastName,
-						]),
+					{/* Contact details section: open for editing	 */}
+					{enableContactDetails && (
+						<Flex
+							cfg={{
+								width: 5,
+								flex: '0 0 auto',
+								flexDirection: 'column',
+								pl: 4,
+							}}
+						>
+							<UnderlinedButton
+								onClick={onClickContactsBtn}
+								isOpen={current.matches({ edit: 'contact' })}
+								isEditButton={true}
+								btnRef={contactsBtn}
+								onCollapseCallback={onCollapseContacts}
+							>
+								{i18n.preview.buttons.four}
+							</UnderlinedButton>
+							<ContactDetailsPreview
+								phone={{ value: trustee.telephoneNumber }}
+								email={{ value: trustee.emailAddress }}
+							/>
+						</Flex>
 					)}
-				/>
-			</Flex>
-		</div>
-	);
-};
+				</Flex>
+
+				{/*  All details correct - Checkbox	 */}
+				<Flex cfg={{ flexDirection: 'column' }}>
+					<Hr cfg={{ my: 4 }} />
+					<Checkbox
+						value={complete}
+						checked={complete}
+						onChange={() => {
+							send('COMPLETE', { value: !complete });
+							onCorrect(!complete);
+						}}
+						label={i18n.preview.checkboxLabel.replace(
+							'__NAME__',
+							concatenateStrings([
+								trustee.title,
+								trustee.firstName,
+								trustee.lastName,
+							]),
+						)}
+					/>
+				</Flex>
+			</div>
+		);
+	},
+);


### PR DESCRIPTION
#### Fixes [AB#105814](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/105814) 

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable Azure Pipelines for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fixing bugs #105814 & #106850. The focus was being assigned to all card buttons, therefore once a page was loaded, the focus was always in the last button of the last card because this was the last element rendered.

In all cards, we have 2 sections: 
- **Toolbar** (containing at least the 'Remove' button & sometimes the title button) 
- **Content** (this section changes depending if the data is being edited or simply displaying the card info).

Because the 'content' section changes, when clicking one of its buttons (on the `Preview` view) the focus needs to be added to the button rendered in the new view in the editing section.
And when collapsing the editing section, the focus needs to return to the button that was clicked in the `Preview` view.

To solve this, we need to save which button was last clicked, to identify which button needs the focus back. 
This data is saved in the card context, adding a new property: `lastBtnClicked`.

For some reason the Employer card was always wrongly assigning the focus to the `Remove` button, for this reason I have separated the 2 buttons in individual components and this have solved the issue.