### PR TITLE
Add ForwardRef to Link component

### DIFF
--- a/packages/core/src/components/links/links.tsx
+++ b/packages/core/src/components/links/links.tsx
@@ -23,51 +23,58 @@ export interface LinkProps {
 
 const defaultHintId = 'cancelHint';
 
-export const Link: React.FC<LinkProps> = ({
-	cfg: globalStyles,
-	underline = false,
-	className,
-	testId,
-	taskList = false,
-	hint,
-	hintCfg,
-	hintId = defaultHintId,
-	children,
-	...props
-}) => {
-	const classNames = useClassNames(globalStyles, [
-		styles.link,
-		{ [styles['link-underline']]: underline },
-		className,
-	]);
+export const Link: React.FC<LinkProps> = React.forwardRef<
+	HTMLAnchorElement,
+	LinkProps
+>(
+	(
+		{
+			cfg: globalStyles,
+			underline = false,
+			className,
+			testId,
+			taskList = false,
+			hint,
+			hintCfg,
+			hintId = defaultHintId,
+			children,
+			...props
+		},
+		ref,
+	) => {
+		const classNames = useClassNames(globalStyles, [
+			styles.link,
+			{ [styles['link-underline']]: underline },
+			className,
+		]);
 
-	let anchorProps = {
-		'data-testid': testId,
-		className: classNames,
-		href: props.href ? props.href : '#',
-		onClick: null,
-		'aria-describedby': hint ? hintId : null,
-		...props,
-	};
-
-	if (props.onClick && (!props.href || taskList)) {
-		anchorProps.onClick = function (e) {
-			e.preventDefault();
-			props.onClick();
+		let anchorProps = {
+			'data-testid': testId,
+			className: classNames,
+			href: props.href ? props.href : '#',
+			onClick: null,
+			'aria-describedby': hint ? hintId : null,
+			...props,
 		};
-	}
 
-	const Anchor: React.FC = () =>
-		React.createElement('a', anchorProps, children);
+		if (props.onClick && (!props.href || taskList)) {
+			anchorProps.onClick = function (e) {
+				e.preventDefault();
+				props.onClick();
+			};
+		}
 
-	return (
-		<>
-			<Anchor />
-			{hint && (
-				<Span className={styles.hint} id={hintId} cfg={{ ...hintCfg }}>
-					{hint}
-				</Span>
-			)}
-		</>
-	);
-};
+		return (
+			<>
+				<a ref={ref} {...anchorProps}>
+					{children}
+				</a>
+				{hint && (
+					<Span className={styles.hint} id={hintId} cfg={{ ...hintCfg }}>
+						{hint}
+					</Span>
+				)}
+			</>
+		);
+	},
+);


### PR DESCRIPTION
For [AB#108019](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/108019) it is useful to be able to focus the 'Add service provider' link. This requires the Link component to support a ref property pointing to the actual link.