### PR TITLE
Flexbox layout on labels was preventing text wrapping in IE

### DIFF
--- a/packages/forms/src/elements/checkbox/checkbox.tsx
+++ b/packages/forms/src/elements/checkbox/checkbox.tsx
@@ -33,8 +33,6 @@ export const Checkbox: React.FC<Partial<CheckboxIconProps>> = ({
 				{
 					mt: 1,
 					mb: 1,
-					alignItems: 'flex-start',
-					flexDirection: 'column',
 				},
 				cfg,
 			)}

--- a/packages/forms/src/elements/currency/currency.tsx
+++ b/packages/forms/src/elements/currency/currency.tsx
@@ -243,7 +243,7 @@ const InputCurrency: React.FC<InputCurrencyProps> = React.memo(
 		return (
 			<StyledInputLabel
 				isError={meta && meta.touched && meta.error}
-				cfg={Object.assign({ flexDirection: 'column', mt: 1 }, cfg)}
+				cfg={Object.assign({ mt: 1 }, cfg)}
 				noLeftBorder={noLeftBorder}
 			>
 				<InputElementHeading

--- a/packages/forms/src/elements/date/date.tsx
+++ b/packages/forms/src/elements/date/date.tsx
@@ -215,10 +215,7 @@ export const InputDate: React.FC<InputDateComponentProps> = memo(
 						? helper.hintId
 						: helper.labelId
 				}
-				cfg={Object.assign(
-					{ mt: 1, py: 1, alignItems: 'flex-start', flexDirection: 'column' },
-					cfg,
-				)}
+				cfg={Object.assign({ mt: 1, py: 1 }, cfg)}
 				hiddenLabel={hiddenLabel}
 				hiddenLabelId={hiddenLabelId}
 			>

--- a/packages/forms/src/elements/elements.module.scss
+++ b/packages/forms/src/elements/elements.module.scss
@@ -16,7 +16,7 @@ fieldset {
 }
 
 .label {
-	display: flex;
+	display: block;
 	cursor: default;
 }
 

--- a/packages/forms/src/elements/email/email.tsx
+++ b/packages/forms/src/elements/email/email.tsx
@@ -28,7 +28,7 @@ const InputEmail: React.FC<InputEmailProps> = ({
 	return (
 		<StyledInputLabel
 			isError={meta && meta.touched && meta.error}
-			cfg={Object.assign({ flexDirection: 'column', mt: 1 }, cfg)}
+			cfg={Object.assign({ mt: 1 }, cfg)}
 		>
 			<InputElementHeading
 				label={label}

--- a/packages/forms/src/elements/number/number.tsx
+++ b/packages/forms/src/elements/number/number.tsx
@@ -170,7 +170,7 @@ const InputNumber: React.FC<InputNumberProps> = ({
 	return (
 		<StyledInputLabel
 			isError={meta && meta.touched && meta.error}
-			cfg={Object.assign({ flexDirection: 'column', mt: 1 }, cfg)}
+			cfg={Object.assign({ mt: 1 }, cfg)}
 			noLeftBorder={noLeftBorder}
 			element={wrapperElement}
 		>

--- a/packages/forms/src/elements/phone/phone.tsx
+++ b/packages/forms/src/elements/phone/phone.tsx
@@ -28,7 +28,7 @@ const InputPhone: React.FC<InputPhoneProps> = ({
 	return (
 		<StyledInputLabel
 			isError={meta && meta.touched && meta.error}
-			cfg={Object.assign({ flexDirection: 'column', mt: 1 }, cfg)}
+			cfg={Object.assign({ mt: 1 }, cfg)}
 		>
 			<InputElementHeading
 				label={label}

--- a/packages/forms/src/elements/radio/radio.tsx
+++ b/packages/forms/src/elements/radio/radio.tsx
@@ -38,8 +38,6 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
 					mt: 1,
 					mb: 1,
 					py: 1,
-					alignItems: 'flex-start',
-					flexDirection: 'column',
 				},
 				cfg,
 			)}

--- a/packages/forms/src/elements/search/search.tsx
+++ b/packages/forms/src/elements/search/search.tsx
@@ -112,7 +112,7 @@ const Search: React.FC<SearchProps> = React.memo(
 		return (
 			<div className={classes}>
 				<StyledInputLabel
-					cfg={Object.assign({ flexDirection: 'column' }, cfg)}
+					cfg={cfg}
 					element="label"
 					isError={meta && meta.touched && meta.error}
 				>

--- a/packages/forms/src/elements/select/select.tsx
+++ b/packages/forms/src/elements/select/select.tsx
@@ -70,7 +70,7 @@ export const Select: React.FC<
 						<StyledInputLabel
 							element="label"
 							isError={meta && meta.touched && meta.error}
-							cfg={Object.assign({ flexDirection: 'column' }, cfg)}
+							cfg={cfg}
 							{...getLabelProps()}
 						>
 							<InputElementHeading

--- a/packages/forms/src/elements/text/text.tsx
+++ b/packages/forms/src/elements/text/text.tsx
@@ -60,7 +60,7 @@ const InputText: React.FC<InputTextProps> = React.forwardRef<
 			<StyledInputLabel
 				isError={meta && meta.touched && meta.error}
 				element={wrapperElement}
-				cfg={Object.assign({ flexDirection: 'column', mt: 1 }, cfg)}
+				cfg={Object.assign({ mt: 1 }, cfg)}
 			>
 				<InputElementHeadingWrapper>
 					<InputElementHeading


### PR DESCRIPTION
Flexbox layout on labels was preventing text wrapping in IE. Change to `display: block` and remove all the flexbox properties that are now redundant. [AB#109665](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/109665)