### PR TITLE
Support 'Cannot start yet' on task list AB#108476

### DIFF
--- a/packages/layout/src/components/__tests__/tasklist.spec.tsx
+++ b/packages/layout/src/components/__tests__/tasklist.spec.tsx
@@ -124,6 +124,61 @@ describe('Tasklist', () => {
 		expect(totalSections.length).toMatchInlineSnapshot(`8`);
 	});
 
+	test('incomplete link is linked', () => {
+		const title = 'Scheme return home';
+		const { getByText } = getComponent(title);
+
+		[...s1.links, ...s2.links, ...s3.links]
+			.filter((link) => !link.completed && !link.disabled)
+			.forEach((link) => {
+				expect(getByText(link.name).closest('a')).not.toBeNull();
+			});
+	});
+
+	test('completed link is linked', () => {
+		const title = 'Scheme return home';
+		const { getByText } = getComponent(title);
+
+		[...s1.links, ...s2.links, ...s3.links]
+			.filter((link) => link.completed && !link.disabled)
+			.forEach((link) => {
+				expect(getByText(link.name).closest('a')).not.toBeNull();
+			});
+	});
+
+	test('disabled link is not linked', () => {
+		const title = 'Scheme return home';
+		const { getByText } = getComponent(title);
+
+		[...s1.links, ...s2.links, ...s3.links]
+			.filter((link) => link.disabled)
+			.forEach((link) => {
+				expect(getByText(link.name).closest('a')).toBeNull();
+			});
+	});
+
+	test('status is labelled correctly', () => {
+		const title = 'Scheme return home';
+		const { getByText } = getComponent(title);
+
+		[...s1.links, ...s2.links, ...s3.links].forEach((link) => {
+			let expectedStatus = 'Section not complete';
+			let expectedClass = 'incomplete';
+			if (link.completed) {
+				expectedStatus = 'Section complete';
+				expectedClass = 'complete';
+			}
+			if (link.disabled) {
+				expectedStatus = 'Section unavailable';
+				expectedClass = 'disabled';
+			}
+
+			const status = getByText(link.name).nextElementSibling;
+			expect(status.textContent).toBe(expectedStatus);
+			expect(status).toHaveAttribute('class', `taskStatus ${expectedClass}`);
+		});
+	});
+
 	const getComponent = (title: string) => {
 		const { container, getByText } = render(
 			<Tasklist
@@ -143,6 +198,7 @@ describe('Tasklist', () => {
 						/*intentional*/
 					},
 				}}
+				sectionDisabledLabel="Section unavailable"
 				sectionCompleteLabel="Section complete"
 				sectionIncompleteLabel="Section not complete"
 			/>,

--- a/packages/layout/src/components/navitem/NavItem.tsx
+++ b/packages/layout/src/components/navitem/NavItem.tsx
@@ -11,7 +11,6 @@ export const NavItem: React.FC<NavItemProps> = ({ link, children }) => {
 				fontWeight: 3,
 				width: link.hideIcon ? 10 : 8,
 			}}
-			disabled={link.disabled}
 			href={link.path}
 			onClick={() => link.onClick(link)}
 			taskList={true}

--- a/packages/layout/src/components/tasklist/components/TaskStatus.tsx
+++ b/packages/layout/src/components/tasklist/components/TaskStatus.tsx
@@ -4,17 +4,23 @@ import styles from '../tasklist.module.scss';
 
 const TaskStatus: React.FC<TaskStatusIconProps> = ({
 	link,
+	sectionDisabledLabel,
 	sectionCompleteLabel,
 	sectionIncompleteLabel,
 }) => {
+	let label: string, className: string;
+	if (link.completed) {
+		label = sectionCompleteLabel;
+		className = styles.complete;
+	} else if (link.disabled) {
+		label = sectionDisabledLabel;
+		className = styles.disabled;
+	} else {
+		label = sectionIncompleteLabel;
+		className = styles.incomplete;
+	}
 	return (
-		<strong
-			className={`${styles.taskStatus} ${
-				link.completed ? styles.complete : styles.incomplete
-			}`}
-		>
-			{link.completed ? sectionCompleteLabel : sectionIncompleteLabel}
-		</strong>
+		<strong className={`${styles.taskStatus} ${className}`}>{label}</strong>
 	);
 };
 

