### PR TITLE
The highlight component layout was incorrect

### DIFF
--- a/packages/layout/src/components/highlight/highlight.mdx
+++ b/packages/layout/src/components/highlight/highlight.mdx
@@ -18,6 +18,14 @@ import { Highlight } from '@tpr/layout';
 <Playground>
 	<Highlight
 		context="Scheme maintenance"
+		name="Short name"
+		reference="PSR: 12014314"
+	/>
+</Playground>
+
+<Playground>
+	<Highlight
+		context="Scheme maintenance"
 		name="Test Scheme: Pension scheme with an long name that will not fit on one line even at full width"
 		reference="PSR: 12014314"
 	/>

--- a/packages/layout/src/components/highlight/highlight.module.scss
+++ b/packages/layout/src/components/highlight/highlight.module.scss
@@ -20,6 +20,7 @@ $horizontal-space-outer: $space-6;
 }
 
 .container {
+	flex-grow: 1; // Required when the text inside .name is short.
 	flex-direction: column;
 }
 


### PR DESCRIPTION
The highlight component layout was incorrect when the name property had a short value [AB#109282](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/109282)