### PR TITLE
AB#110647 trustee card - main heading is the trustee name

### DIFF
--- a/packages/layout/src/components/__tests__/trustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/trustee.spec.tsx
@@ -88,6 +88,8 @@ const setupComponent = (enableContactDetails: boolean) => {
 	findAllByTestId = getAllByTestId;
 };
 
+const trusteeName: string = `${trustee.title} ${trustee.firstName} ${trustee.lastName}`;
+
 describe('TrusteeCard enableContactDetails == true', () => {
 	beforeEach(async () => {
 		setupComponent(true);
@@ -100,7 +102,7 @@ describe('TrusteeCard enableContactDetails == true', () => {
 		});
 
 		test('buttons render correctly', () => {
-			assertMainHeadingExists(findByText, findByTestId, 'Trustee', true);
+			assertMainHeadingExists(findByText, findByTestId, trusteeName, true);
 
 			assertRemoveButtonExists(findByText, findByTestId);
 
@@ -132,7 +134,7 @@ describe('TrusteeCard enableContactDetails == true', () => {
 		test('renders with a section containing an aria label', () => {
 			assertThatASectionExistsWithAnAriaLabel(
 				findByRole,
-				`${trustee.title} ${trustee.firstName} ${trustee.lastName} ${trustee.trusteeType} Trustee`,
+				`${trusteeName} ${trustee.trusteeType} Trustee`,
 			);
 		});
 
@@ -147,13 +149,13 @@ describe('TrusteeCard enableContactDetails == true', () => {
 		});
 
 		test('is accessible', async () => {
-			findByText('Trustee').click();
+			findByText(trusteeName).click();
 			const results = await axe(component);
 			expect(results).toHaveNoViolations();
 		});
 
 		test('renders name fields', () => {
-			findByText('Trustee').click();
+			findByText(trusteeName).click();
 
 			expect(findByTestId('trustee-name-form')).not.toBe(null);
 
@@ -191,7 +193,7 @@ describe('TrusteeCard enableContactDetails == true', () => {
 
 		test('trustee title can be left empty when name is updated', async () => {
 			await act(async () => {
-				findByText(/Trustee/).click();
+				findByText(trusteeName).click();
 			});
 			await axe(component);
 			clearTitleField(findByText);
@@ -216,7 +218,7 @@ describe('TrusteeCard enableContactDetails == true', () => {
 		});
 
 		test('is accessible', async () => {
-			findByText(/Trustee/).click();
+			findByText(trusteeName).click();
 			findByText(/Continue/).click();
 
 			const results = await axe(component);

--- a/packages/layout/src/components/cards/common/interfaces.ts
+++ b/packages/layout/src/components/cards/common/interfaces.ts
@@ -149,6 +149,7 @@ export interface CardContentProps {
 export interface IToolbarButtonProps {
 	remove?: boolean;
 	button: MutableRefObject<any>;
+	text?: string;
 }
 
 export interface ICardMainHeadingButtonProps {

--- a/packages/layout/src/components/cards/trustee/trustee.tsx
+++ b/packages/layout/src/components/cards/trustee/trustee.tsx
@@ -92,7 +92,7 @@ const CardContent: React.FC<CardContentProps> = ({
 };
 
 const ToolbarButton: React.FC<IToolbarButtonProps> = React.memo(
-	({ remove = false, button }) => {
+	({ remove = false, button, text }) => {
 		const { current, send, i18n } = useTrusteeContext();
 
 		return (
@@ -114,7 +114,7 @@ const ToolbarButton: React.FC<IToolbarButtonProps> = React.memo(
 						current={current}
 						onClick={() => send('EDIT_TRUSTEE')}
 					>
-						{i18n.preview.buttons.one}
+						{text ? text : i18n.preview.buttons.one}
 					</CardMainHeadingButton>
 				)}
 			</>
@@ -134,49 +134,52 @@ export const TrusteeCard: React.FC<
 
 	return (
 		<TrusteeProvider {...props}>
-			{({ current, i18n }) => (
-				<Section
-					cfg={cfg}
-					data-testid={props.testId}
-					className={styles.card}
-					ariaLabel={concatenateStrings([
-						current.context.trustee.title,
-						current.context.trustee.firstName,
-						current.context.trustee.lastName,
-						current.context.trustee.trusteeType,
-						i18n.preview.buttons.one,
-					])}
-				>
-					<Toolbar
-						buttonLeft={() => <ToolbarButton button={trusteeButtonRef} />}
-						buttonRight={() => (
-							<ToolbarButton button={removeButtonRef} remove={true} />
-						)}
-						complete={isComplete(current.context)}
-						subtitle={() => (
-							<Subtitle
-								main={concatenateStrings([
-									current.context.trustee.title,
-									current.context.trustee.firstName,
-									current.context.trustee.lastName,
-								])}
-								secondary={`${capitalize(
-									current.context.trustee.trusteeType,
-								)} trustee`}
-							/>
-						)}
-						statusText={
-							isComplete(current.context)
-								? i18n.preview.statusText.confirmed
-								: i18n.preview.statusText.unconfirmed
-						}
-					/>
-					<CardContent
-						onChangeAddress={props.onChangeAddress}
-						enableContactDetails={enableContactDetails}
-					/>
-				</Section>
-			)}
+			{({ current, i18n }) => {
+				const trusteeName: string = concatenateStrings([
+					current.context.trustee.title,
+					current.context.trustee.firstName,
+					current.context.trustee.lastName,
+				]);
+
+				return (
+					<Section
+						cfg={cfg}
+						data-testid={props.testId}
+						className={styles.card}
+						ariaLabel={concatenateStrings([
+							trusteeName,
+							current.context.trustee.trusteeType,
+							i18n.preview.buttons.one,
+						])}
+					>
+						<Toolbar
+							buttonLeft={() => (
+								<ToolbarButton button={trusteeButtonRef} text={trusteeName} />
+							)}
+							buttonRight={() => (
+								<ToolbarButton button={removeButtonRef} remove={true} />
+							)}
+							complete={isComplete(current.context)}
+							subtitle={() => (
+								<Subtitle
+									secondary={`${capitalize(
+										current.context.trustee.trusteeType,
+									)} trustee`}
+								/>
+							)}
+							statusText={
+								isComplete(current.context)
+									? i18n.preview.statusText.confirmed
+									: i18n.preview.statusText.unconfirmed
+							}
+						/>
+						<CardContent
+							onChangeAddress={props.onChangeAddress}
+							enableContactDetails={enableContactDetails}
+						/>
+					</Section>
+				);
+			}}
 		</TrusteeProvider>
 	);
 });


### PR DESCRIPTION
#### Fixes [AB#110647](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/110647)

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable Azure Pipelines for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

Trustee name becomes the main heading for Trustee card