--- a/packages/layout/src/components/tasklist/components/TasklistMenu.tsx
+++ b/packages/layout/src/components/tasklist/components/TasklistMenu.tsx
@@ -9,6 +9,7 @@ const TasklistMenu: React.FC<TasklistMenuProps> = ({
 	title,
 	links,
 	maintenanceMode,
+	sectionDisabledLabel,
 	sectionCompleteLabel,
 	sectionIncompleteLabel,
 }) => {
@@ -38,16 +39,31 @@ const TasklistMenu: React.FC<TasklistMenuProps> = ({
 									width: 10,
 								}}
 							>
-								<NavItem link={link}>
-									<span className={styles.taskName}>{link.name}</span>
-									{!maintenanceMode && !link.hideIcon && (
-										<TaskStatus
-											link={link}
-											sectionCompleteLabel={sectionCompleteLabel}
-											sectionIncompleteLabel={sectionIncompleteLabel}
-										/>
-									)}
-								</NavItem>
+								{link.disabled ? (
+									<div className={styles.taskDisabled}>
+										<span className={styles.taskName}>{link.name}</span>
+										{!maintenanceMode && !link.hideIcon && (
+											<TaskStatus
+												link={link}
+												sectionDisabledLabel={sectionDisabledLabel}
+												sectionCompleteLabel={sectionCompleteLabel}
+												sectionIncompleteLabel={sectionIncompleteLabel}
+											/>
+										)}
+									</div>
+								) : (
+									<NavItem link={link}>
+										<span className={styles.taskName}>{link.name}</span>
+										{!maintenanceMode && !link.hideIcon && (
+											<TaskStatus
+												link={link}
+												sectionDisabledLabel={sectionDisabledLabel}
+												sectionCompleteLabel={sectionCompleteLabel}
+												sectionIncompleteLabel={sectionIncompleteLabel}
+											/>
+										)}
+									</NavItem>
+								)}
 							</Flex>
 						</Flex>
 						<Hr />

--- a/packages/layout/src/components/tasklist/components/types.ts
+++ b/packages/layout/src/components/tasklist/components/types.ts
@@ -10,12 +10,14 @@ export type TasklistMenuProps = {
 	title: string;
 	links: NavItemLinkProps[];
 	maintenanceMode: boolean;
+	sectionDisabledLabel: string;
 	sectionCompleteLabel: string;
 	sectionIncompleteLabel: string;
 };
 
 export type TaskStatusIconProps = {
 	link: NavItemLinkProps;
+	sectionDisabledLabel: string;
 	sectionCompleteLabel: string;
 	sectionIncompleteLabel: string;
 };
@@ -35,6 +37,7 @@ export type TasklistProps = {
 	location: any;
 	/** import from react-router-dom */
 	history: any;
+	sectionDisabledLabel: string;
 	sectionCompleteLabel: string;
 	sectionIncompleteLabel: string;
 	testId?: string;

--- a/packages/layout/src/components/tasklist/tasklist.mdx
+++ b/packages/layout/src/components/tasklist/tasklist.mdx
@@ -95,15 +95,14 @@ import { Tasklist } from '@tpr/layout';
 					{
 						name: 'Review',
 						completed: false,
-						disabled: true,
-						path: '/review-and-submit',
+						path: '/review',
 						hideIcon: true,
 					},
 					{
 						name: 'Submit',
 						completed: false,
 						disabled: true,
-						path: '/review-and-submit',
+						path: '/declare-and-submit',
 					},
 				],
 				order: 4,
@@ -120,6 +119,7 @@ import { Tasklist } from '@tpr/layout';
 				matchPath={matchPath}
 				location={location}
 				history={{ push: () => {} }}
+				sectionDisabledLabel="Cannot start yet"
 				sectionCompleteLabel="Completed"
 				sectionIncompleteLabel="Not started"
 			/>

--- a/packages/layout/src/components/tasklist/tasklist.module.scss
+++ b/packages/layout/src/components/tasklist/tasklist.module.scss
@@ -30,7 +30,7 @@
 	}
 
 	.taskStatus {
-		font-size: $font-size-1;
+		font-size: $font-size-2;
 		font-weight: bold;
 		text-transform: uppercase;
 		padding: 8px;
@@ -39,11 +39,25 @@
 			background-color: $colors-primary-3;
 			color: $white;
 		}
-		&.incomplete {
+		&.incomplete,
+		&.disabled {
 			background-color: $colors-neutral-3;
 			color: $colors-neutral-8;
 		}
 	}
+
+	.taskDisabled {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		align-items: center;
+		width: 100%;
+		font-family: $fonts-sans-serif;
+		font-size: $font-size-2;
+		font-weight: $font-weight-3;
+		color: $colors-neutral-a2;
+	}
+
 	.taskName {
 		padding: 7px 0;
 	}

--- a/packages/layout/src/components/tasklist/tasklist.tsx
+++ b/packages/layout/src/components/tasklist/tasklist.tsx
@@ -61,6 +61,7 @@ export const Tasklist: React.FC<TasklistProps> = ({
 	matchPath,
 	location,
 	history,
+	sectionDisabledLabel,
 	sectionCompleteLabel,
 	sectionIncompleteLabel,
 	testId,
@@ -138,6 +139,7 @@ export const Tasklist: React.FC<TasklistProps> = ({
 								title={item.title}
 								links={item.links}
 								maintenanceMode={maintenanceMode}
+								sectionDisabledLabel={sectionDisabledLabel}
 								sectionCompleteLabel={sectionCompleteLabel}
 								sectionIncompleteLabel={sectionIncompleteLabel}
 							/>


### PR DESCRIPTION
Uses existing `disabled` property (which is a hangover from when the side nav used buttons) to support 'Cannot start yet' on the task list. 

Add extra tests for this and other statuses on the task list.