### PR TITLE
Task list updates for scheme maintenance

### DIFF
--- a/packages/layout/src/components/__tests__/tasklist.spec.tsx
+++ b/packages/layout/src/components/__tests__/tasklist.spec.tsx
@@ -99,6 +99,30 @@ describe('Tasklist', () => {
 		expect(totalProgress).toEqual(totalSections.length);
 	});
 
+	test('progress bar is not shown when titleComplete and titleIncomplete are falsy', () => {
+		const { queryByText } = getComponent('');
+
+		const progressText = queryByText((content) =>
+			content.startsWith('You have completed'),
+		);
+		expect(progressText).toBeNull();
+	});
+
+	test('progress is not shown when showStatus = false', () => {
+		const title = 'Scheme return home';
+		const { queryByText } = getComponent(title, false);
+
+		const progressText = queryByText((content) =>
+			content.startsWith('You have completed'),
+		);
+		expect(progressText).toBeNull();
+
+		[...s1.links, ...s2.links, ...s3.links].forEach((link) => {
+			const status = queryByText(link.name).nextElementSibling;
+			expect(status).toBeNull();
+		});
+	});
+
 	test('each section title is visible', () => {
 		const title = 'Scheme return home';
 		const { getByText } = getComponent(title);
@@ -185,15 +209,14 @@ describe('Tasklist', () => {
 		});
 	});
 
