### PR TITLE
Task/108589 select address loses value

### DIFF
--- a/packages/forms/src/elements/address/selectAddress.tsx
+++ b/packages/forms/src/elements/address/selectAddress.tsx
@@ -160,7 +160,7 @@ export const SelectAddress: React.FC<SelectAddressProps> = ({
 				placeholder={selectAddressPlaceholder}
 				readOnly={true}
 				disabled={loading}
-				selectedItem={null} // don't reselect if the same address turns up again
+				selectedItem={ addressSelected ? form.getFieldState('selectedAddress') :  null}
 			/>
 			<Button
 				testId={(testId ? testId + '-' : '') + 'select-address-button'}

--- a/packages/forms/src/elements/address/selectAddress.tsx
+++ b/packages/forms/src/elements/address/selectAddress.tsx
@@ -160,7 +160,7 @@ export const SelectAddress: React.FC<SelectAddressProps> = ({
 				placeholder={selectAddressPlaceholder}
 				readOnly={true}
 				disabled={loading}
-				selectedItem={ addressSelected ? form.getFieldState('selectedAddress') :  null}
+				initialSelectedItem={ addressSelected ? form.getFieldState('selectedAddress') :  null}
 			/>
 			<Button
 				testId={(testId ? testId + '-' : '') + 'select-address-button'}

--- a/packages/forms/src/elements/select/select.tsx
+++ b/packages/forms/src/elements/select/select.tsx
@@ -164,9 +164,7 @@ export const FFSelect: React.FC<
 				return (
 					<Select
 						ref={ref}
-						initialSelectedItem={
-							initialSelectedItem ? initialSelectedItem : input.value
-						}
+						initialSelectedItem={initialSelectedItem}
 						itemToString={itemToString}
 						onChange={(value, _ctx) => {
 							// override onChange from outside if needed

--- a/packages/forms/src/elements/select/select.tsx
+++ b/packages/forms/src/elements/select/select.tsx
@@ -59,6 +59,7 @@ export const Select: React.FC<
 					getItemProps,
 					getLabelProps,
 					getMenuProps,
+					getToggleButtonProps,
 					isOpen,
 					highlightedIndex,
 					selectedItem,
@@ -103,6 +104,7 @@ export const Select: React.FC<
 										data-testid={`${testId}-button`}
 										className={styles.iconButton}
 										onClick={() => toggleMenu()}
+										{...getToggleButtonProps()}
 									>
 										<UnfoldMore />
 									</button>


### PR DESCRIPTION
#### Fixes AB#0000

#### Checklist

- [X ] Includes tests
- [ X] Update documentation

<!-- DO NOT enable Azure Pipelines for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Alters behaviour so that selected address persists when tabbing away, but is set to null when re-opening the search.

#### Reviewers should focus on:

The behaviour above being persistent across multiple loops of the behaviour

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
