### PR TITLE
Reduce verbosity on moving the the select address component AB#106672

### DIFF
--- a/packages/forms/src/elements/address/addressLookup.tsx
+++ b/packages/forms/src/elements/address/addressLookup.tsx
@@ -71,7 +71,7 @@ export const AddressLookup: React.FC<AddressProps> = ({
 
 	// Render a different child component depending on the state
 	return (
-		<div aria-live="polite">
+		<>
 			{addressView === AddressView.PostcodeLookup && (
 				<PostcodeLookup
 					postcode={postcode}
@@ -134,30 +134,32 @@ export const AddressLookup: React.FC<AddressProps> = ({
 					}}
 				/>
 			)}
-			{addressView === AddressView.EditAddress && (
-				<EditAddress
-					initialValue={initialValue}
-					loading={loading}
-					value={address}
-					testId={testId}
-					onChangeAddressClick={() => {
-						if (onAddressChanging) {
-							onAddressChanging(false);
-						}
-						setAddressView(AddressView.PostcodeLookup);
-					}}
-					addressLine1Label={addressLine1Label}
-					addressLine1RequiredMessage={addressLine1RequiredMessage}
-					addressLine2Label={addressLine2Label}
-					addressLine3Label={addressLine3Label}
-					townLabel={townLabel}
-					countyLabel={countyLabel}
-					postcodeLabel={postcodeLabel}
-					countryLabel={countryLabel}
-					changeAddressButton={changeAddressButton}
-					headingLevel={headingLevel}
-				/>
-			)}
-		</div>
+			<div aria-live="polite">
+				{addressView === AddressView.EditAddress && (
+					<EditAddress
+						initialValue={initialValue}
+						loading={loading}
+						value={address}
+						testId={testId}
+						onChangeAddressClick={() => {
+							if (onAddressChanging) {
+								onAddressChanging(false);
+							}
+							setAddressView(AddressView.PostcodeLookup);
+						}}
+						addressLine1Label={addressLine1Label}
+						addressLine1RequiredMessage={addressLine1RequiredMessage}
+						addressLine2Label={addressLine2Label}
+						addressLine3Label={addressLine3Label}
+						townLabel={townLabel}
+						countyLabel={countyLabel}
+						postcodeLabel={postcodeLabel}
+						countryLabel={countryLabel}
+						changeAddressButton={changeAddressButton}
+						headingLevel={headingLevel}
+					/>
+				)}
+			</div>
+		</>
 	);
 };


### PR DESCRIPTION
When switching from Postcode lookup > Select address, the previous code surrounded the whole component in an aria-live region and set the focus, which led to the following being announced: 

_"Postcode BN9 9TT Change Select an address Optional Select an address Optional Open dropdown Open dropdown Select address Select an address Optional Open dropdown Edit Read-only Autocomplete Select an address from the list Blank"._ 

Removing the aria-live region but leaving the focus creates a good experience where you are placed in the next field you need and it's announced once.

The aria-live region is retained for moving from Select address > Edit address, where it announces the selected address once and makes clear which fields are editable.