-	const getComponent = (title: string) => {
-		const { container, getByText } = render(
+	const getComponent = (title: string, showStatus: boolean = true) => {
+		const { container, getByText, queryByText } = render(
 			<Tasklist
 				titleComplete={title}
 				titleIncomplete={title}
+				showStatus={showStatus}
 				reviewTitle="Review page"
-				welcomeTitle="Welcome page"
 				reviewPath="/"
-				welcomePath="/"
 				sections={sections}
 				matchPath={() => {
 					/*intentional*/
@@ -209,6 +232,6 @@ describe('Tasklist', () => {
 				sectionIncompleteLabel="Section not complete"
 			/>,
 		);
-		return { container, getByText };
+		return { container, getByText, queryByText };
 	};
 });

--- a/packages/layout/src/components/tasklist/components/TasklistMenu.tsx
+++ b/packages/layout/src/components/tasklist/components/TasklistMenu.tsx
@@ -8,7 +8,7 @@ import { NavItem } from '../../../components/navitem/navitem';
 const TasklistMenu: React.FC<TasklistMenuProps> = ({
 	title,
 	links,
-	maintenanceMode,
+	showStatus,
 	sectionDisabledLabel,
 	sectionCompleteLabel,
 	sectionIncompleteLabel,
@@ -42,7 +42,7 @@ const TasklistMenu: React.FC<TasklistMenuProps> = ({
 								{link.disabled ? (
 									<div className={styles.taskDisabled}>
 										<span className={styles.taskName}>{link.name}</span>
-										{!maintenanceMode && !link.hideIcon && (
+										{showStatus && !link.hideIcon && (
 											<TaskStatus
 												link={link}
 												sectionDisabledLabel={sectionDisabledLabel}
@@ -54,7 +54,7 @@ const TasklistMenu: React.FC<TasklistMenuProps> = ({
 								) : (
 									<NavItem link={link}>
 										<span className={styles.taskName}>{link.name}</span>
-										{!maintenanceMode && !link.hideIcon && (
+										{showStatus && !link.hideIcon && (
 											<TaskStatus
 												link={link}
 												sectionDisabledLabel={sectionDisabledLabel}

--- a/packages/layout/src/components/tasklist/components/types.ts
+++ b/packages/layout/src/components/tasklist/components/types.ts
@@ -9,7 +9,7 @@ export type TasklistSectionProps = {
 export type TasklistMenuProps = {
 	title: string;
 	links: NavItemLinkProps[];
-	maintenanceMode: boolean;
+	showStatus: boolean;
 	sectionDisabledLabel: string;
 	sectionCompleteLabel: string;
 	sectionIncompleteLabel: string;
@@ -23,11 +23,11 @@ export type TaskStatusIconProps = {
 };
 
 export type TasklistProps = {
-	titleComplete: string;
-	titleIncomplete: string;
+	titleComplete?: string;
+	titleIncomplete?: string;
 	reviewTitle: string;
 	reviewPath: string;
-	maintenanceMode?: boolean;
+	showStatus?: boolean;
 	sections: TasklistSectionProps[];
 	/** import from react-router-dom */
 	matchPath: any;

--- a/packages/layout/src/components/tasklist/components/types.ts
+++ b/packages/layout/src/components/tasklist/components/types.ts
@@ -27,8 +27,6 @@ export type TasklistProps = {
 	titleIncomplete: string;
 	reviewTitle: string;
 	reviewPath: string;
-	welcomeTitle: string;
-	welcomePath: string;
 	maintenanceMode?: boolean;
 	sections: TasklistSectionProps[];
 	/** import from react-router-dom */

--- a/packages/layout/src/components/tasklist/tasklist.mdx
+++ b/packages/layout/src/components/tasklist/tasklist.mdx
@@ -113,7 +113,6 @@ import { Tasklist } from '@tpr/layout';
 				titleComplete="Scheme return complete"
 				titleIncomplete="Scheme return incomplete"
 				reviewTitle="Review current and previous scheme returns"
-				welcomeTitle="Return to the welcome page"
 				sections={sections}
 				maintenanceMode={false}
 				matchPath={matchPath}

--- a/packages/layout/src/components/tasklist/tasklist.mdx
+++ b/packages/layout/src/components/tasklist/tasklist.mdx
@@ -19,6 +19,8 @@ Tasklist component for tpr apps
 import { Tasklist } from '@tpr/layout';
 ```
 
+## With progress bar
+
 <Playground>
 	{() => {
 		const location = {
@@ -114,7 +116,116 @@ import { Tasklist } from '@tpr/layout';
 				titleIncomplete="Scheme return incomplete"
 				reviewTitle="Review current and previous scheme returns"
 				sections={sections}
-				maintenanceMode={false}
+				showStatus={true}
+				matchPath={matchPath}
+				location={location}
+				history={{ push: () => {} }}
+				sectionDisabledLabel="Cannot start yet"
+				sectionCompleteLabel="Completed"
+				sectionIncompleteLabel="Not started"
+			/>
+		);
+	}}
+</Playground>
+
+## Without progress bar
+
+If `showStatus` is false the progress bar and status indicators are hidden. If `titleComplete` and/or `titleIncomplete` are falsy, the progress bar is also hidden.
+
+<Playground>
+	{() => {
+		const location = {
+			pathname: '/scheme-name-and-address',
+		};
+		const sections = [
+			{
+				title: 'Scheme details',
+				links: [
+					{
+						name: 'Scheme name and address',
+						completed: true,
+						onClick: (link) => alert(`You clicked on /scheme-name-and-address`),
+						path: '',
+					},
+					{
+						name: 'Scheme status and membership',
+						onClick: (link) =>
+							alert(`You clicked on /scheme-status-and-membership`),
+						path: '',
+					},
+					{
+						name: 'Consent to electronic communication',
+						onClick: (link) =>
+							alert(`You clicked on /consent-to-electronic-communication`),
+						path: '',
+					},
+				],
+				order: 1,
+			},
+			{
+				title: 'Roles',
+				links: [
+					{
+						name: 'Trustee details',
+						completed: true,
+						active: (_path) => true,
+						path: '/trustee-details',
+					},
+					{ name: 'Employer details', path: '/employer-details' },
+					{
+						name: 'Service provider details',
+						path: '/service-provider-details',
+					},
+				],
+				order: 2,
+			},
+			{
+				title: 'Financial details',
+				links: [
+					{
+						name: 'S179 valuation',
+						completed: true,
+						active: (_path) => true,
+						path: '/s179-valuation',
+					},
+					{ name: 'Part 3 funding valuation', path: '/part-3-valuation' },
+					{
+						name: 'Buyout valuation',
+						completed: false,
+						path: '/buyout-valuation',
+					},
+					{
+						name: 'Asset breakdown',
+						completed: true,
+						path: '/asset-breakdown',
+					},
+				],
+				order: 3,
+			},
+			{
+				title: 'Review and submit',
+				links: [
+					{
+						name: 'Review',
+						completed: false,
+						path: '/review',
+						hideIcon: true,
+					},
+					{
+						name: 'Submit',
+						completed: false,
+						disabled: true,
+						path: '/declare-and-submit',
+					},
+				],
+				order: 4,
+			},
+		];
+		return (
+			<Tasklist
+				reviewTitle="Review current and previous scheme returns"
+				sections={sections}
+				showStatus={false}
 				matchPath={matchPath}
 				location={location}
 				history={{ push: () => {} }}

--- a/packages/layout/src/components/tasklist/tasklist.tsx
+++ b/packages/layout/src/components/tasklist/tasklist.tsx
@@ -57,8 +57,6 @@ export const Tasklist: React.FC<TasklistProps> = ({
 	titleIncomplete,
 	reviewTitle,
 	reviewPath,
-	welcomeTitle,
-	welcomePath,
 	sections: originalSections,
 	maintenanceMode = false,
 	matchPath,
@@ -116,20 +114,6 @@ export const Tasklist: React.FC<TasklistProps> = ({
 						taskList={true}
 					>
 						{reviewTitle}
-					</Link>
-					<Link
-						cfg={{
-							fontWeight: 3,
-							color: 'primary.2',
-							textAlign: 'left',
-							lineHeight: 6,
-							fontSize: 2,
-						}}
-						href={welcomePath}
-						onClick={() => history.push(welcomePath)}
-						taskList={true}
-					>
-						{welcomeTitle}
 					</Link>
 				</Flex>
 			</Flex>

--- a/packages/layout/src/components/tasklist/tasklist.tsx
+++ b/packages/layout/src/components/tasklist/tasklist.tsx
@@ -58,7 +58,7 @@ export const Tasklist: React.FC<TasklistProps> = ({
 	reviewTitle,
 	reviewPath,
 	sections: originalSections,
-	maintenanceMode = false,
+	showStatus = true,
 	matchPath,
 	location,
 	history,
@@ -78,28 +78,32 @@ export const Tasklist: React.FC<TasklistProps> = ({
 				cfg={{ flexDirection: 'column', mt: 8 }}
 				className={styles.tasklistMenu}
 			>
-				<P
-					cfg={{
-						color: 'neutral.8',
-						fontSize: 4,
-						fontWeight: 3,
-						lineHeight: 6,
-					}}
-					className={styles.label}
-				>
-					{completed ? titleComplete : titleIncomplete}
-				</P>
-				<P
-					cfg={{
-						color: 'neutral.8',
-						fontSize: 3,
-						fontWeight: 3,
-						lineHeight: 6,
-					}}
-					className={styles.label}
-				>
-					{`You have completed ${allCompleted.length} of ${allSections.length} sections`}
-				</P>
+				{showStatus && titleComplete && titleIncomplete && (
+					<>
+						<P
+							cfg={{
+								color: 'neutral.8',
+								fontSize: 4,
+								fontWeight: 3,
+								lineHeight: 6,
+							}}
+							className={styles.label}
+						>
+							{completed ? titleComplete : titleIncomplete}
+						</P>
+						<P
+							cfg={{
+								color: 'neutral.8',
+								fontSize: 3,
+								fontWeight: 3,
+								lineHeight: 6,
+							}}
+							className={styles.label}
+						>
+							{`You have completed ${allCompleted.length} of ${allSections.length} sections`}
+						</P>
+					</>
+				)}
 				<Flex cfg={{ flexDirection: 'column', mt: 4 }}>
 					<Link
 						cfg={{
@@ -125,7 +129,7 @@ export const Tasklist: React.FC<TasklistProps> = ({
 							<TasklistMenu
 								title={item.title}
 								links={item.links}
-								maintenanceMode={maintenanceMode}
+								showStatus={showStatus}
 								sectionDisabledLabel={sectionDisabledLabel}
 								sectionCompleteLabel={sectionCompleteLabel}
 								sectionIncompleteLabel={sectionIncompleteLabel}


### PR DESCRIPTION
#### Part of [AB#107915](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/107915) 

#### Checklist

- [X] Includes tests
- [X] Update documentation

#### Changes proposed in this pull request:

1. The option to have a 'Back to welcome page' link is removed. This will be replaced by a standard `BackLink` component.
2. The `maintenanceMode` property is renamed to `showStatus`, because the task list component will be used in future applications which do not have the concept of scheme maintenance/scheme return.
3. The progress summary at the top is hidden if `showStatus === false` or if the properties it uses, `titleComplete` and `titleIncomplete`, are missing or falsy.