### PR TITLE
Revise ARIA approach for address lookup AB#106672

### DIFF
--- a/packages/forms/src/__tests__/addressLookup.spec.tsx
+++ b/packages/forms/src/__tests__/addressLookup.spec.tsx
@@ -19,6 +19,7 @@ const defaultProps: AddressProps = {
 	selectAddressButton: 'Select address',
 	selectAddressRequiredMessage: 'Select an address to continue',
 	noAddressesFoundMessage: 'No matching addresses were found',
+	addressSelectedStatus: 'Address selected',
 	addressLine1Label: 'Address line 1',
 	addressLine1RequiredMessage: 'You must complete this field',
 	addressLine2Label: 'Address line 2',

--- a/packages/forms/src/elements/address/addressLookup.mdx
+++ b/packages/forms/src/elements/address/addressLookup.mdx
@@ -79,6 +79,7 @@ import { AddressLookup } from '@tpr/forms';
     						postcodeLookupButton="Find address"
     						changePostcodeButton="Change"
     						changePostcodeAriaLabel="Change postcode"
+								addressSelectedStatus="Address selected"
     						selectAddressLabel="Select an address"
     						selectAddressPlaceholder="Select an address from the list"
     						selectAddressButton="Select address"
@@ -203,6 +204,7 @@ import { AddressLookup } from '@tpr/forms';
 | selectAddressButton          | true     | string                                          | Text of the button which selects a matching address                                                                    |
 | selectAddressRequiredMessage | true     | string                                          | Error when a matched address is not selected                                                                           |
 | noAddressesFoundMessage      | true     | string                                          | Message indicating no addresses matched the postcode                                                                   |
+| addressSelectedStatus        | true     | string                                          | Status available to assistive technology to indicate when an address has been selected                                 |
 | addressLine1Label            | true     | string                                          | Label for Address Line 1 field                                                                                         |
 | addressLine1RequiredMessage  | true     | string                                          | Error message when Address Line 1 is left blank or < 2 characters                                                      |
 | addressLine2Label            | true     | string                                          | Label for Address Line 2 field                                                                                         |

--- a/packages/forms/src/elements/address/addressLookup.tsx
+++ b/packages/forms/src/elements/address/addressLookup.tsx
@@ -6,6 +6,7 @@ import { EditAddress } from './editAddress';
 import { act } from 'react-dom/test-utils';
 import { AddressProps } from './types';
 import { useEffect } from 'react';
+import accessibilityStyles from '@tpr/theming/lib/accessibility.module.scss';
 
 export enum AddressView {
 	PostcodeLookup,
@@ -30,6 +31,7 @@ export const AddressLookup: React.FC<AddressProps> = ({
 	selectAddressRequiredMessage,
 	noAddressesFoundMessage,
 	headingLevel = 2,
+	addressSelectedStatus,
 	addressLine1Label,
 	addressLine1RequiredMessage,
 	addressLine2Label,
@@ -62,6 +64,11 @@ export const AddressLookup: React.FC<AddressProps> = ({
 	const [addresses, setAddresses] = useState<Address[]>([]);
 	const [address, setAddress] = useState<Address | null>(null);
 	const [postcode, setPostcode] = useState<string>(null);
+	const [accessibleStatus, setAccessibleStatus] = React.useState<string>();
+	function updateStatus(status) {
+		setAccessibleStatus(status);
+		setTimeout(() => setAccessibleStatus(''), 4000);
+	}
 
 	useEffect(() => {
 		if (setSubmitButton) {
@@ -71,7 +78,10 @@ export const AddressLookup: React.FC<AddressProps> = ({
 
 	// Render a different child component depending on the state
 	return (
-		<div aria-live="polite">
+		<>
+			<p role="status" className={accessibilityStyles.visuallyHidden}>
+				{accessibleStatus}
+			</p>
 			{addressView === AddressView.PostcodeLookup && (
 				<PostcodeLookup
 					postcode={postcode}
@@ -115,6 +125,7 @@ export const AddressLookup: React.FC<AddressProps> = ({
 					onAddressSelected={(selectedAddress) => {
 						setAddress(selectedAddress);
 						setAddressView(AddressView.EditAddress);
+						updateStatus(addressSelectedStatus);
 					}}
 					postcodeLookupLabel={postcodeLookupLabel}
 					changePostcodeButton={changePostcodeButton}
@@ -158,6 +169,6 @@ export const AddressLookup: React.FC<AddressProps> = ({
 					headingLevel={headingLevel}
 				/>
 			)}
-		</div>
+		</>
 	);
 };

--- a/packages/forms/src/elements/address/i18nAddressLookup.ts
+++ b/packages/forms/src/elements/address/i18nAddressLookup.ts
@@ -12,6 +12,7 @@ export interface I18nAddressLookup {
 	selectAddressButton?: string;
 	selectAddressRequiredMessage?: string;
 	noAddressesFoundMessage?: string;
+	addressSelectedStatus?: string;
 	addressLine1Label?: string;
 	addressLine1RequiredMessage?: string;
 	addressLine2Label?: string;
@@ -37,6 +38,7 @@ export const i18n: I18nAddressLookup = {
 	selectAddressButton: 'Select address',
 	selectAddressRequiredMessage: 'Select an address to continue',
 	noAddressesFoundMessage: 'No matching addresses were found',
+	addressSelectedStatus: 'Address selected',
 	addressLine1Label: 'Address line 1',
 	addressLine1RequiredMessage: 'You must complete this field',
 	addressLine2Label: 'Address line 2',

--- a/packages/forms/src/elements/address/types/AddressProps.ts
+++ b/packages/forms/src/elements/address/types/AddressProps.ts
@@ -13,6 +13,7 @@ export interface AddressProps extends SubmitButtonProps {
 	postcodeLookupButton: string;
 	changePostcodeButton: string;
 	changePostcodeAriaLabel?: string;
+	addressSelectedStatus: string;
 	selectAddressLabel: string;
 	selectAddressPlaceholder?: string;
 	selectAddressButton: string;

--- a/packages/layout/src/components/cards/common/views/address/addressPage.tsx
+++ b/packages/layout/src/components/cards/common/views/address/addressPage.tsx
@@ -72,6 +72,7 @@ const AddressPage: React.FC<AddressPageProps> = ({
 										i18n.selectAddressRequiredMessage
 									}
 									noAddressesFoundMessage={i18n.noAddressesFoundMessage}
+									addressSelectedStatus={i18n.addressSelectedStatus}
 									addressLine1Label={i18n.addressLine1Label}
 									addressLine1RequiredMessage={i18n.addressLine1RequiredMessage}
 									addressLine2Label={i18n.addressLine2Label}


### PR DESCRIPTION
When switching from Postcode lookup > Select address, the previous code surrounded the whole component in an aria-live region and set the focus, which led to the following being announced: _"Postcode BN9 9TT Change Select an address Optional Select an address Optional Open dropdown Open dropdown Select address Select an address Optional Open dropdown Edit Read-only Autocomplete Select an address from the list Blank"._ Removing the aria-live region but leaving the focus creates a good experience where you are placed in the next field you need and it's announced once.

When switching for Select address > Edit address, the previous code also already set the focus, but this time the focused field isn't announced. As a workaround, a hidden status is introduced which announces "Address selected" to indicate the change of context.