### PR TITLE
Support changing the browser font size

### DIFF
--- a/packages/core/src/components/buttons/buttons.module.scss
+++ b/packages/core/src/components/buttons/buttons.module.scss
@@ -16,7 +16,7 @@
 .appearance-primary {
 	color: $white;
 	border: none;
-	border-radius: 8px;
+	border-radius: 0.5rem;
 
 	&:hover {
 		background: $colors-accents-2;
@@ -25,7 +25,7 @@
 	&:focus {
 		background: $colors-warning-1;
 		color: $colors-neutral-8;
-		box-shadow: 0px 2px 0px $colors-neutral-8;
+		box-shadow: 0 0.125rem 0 $colors-neutral-8;
 		outline: none;
 	}
 
@@ -44,12 +44,12 @@
 	color: $white;
 	background: $colors-primary-3 !important;
 	border: none;
-	border-radius: 8px;
+	border-radius: 0.5rem;
 
 	&:focus {
 		background: $colors-warning-1 !important;
 		color: $colors-neutral-8;
-		box-shadow: 0px 2px 0px $colors-neutral-8;
+		box-shadow: 0 0.125rem 0 $colors-neutral-8;
 		outline: none;
 	}
 
@@ -61,9 +61,9 @@
 }
 
 .appearance-outlined {
-	border: 2px solid $colors-primary-3;
+	border: 0.125rem solid $colors-primary-3;
 	background: transparent !important;
-	border-radius: 6px;
+	border-radius: 0.375rem;
 
 	&.intent-black {
 		color: $black;
@@ -77,12 +77,12 @@
 	&[aria-disabled='true'] {
 		color: $colors-neutral-6;
 		cursor: not-allowed !important;
-		border: 2px solid $colors-neutral-6;
+		border: 0.125rem solid $colors-neutral-6;
 
 		&:hover {
 			color: $colors-neutral-6;
 			background: none !important;
-			border: 2px solid $colors-neutral-6 !important;
+			border: 0.125rem solid $colors-neutral-6 !important;
 		}
 	}
 }
@@ -201,22 +201,22 @@
 .size-small {
 	font-size: $font-size-1;
 	text-align: center;
-	height: 40px;
-	padding: 0 15px;
+	height: 2.5rem;
+	padding: 0 0.9375rem;
 }
 
 .size-medium {
 	font-weight: $font-weight-2;
 	font-size: $font-size-2;
 	text-align: center;
-	height: 50px;
-	padding: 0 28px;
+	height: 3.125rem;
+	padding: 0 1.75rem;
 }
 
 .size-large {
 	font-weight: $font-weight-3;
 	font-size: $font-size-3;
 	text-align: center;
-	height: 60px;
-	padding: 0 38px;
+	height: 3.75rem;
+	padding: 0 2.375rem;
 }

--- a/packages/core/src/components/links/links.module.scss
+++ b/packages/core/src/components/links/links.module.scss
@@ -31,31 +31,8 @@
 		background: $colors-warning-1;
 		outline: none;
 		text-decoration: none;
-		box-shadow: 0px -2px $colors-warning-1, 0px 4px $colors-neutral-8;
+		box-shadow: 0 -0.125rem $colors-warning-1, 0 0.25rem $colors-neutral-8;
 	}
-}
-
-.link-underline {
-	text-decoration: underline;
-}
-
-.link-button-small {
-	line-height: 40px;
-}
-
-.link-button-medium {
-	line-height: 50px;
-}
-
-.link-button-large {
-	line-height: 60px;
-}
-
-.linkArrowBtn {
-	display: inline-flex;
-	flex-direction: row-reverse;
-	justify-content: center;
-	align-items: center;
 }
 
 .hint {

--- a/packages/core/src/components/typography/typography.module.scss
+++ b/packages/core/src/components/typography/typography.module.scss
@@ -4,7 +4,7 @@
 	font-family: $fonts-sans-serif;
 	font-weight: $font-weight-3;
 	font-size: $font-size-6;
-	letter-spacing: 0px;
+	letter-spacing: 0;
 	line-height: $line-height-4;
 	color: $colors-neutral-8;
 }
@@ -13,14 +13,14 @@
 	font-family: $fonts-sans-serif;
 	font-weight: $font-weight-2;
 	font-size: $font-size-5;
-	letter-spacing: 0px;
+	letter-spacing: 0;
 	line-height: $line-height-1;
 }
 
 @mixin styled-as-h3 {
 	font-family: $fonts-sans-serif;
 	font-size: $font-size-4;
-	letter-spacing: 0px;
+	letter-spacing: 0;
 	line-height: $line-height-1;
 }
 
@@ -28,7 +28,7 @@
 	font-family: $fonts-sans-serif;
 	font-weight: $font-weight-3;
 	font-size: $font-size-3;
-	letter-spacing: 0px;
+	letter-spacing: 0;
 	line-height: $line-height-1;
 }
 
@@ -36,7 +36,7 @@
 	font-family: $fonts-sans-serif;
 	font-weight: $font-weight-2;
 	font-size: $font-size-2;
-	letter-spacing: 0px;
+	letter-spacing: 0;
 	line-height: $line-height-1;
 }
 
@@ -44,7 +44,7 @@
 	font-family: $fonts-sans-serif;
 	font-weight: $font-weight-2;
 	font-size: $font-size-2;
-	letter-spacing: 0px;
+	letter-spacing: 0;
 	line-height: $line-height-1;
 }
 
@@ -105,7 +105,7 @@
 	font-family: $fonts-sans-serif;
 	font-weight: $font-weight-2;
 	font-size: $font-size-2;
-	letter-spacing: 0px;
+	letter-spacing: 0;
 	line-height: $line-height-3;
 	margin-bottom: 1em;
 }
@@ -114,13 +114,13 @@
 	font-family: $fonts-sans-serif;
 	font-weight: $font-weight-2;
 	font-size: $font-size-2;
-	letter-spacing: 0px;
+	letter-spacing: 0;
 	line-height: $line-height-3;
 }
 
 .hr {
 	width: 100%;
-	border-bottom: 1px solid $colors-neutral-4;
+	border-bottom: 0.0625rem solid $colors-neutral-4;
 }
 
 .bold {

--- a/packages/forms/src/elements/address/addressLookup.module.scss
+++ b/packages/forms/src/elements/address/addressLookup.module.scss
@@ -4,9 +4,6 @@
 	margin: 0 0 $space-3;
 }
 
-.nonEditable.selectedPostcode {
-	margin-top: 9px; /* Aligns with the field label on the postcode lookup view */
-}
 /* Ensure there is a space for the data even if the field is empty */
 .nonEditableText::after {
 	content: ' ';
@@ -22,7 +19,7 @@
 }
 
 .nonEditableLabel {
-	margin: $space-3 0 $space-1;
+	margin: 0 0 $space-1;
 }
 
 .button {

--- a/packages/forms/src/elements/checkbox/checkbox.module.scss
+++ b/packages/forms/src/elements/checkbox/checkbox.module.scss
@@ -14,12 +14,12 @@
 	}
 
 	input[type='checkbox']:focus + .checkbox {
-		box-shadow: 0 0 0 4px #ffd300;
+		box-shadow: 0 0 0 0.25rem #ffd300;
 	}
 
 	.checkbox {
-		min-width: 40px;
-		min-height: 40px;
+		min-width: 2.5rem;
+		min-height: 2.5rem;
 	}
 }
 
@@ -33,7 +33,7 @@
 	font-size: $font-size-2;
 	font-weight: $font-weight-2;
 	margin-top: $space-2;
-	margin-left: 55px;
+	margin-left: 3.4375rem;
 	margin-bottom: 0;
 }
 

--- a/packages/forms/src/elements/date/date.module.scss
+++ b/packages/forms/src/elements/date/date.module.scss
@@ -4,13 +4,19 @@
 	display: flex;
 	flex: 0 0 auto;
 	flex-direction: column;
-	width: 3.5em;
 	margin-right: $space-4;
+}
+
+.inputSmall input {
+	width: 3.5em;
 }
 
 .inputLarge {
 	display: flex;
 	flex: 0 0 auto;
 	flex-direction: column;
+}
+
+.inputLarge input {
 	width: 4.5em;
 }

--- a/packages/forms/src/elements/elements.module.scss
+++ b/packages/forms/src/elements/elements.module.scss
@@ -22,7 +22,7 @@ fieldset {
 
 .labelError {
 	padding-left: $space-3;
-	border-left: 4px solid $colors-danger-2;
+	border-left: 0.25rem solid $colors-danger-2;
 }
 
 .labelText {

--- a/packages/forms/src/elements/input/common.module.scss
+++ b/packages/forms/src/elements/input/common.module.scss
@@ -2,18 +2,18 @@
 
 @mixin inputDefault {
 	background: $white;
-	border: 1px solid $colors-neutral-7;
+	border: 0.0625rem solid $colors-neutral-7;
 	display: flex;
 	font-family: $fonts-sans-serif;
 	font-size: $font-size-2;
 	height: $space-10;
 	outline: none;
-	padding: 0 8px;
+	padding: 0 0.5rem;
 	width: 100%;
 }
 
 @mixin inputFocus {
-	border: 4px solid $colors-neutral-7;
-	box-shadow: 0 0 0 3px $colors-warning-1;
-	padding: 0 6px;
+	border: 0.25rem solid $colors-neutral-7;
+	box-shadow: 0 0 0 0.1875rem $colors-warning-1;
+	padding: 0 0.375rem;
 }

--- a/packages/forms/src/elements/input/input.module.scss
+++ b/packages/forms/src/elements/input/input.module.scss
@@ -15,7 +15,7 @@
 }
 
 .inputText-error {
-	border: 4px solid $colors-danger-2;
+	border: 0.25rem solid $colors-danger-2;
 }
 
 /* Chrome, Safari, Edge, Opera */
@@ -33,14 +33,17 @@ input[type='number'] {
 .after {
 	position: absolute;
 	left: 100%;
-	line-height: 50px;
 	margin-left: 0.5rem;
 }
 
 .before {
-	line-height: 50px;
 	margin-right: 0.5rem;
 	flex-shrink: inherit;
+}
+
+.inputWrapper {
+	flex: 1 1 auto;
+	align-items: center;
 }
 
 .input-wrapper_relative {

--- a/packages/forms/src/elements/input/input.tsx
+++ b/packages/forms/src/elements/input/input.tsx
@@ -61,8 +61,10 @@ export const Input: React.FC<InputProps> = React.forwardRef<
 
 		return (
 			<Flex
-				cfg={{ flex: '1 1 auto' }}
-				className={After ? styles['input-wrapper_relative'] : ''}
+				className={classNames([
+					styles.inputWrapper,
+					After ? styles['input-wrapper_relative'] : '',
+				])}
 			>
 				{Before && (
 					<span

--- a/packages/forms/src/elements/radio/radio.module.scss
+++ b/packages/forms/src/elements/radio/radio.module.scss
@@ -12,13 +12,13 @@
 	}
 
 	input[type='radio']:focus + .radio {
-		box-shadow: 0 0 0 4px #ffd300;
+		box-shadow: 0 0 0 0.25rem #ffd300;
 	}
 
 	.radio {
 		border-radius: 50%;
-		min-width: 40px;
-		min-height: 40px;
+		min-width: 2.5rem;
+		min-height: 2.5rem;
 	}
 }
 
@@ -53,7 +53,7 @@
 	font-size: $font-size-2;
 	font-weight: $font-weight-2;
 	margin-top: $space-2;
-	padding-left: 55px;
+	padding-left: 3.4375rem;
 	max-width: 100%;
 	@include removeMarginBottom;
 }

--- a/packages/forms/src/elements/search/search.module.scss
+++ b/packages/forms/src/elements/search/search.module.scss
@@ -37,7 +37,7 @@
 					list-style-type: none;
 					border: none;
 					box-shadow: none;
-					margin-top: 2px;
+					margin-top: 0.125rem;
 
 					li {
 						padding: $space-2 $space-3;
@@ -61,8 +61,8 @@
 				> div {
 					ul {
 						display: block;
-						border: 1px solid #ddd;
-						box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+						border: 0.0625rem solid #ddd;
+						box-shadow: 0 0.125rem 0.625rem rgba(0, 0, 0, 0.1);
 					}
 				}
 			}
@@ -80,7 +80,7 @@
 
 @keyframes hideAutocomplete {
 	0% {
-		max-height: 100px;
+		max-height: 6.25rem;
 		opacity: 0.2;
 	}
 	100% {

--- a/packages/forms/src/elements/select/popup.module.scss
+++ b/packages/forms/src/elements/select/popup.module.scss
@@ -8,7 +8,7 @@
 	font-weight: $font-weight-2;
 	color: $colors-neutral-7;
 	cursor: pointer;
-	padding: 10px 15px;
+	padding: 0.625rem 0.9375rem;
 	background-color: transparent;
 }
 

--- a/packages/forms/src/elements/select/select.module.scss
+++ b/packages/forms/src/elements/select/select.module.scss
@@ -9,15 +9,15 @@
 	flex: 0 0 auto;
 	flex-direction: column;
 	position: absolute;
-	min-height: 30px;
+	min-height: 1.875rem;
 	height: auto;
 	color: $black;
 	background: white;
 	width: 100%;
-	max-height: 280px;
-	border: 1px solid #ddd;
-	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-	margin-top: 2px;
+	max-height: 17.5rem;
+	border: 0.0625rem solid #ddd;
+	box-shadow: 0 0.125rem 0.625rem rgba(0, 0, 0, 0.1);
+	margin-top: 0.125rem;
 	z-index: 10;
 	overflow-x: auto;
 	user-select: none;
@@ -37,17 +37,23 @@
 	align-items: center;
 	position: absolute;
 	background: white;
-	top: 9px;
-	right: 4px;
-	width: 30px;
-	height: 32px;
+	top: 0.5625rem;
+	right: 0.25rem;
+	width: 1.875rem;
+	height: 2rem;
 	cursor: default;
 	outline: none;
+	border: 0.25rem solid transparent;
+
+	svg {
+		min-width: 1.5rem;
+		min-height: 1.5rem;
+	}
 }
 
 .iconButton:focus {
-	border: 4px solid $colors-neutral-7;
-	box-shadow: 0 0 0 3px $colors-warning-1;
+	border-color: $colors-neutral-7;
+	box-shadow: 0 0 0 0.1875rem $colors-warning-1;
 }
 
 .iconButton:disabled {

--- a/packages/icons/src/__tests__/icons.spec.tsx
+++ b/packages/icons/src/__tests__/icons.spec.tsx
@@ -18,10 +18,7 @@ import {
 	RadioButtonChecked,
 	RadioButtonUnchecked,
 } from '../components/form/form';
-import {
-	LoadingSpinnerCircle,
-	LoadingSpinnerProgress,
-} from '../components/spinners/spinners';
+import { LoadingSpinnerProgress } from '../components/spinners/spinners';
 import { SVG } from '../components/global';
 import { render } from '@testing-library/react';
 
@@ -167,11 +164,6 @@ describe('Icons', () => {
 	});
 
 	describe('Spinners', () => {
-		test('Loading Spinner Circle', () => {
-			const { getByTestId } = render(<LoadingSpinnerCircle />);
-			expect(getByTestId('spinner-circle')).toBeDefined();
-		});
-
 		test('Loading Spinner Progress', () => {
 			const { getByTestId } = render(<LoadingSpinnerProgress />);
 			expect(getByTestId('spinner-progress')).toBeDefined();

--- a/packages/icons/src/components/spinners/spinners.module.scss
+++ b/packages/icons/src/components/spinners/spinners.module.scss
@@ -7,21 +7,21 @@
 	.spinner {
 		display: inline-block;
 		position: relative;
-		width: 80px;
-		height: 80px;
+		width: 5rem;
+		height: 5rem;
 
 		div {
-			transform-origin: 40px 40px;
+			transform-origin: 2.5rem 2.5rem;
 			animation: progress-animation 1.2s linear infinite;
 
 			&:after {
 				content: ' ';
 				display: block;
 				position: absolute;
-				top: 3px;
-				left: 37px;
-				width: 6px;
-				height: 18px;
+				top: 0.1875rem;
+				left: 2.3125rem;
+				width: 0.375rem;
+				height: 1.125rem;
 				border-radius: 20%;
 				background: #483b8b;
 			}
@@ -79,7 +79,6 @@
 
 	.text {
 		font-family: $fonts-sans-serif;
-		font-size: 16px;
 		color: $black;
 		text-align: center;
 	}

--- a/packages/icons/src/components/spinners/spinners.module.scss
+++ b/packages/icons/src/components/spinners/spinners.module.scss
@@ -1,58 +1,5 @@
 @import '@tpr/theming/lib/variables.scss';
 
-.spinnerCircle {
-	display: inline-block;
-	text-align: center;
-
-	.spinner {
-		position: relative;
-		width: 80px;
-		height: 80px;
-		overflow: visible;
-		margin: 0 auto;
-
-		div {
-			position: absolute;
-			border: 10px solid #cdd500;
-			opacity: 1;
-			border-radius: 50%;
-			//animation: lds-ripple 1s cubic-bezier(0, 0.2, 0.8, 1) infinite;
-			animation: circle-animation 1s cubic-bezier(0, 0.9, 0.9, 1) infinite;
-
-			&:nth-child(2) {
-				animation-delay: -0.5s;
-				border: 10px solid #cdd500;
-			}
-		}
-	}
-
-	.text {
-		font-family: $fonts-sans-serif;
-		font-size: 16px;
-		color: $black;
-		text-align: center;
-	}
-}
-
-@keyframes circle-animation {
-	0% {
-		top: 36px;
-		left: 36px;
-		width: 0px;
-		height: 0;
-		opacity: 1;
-	}
-	100% {
-		top: 0px;
-		left: 0px;
-		width: 72px;
-		height: 72px;
-		opacity: 0;
-	}
-}
-
-/* ----------------------------------- */
-
 .spinnerProgress {
 	display: inline-block;
 	text-align: center;

--- a/packages/icons/src/components/spinners/spinners.tsx
+++ b/packages/icons/src/components/spinners/spinners.tsx
@@ -2,25 +2,6 @@ import React from 'react';
 import { SpinnerProps } from '../types';
 import styles from './spinners.module.scss';
 
-export const LoadingSpinnerCircle: React.FC<SpinnerProps> = ({
-	text = 'Loading...',
-}) => {
-	return (
-		<div
-			className={styles.spinnerCircle}
-			data-testid="spinner-circle"
-			role="alert"
-			aria-busy="true"
-		>
-			<div className={styles.spinner}>
-				<div></div>
-				<div></div>
-			</div>
-			<div className={styles.text}>{text}</div>
-		</div>
-	);
-};
-
 export const LoadingSpinnerProgress: React.FC<SpinnerProps> = ({
 	text = 'Loading...',
 }) => {

--- a/packages/icons/src/index.mdx
+++ b/packages/icons/src/index.mdx
@@ -119,34 +119,10 @@ import { CheckboxChecked, CheckboxBlank, UnfoldMore } from '@tpr/icons';
 	<Cross />
 </Playground>
 
-## LoadingSpinnerCircle
-
-<Playground>
-	<LoadingSpinnerCircle />
-</Playground>
-
-## LoadingSpinnerCircle icon only
-
-<Playground>
-	<LoadingSpinnerCircle iconOnly={true} />
-</Playground>
-
-## LoadingSpinnerCircle with custom text
-
-<Playground>
-	<LoadingSpinnerCircle text="Please wait while the app is loading ..." />
-</Playground>
-
 ## LoadingSpinnerProgress
 
 <Playground>
 	<LoadingSpinnerProgress />
-</Playground>
-
-## LoadingSpinnerProgress icon only
-
-<Playground>
-	<LoadingSpinnerProgress iconOnly={true} />
 </Playground>
 
 ## LoadingSpinnerProgress with custom text

--- a/packages/layout/src/components/cards/cards.module.scss
+++ b/packages/layout/src/components/cards/cards.module.scss
@@ -5,21 +5,21 @@
 	position: relative;
 	display: flex;
 	flex-direction: column;
-	border: 1px solid $colors-neutral-4;
-	box-shadow: 0 2px 3px rgba(0, 0, 0, 0.2);
+	border: 0.0625rem solid $colors-neutral-4;
+	box-shadow: 0 0.125rem 0.1875rem rgba(0, 0, 0, 0.2);
 	margin-bottom: $space-6;
 
 	.cardToolbar {
 		display: flex;
 		flex-direction: row;
 		flex: 0 0 auto;
-		min-height: 100px;
-		padding: 40px 40px 20px 40px;
-		border-left: 5px solid;
+		min-height: 6.25rem;
+		padding: $space-4;
+		border-left: 0.3125rem solid;
 		border-color: $colors-danger-2;
 
 		.divider {
-			width: 1px;
+			width: 0.0625rem;
 			background-color: $colors-neutral-6;
 			height: 50%;
 			margin: 0 $space-4;
@@ -55,9 +55,9 @@
 	.content {
 		display: flex;
 		flex-direction: column;
-		border-left: 5px solid;
+		border-left: 0.3125rem solid;
 		border-color: $colors-danger-2;
-		padding: 0 40px 20px 40px;
+		padding: 0 $space-4 $space-4 $space-4;
 
 		.emailPhonePreviewLabel {
 			@include styled-as-h4;
@@ -96,5 +96,17 @@
 
 	.complete {
 		border-left-color: $colors-success-1;
+	}
+}
+
+@media (min-width: 40em) {
+	.card {
+		.cardToolbar {
+			padding: $space-8 $space-8 $space-4 $space-8;
+		}
+
+		.content {
+			padding: 0 $space-8 $space-4 $space-8;
+		}
 	}
 }

--- a/packages/layout/src/components/cards/common/views/remove/date/date.module.scss
+++ b/packages/layout/src/components/cards/common/views/remove/date/date.module.scss
@@ -2,7 +2,7 @@
 // typography.module.scss includes '@tpr/theming/lib/variables.scss'
 
 .dateWrapper {
-	margin-left: 55px;
+	margin-left: 3.4375rem;
 }
 
 .errorMsg {

--- a/packages/layout/src/components/cards/common/views/remove/reason/reason.module.scss
+++ b/packages/layout/src/components/cards/common/views/remove/reason/reason.module.scss
@@ -6,6 +6,6 @@
 }
 
 .dateWrapper {
-	margin-left: 50px;
-	margin-bottom: 20px;
+	margin-left: 3.4375rem;
+	margin-bottom: 1.25rem;
 }

--- a/packages/layout/src/components/cards/components/button.module.scss
+++ b/packages/layout/src/components/cards/components/button.module.scss
@@ -5,16 +5,16 @@
 	background: transparent;
 	box-shadow: none;
 	border: none;
-	border-bottom: 1px solid;
-	padding: 0 0 4px 0;
+	border-bottom: 0.0625rem solid;
+	padding: 0 0 0.25rem 0;
 	width: 100%;
 	min-height: $space-5;
 }
 
 @mixin button-focus {
 	background-color: $colors-warning-1;
-	box-shadow: 0px -2px $colors-warning-1, 0px 4px $colors-neutral-8;
-	border: none;
+	box-shadow: 0 -0.125rem $colors-warning-1, 0 0.25rem $colors-neutral-8;
+	border-color: transparent;
 	outline: none;
 	color: $colors-neutral-8;
 }
@@ -28,6 +28,11 @@
 	p {
 		color: $colors-primary-3;
 		@include removeMarginBottom;
+	}
+
+	svg {
+		min-width: 1.5rem;
+		min-height: 1.5rem;
 	}
 
 	&:focus {
@@ -46,7 +51,7 @@
 
 .button:disabled {
 	color: $colors-neutral-6;
-	border-bottom: 2px solid $colors-neutral-6;
+	border-bottom: 0.125rem solid $colors-neutral-6;
 	cursor: not-allowed;
 }
 

--- a/packages/layout/src/components/cards/components/card.module.scss
+++ b/packages/layout/src/components/cards/components/card.module.scss
@@ -1,7 +1,7 @@
 @import '../cards.module.scss';
 
 .toolbarBottomBorder {
-	border-bottom: 1px solid $colors-neutral-6;
+	border-bottom: 0.625rem solid $colors-neutral-6;
 
 	.sectionTitle {
 		color: $colors-neutral-6;

--- a/packages/layout/src/components/cards/components/content.module.scss
+++ b/packages/layout/src/components/cards/components/content.module.scss
@@ -4,8 +4,8 @@
 	position: relative;
 	display: flex;
 	flex-direction: column;
-	padding: 0 40px 20px 40px;
-	border-left: 5px solid white;
+	padding: 0 $space-4 $space-4 $space-4;
+	border-left: 0.3125rem solid white;
 }
 
 .loading {
@@ -21,4 +21,10 @@
 	width: 100%;
 	height: 100%;
 	background: transparent;
+}
+
+@media (min-width: 40em) {
+	.content {
+		padding: 0 $space-8 $space-4 $space-8;
+	}
 }

--- a/packages/layout/src/components/footer/footer.module.scss
+++ b/packages/layout/src/components/footer/footer.module.scss
@@ -2,11 +2,41 @@
 
 .wrapper {
 	background-color: $colors-neutral-3;
-	border-top: 5px solid $colors-neutral-a2;
+	border-top: 0.3125rem solid $colors-neutral-a2;
+}
+
+.logo {
+	width: 11.25rem;
+	height: 4.6875rem;
+	box-sizing: content-box;
+	padding: $space-6;
 }
 
 .footerText {
-	align-items: center;
-	height: 50px;
-	border-top: 2px solid $colors-neutral-4;
+	flex-direction: column;
+	justify-content: space-between;
+	margin-top: $space-3;
+	padding: $space-2 $space-6;
+	border-top: 0.125rem solid $colors-neutral-4;
+}
+
+.footerLinks {
+	flex-direction: column;
+}
+
+.footerLinks > a {
+	margin: 0 0.25rem;
+}
+
+@media (min-width: 40em) {
+	.footerText {
+		flex-direction: row;
+		align-items: center;
+	}
+}
+
+@media (min-width: 27em) {
+	.footerLinks {
+		flex-direction: row;
+	}
 }

--- a/packages/layout/src/components/footer/footer.tsx
+++ b/packages/layout/src/components/footer/footer.tsx
@@ -26,30 +26,27 @@ export const Footer: React.FC<FooterProps> = ({
 	return (
 		<DocWidth className={styles.wrapper}>
 			<AppWidth>
-				<Flex cfg={{ flexDirection: 'column' }}>
-					<Flex
-						cfg={{ justifyContent: 'flex-start', p: 6, alignItems: 'center' }}
-					>
-						<img src={logoUrl} alt={logoAlt} width="180" height="75" />
+				<img
+					src={logoUrl}
+					alt={logoAlt}
+					width="180"
+					height="75"
+					className={styles.logo}
+				/>
+				<Flex className={styles.footerText}>
+					<Flex className={styles.footerLinks}>
+						{links.map(({ url, title, ...linkProps }, key: number) => (
+							<Link
+								key={key}
+								href={url}
+								cfg={{ mr: 3, color: 'neutral.a2' }}
+								{...linkProps}
+							>
+								{title}
+							</Link>
+						))}
 					</Flex>
-					<Flex
-						cfg={{ justifyContent: 'space-between', mt: 3, px: 6 }}
-						className={styles.footerText}
-					>
-						<Flex>
-							{links.map(({ url, title, ...linkProps }, key: number) => (
-								<Link
-									key={key}
-									href={url}
-									cfg={{ mr: 3, color: 'neutral.a2' }}
-									{...linkProps}
-								>
-									{title}
-								</Link>
-							))}
-						</Flex>
-						<P cfg={{ fontSize: 1, color: 'neutral.a2', my: 1 }}>{copyright}</P>
-					</Flex>
+					<P cfg={{ fontSize: 1, color: 'neutral.a2', my: 1 }}>{copyright}</P>
 				</Flex>
 			</AppWidth>
 		</DocWidth>

--- a/packages/layout/src/components/header/header.module.scss
+++ b/packages/layout/src/components/header/header.module.scss
@@ -21,6 +21,11 @@ $horizontal-space-outer: $space-6;
 	flex: 0 0 auto;
 }
 
+.logo > img {
+	width: 11.25rem;
+	height: 4.6825rem;
+}
+
 .title {
 	display: none;
 }
@@ -46,7 +51,7 @@ $horizontal-space-outer: $space-6;
 	}
 	.logo {
 		padding: 0 $horizontal-space-outer;
-		border-right: 1px solid $colors-accents-1;
+		border-right: 0.0625rem solid $colors-accents-1;
 	}
 	.title {
 		display: flex;
@@ -81,6 +86,8 @@ $horizontal-space-outer: $space-6;
 
 @media (min-width: 60em) {
 	.logo {
-		width: $sidebar-width;
+		// the width of a sidebar at the default base font size, but not in rems so that it doesn't grow and take up
+		// extra space when the base font size is increased.
+		min-width: 285px;
 	}
 }

--- a/packages/layout/src/components/helplink/helplink.module.scss
+++ b/packages/layout/src/components/helplink/helplink.module.scss
@@ -28,13 +28,15 @@
 	background: $colors-warning-1;
 	outline: none;
 	text-decoration: none;
-	box-shadow: 0px -2px $colors-warning-1, 0px 4px $colors-neutral-8;
+	box-shadow: 0 -0.125rem $colors-warning-1, 0 0.25rem $colors-neutral-8;
 }
 
 .helpLink [aria-expanded] svg {
+	width: 1.5rem;
+	height: 1.5rem;
 	fill: $colors-primary-3;
 	position: relative;
-	top: 6px;
+	top: 0.375rem;
 }
 
 .helpLink [aria-expanded='true'] svg {

--- a/packages/layout/src/components/highlight/highlight.module.scss
+++ b/packages/layout/src/components/highlight/highlight.module.scss
@@ -10,7 +10,7 @@ $horizontal-space-outer: $space-6;
 
 // Stack everything by default.
 .highlightContent {
-	min-height: 50px;
+	min-height: 3.125rem;
 	color: $white;
 	font-weight: $font-weight-4;
 	font-size: $font-size-3;
@@ -25,7 +25,7 @@ $horizontal-space-outer: $space-6;
 	align-items: center;
 	flex: 0 0 auto;
 	padding: $vertical-space $horizontal-space-inner;
-	border-top: 1px solid $colors-accents-1;
+	border-top: 0.0625rem solid $colors-accents-1;
 }
 
 // Allow more space for .name as the viewport width grows.
@@ -44,7 +44,7 @@ $horizontal-space-outer: $space-6;
 }
 
 .reference > div {
-	border-top: 1px solid rgba(202, 202, 202, 0.5);
+	border-top: 0.0625rem solid rgba(202, 202, 202, 0.5);
 	padding: $vertical-space $horizontal-space-inner;
 	align-items: center;
 	width: 100%;
@@ -65,7 +65,7 @@ $horizontal-space-outer: $space-6;
 		top: 0;
 		width: 50%;
 		height: 100%;
-		border-top: 1px solid $colors-accents-1;
+		border-top: 0.0625rem solid $colors-accents-1;
 		box-sizing: border-box;
 		background-color: $colors-accents-2;
 		z-index: 0;
@@ -86,7 +86,7 @@ $horizontal-space-outer: $space-6;
 	.context {
 		padding: $vertical-space $horizontal-space-inner $vertical-space
 			$horizontal-space-outer;
-		width: 180px + ($horizontal-space-outer * 2); // 180px is image width in Header
+		width: 11.25rem + ($horizontal-space-outer * 2); // 11.25rem is image width in Header
 		border: none;
 	}
 	.name {
@@ -98,7 +98,7 @@ $horizontal-space-outer: $space-6;
 	// At this width make .context bigger to match the width to the logo in the Header component,
 	// and unstack .name and .reference to be side-by-side.
 	.context {
-		width: $sidebar-width;
+		width: 17.8rem;
 	}
 	.container,
 	.name,
@@ -107,7 +107,7 @@ $horizontal-space-outer: $space-6;
 	}
 	.reference > div {
 		border-top: none;
-		border-left: 1px solid rgba(202, 202, 202, 0.5);
+		border-left: 0.0625rem solid rgba(202, 202, 202, 0.5);
 		margin: $vertical-space 0;
 		padding: $vertical-space $horizontal-space-outer $vertical-space
 			$horizontal-space-inner;

--- a/packages/layout/src/components/hint/hint.module.scss
+++ b/packages/layout/src/components/hint/hint.module.scss
@@ -1,7 +1,7 @@
 @import '@tpr/theming/lib/variables.scss';
 
 .root {
-	border-left: 4px solid $colors-neutral-4;
+	border-left: 0.25rem solid $colors-neutral-4;
 	color: $colors-neutral-7;
 	line-height: $line-height-3;
 	margin-bottom: $space-4;

--- a/packages/layout/src/components/info/info.module.scss
+++ b/packages/layout/src/components/info/info.module.scss
@@ -4,26 +4,26 @@
 	position: relative;
 	display: flex;
 	flex-direction: column;
-	padding: 30px;
+	padding: $space-6;
 	background: $colors-neutral-3;
 	color: $colors-neutral-7;
 }
 
 .important {
-	margin-top: 40px;
-	border-top: 6px solid $colors-neutral-8;
+	margin-top: $space-8;
+	border-top: 0.375rem solid $colors-neutral-8;
 }
 
 .importantMessage {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	font-size: 18px;
+	font-size: $font-size-3;
 	position: absolute;
 	left: 0;
-	height: 46px;
-	top: -48px;
-	padding: 0 30px;
+	height: 2.875rem;
+	top: -3rem;
+	padding: 0 $space-6;
 	background: $colors-neutral-8;
 	color: $white;
 	font-weight: normal;

--- a/packages/layout/src/components/navitem/index.ts
+++ b/packages/layout/src/components/navitem/index.ts
@@ -1,2 +1,2 @@
 export * from './types';
-export * from './NavItem';
+export * from './navitem';

--- a/packages/layout/src/components/poscon/poscon.module.scss
+++ b/packages/layout/src/components/poscon/poscon.module.scss
@@ -1,5 +1,5 @@
 .enableClose {
-	margin-right: 15px;
+	margin-right: 0.9375rem;
 	margin-left: auto;
 	align-self: flex-start;
 }

--- a/packages/layout/src/components/sidebar/sidebar.module.scss
+++ b/packages/layout/src/components/sidebar/sidebar.module.scss
@@ -25,7 +25,8 @@
 		> div {
 			height: 100%;
 			> svg {
-				min-width: 22px;
+				min-width: 1.375rem;
+				min-height: 1.375rem;
 			}
 		}
 	}
@@ -41,14 +42,14 @@
 			a::before {
 				content: ' ';
 				position: absolute;
-				left: -25px;
-				top: -8px;
+				left: -1.5625rem;
+				top: -0.5rem;
 				height: 100%;
-				min-height: 40px;
-				width: 5px;
+				min-height: 2.5rem;
+				width: 0.3125rem;
 				background: $colors-primary-3;
 				// to hide outline from pseudo element
-				box-shadow: 0px 0px 0px 1px white;
+				box-shadow: 0 0 0 0.3125rem white;
 			}
 		}
 	}
@@ -89,7 +90,7 @@
 			&::before {
 				content: '—';
 				color: $colors-neutral-8;
-				padding-right: 2px;
+				padding-right: 0.125rem;
 			}
 		}
 	}
@@ -107,7 +108,7 @@
 }
 
 .sidebarMenu {
-	border-bottom: 5px solid $colors-neutral-4;
+	border-bottom: 0.3125rem solid $colors-neutral-4;
 }
 
 .sidebarMenu:last-child {

--- a/packages/layout/src/components/tasklist/tasklist.module.scss
+++ b/packages/layout/src/components/tasklist/tasklist.module.scss
@@ -24,14 +24,10 @@
 
 		> div {
 			height: 100%;
-			> svg {
-				min-width: 22px;
-			}
 		}
 
 		&.reviewLink {
 			text-decoration: underline;
-			font-size: 16px;
 			line-height: 1.565em;
 			text-align: left;
 			color: $colors-primary-3;
@@ -43,7 +39,7 @@
 		font-size: $font-size-2;
 		font-weight: bold;
 		text-transform: uppercase;
-		padding: 8px;
+		padding: 0.5rem;
 
 		&.complete {
 			background-color: $colors-primary-3;
@@ -69,7 +65,7 @@
 	}
 
 	.taskName {
-		padding: 7px 0;
+		padding: 0.4375rem 0;
 	}
 
 	div.taskWrapper {

--- a/packages/layout/src/components/warning/warning.module.scss
+++ b/packages/layout/src/components/warning/warning.module.scss
@@ -1,12 +1,12 @@
 @import '@tpr/theming/lib/variables.scss';
 
 .warning {
-	border: 4px solid $colors-danger-2;
+	border: 0.25rem solid $colors-danger-2;
 	font-weight: $font-weight-3;
 
 	svg {
-		min-width: 35px;
-		min-height: 35px;
-   	margin-top: 2px;
+		min-width: 1.5625rem;
+		min-height: 1.5625rem;
+		margin-top: 0.125rem;
 	}
 }

--- a/packages/theming/src/richTextEditor.module.scss
+++ b/packages/theming/src/richTextEditor.module.scss
@@ -26,7 +26,7 @@
 		color: $colors-neutral-8;
 		font-weight: $font-weight-2;
 		font-size: $font-size-2;
-		letter-spacing: 0px;
+		letter-spacing: 0;
 		line-height: $line-height-3;
 		margin-bottom: 1rem;
 	}
@@ -69,7 +69,7 @@
 
 		&:focus {
 			background-color: $colors-warning-1;
-			box-shadow: 0 -2px $colors-warning-1, 0 4px $colors-neutral-8;
+			box-shadow: 0 -0.125rem $colors-warning-1, 0 0.25rem $colors-neutral-8;
 			color: $colors-neutral-8;
 			text-decoration: none;
 		}
@@ -84,7 +84,7 @@
 		color: $colors-neutral-8;
 		font-weight: $font-weight-2;
 		font-size: $font-size-2;
-		letter-spacing: 0px;
+		letter-spacing: 0;
 		line-height: $line-height-3;
 		margin-bottom: 1rem;
 	}
@@ -100,7 +100,7 @@
 	th {
 		padding: $space-2;
 		text-align: left;
-		border: 1px solid $colors-neutral-6;
+		border: 0.0625rem solid $colors-neutral-6;
 	}
 	caption {
 		border-bottom: none;

--- a/packages/theming/src/variables.scss
+++ b/packages/theming/src/variables.scss
@@ -1,6 +1,6 @@
 /**** SCREEN SETTINGS ****/
-$app-width: 1170px;
-$sidebar-width: 285px;
+$app-width: 73rem;
+$sidebar-width: 18rem;
 /**** COLORS ****/
 $white: #ffffff;
 $black: #000000;
@@ -36,7 +36,7 @@ $colors-danger-2: #a91717;
 $colors-danger-3: #cd2e25;
 /* colors confirmation */
 $colors-confirmed: #1e7e34;
-$colors-unconfirmed: #a91717 ;
+$colors-unconfirmed: #a91717;
 
 /**** FONTS ****/
 $fonts-sans-serif: 'Open Sans', sans-serif;
@@ -48,29 +48,24 @@ $line-height-4: 1.511em;
 $line-height-5: 1.555em;
 $line-height-6: 1.565em;
 /**** SPACE ****/
-$space-1: 5px;
-$space-2: 10px;
-$space-3: 15px;
-$space-4: 20px;
-$space-5: 25px;
-$space-6: 30px;
-$space-7: 35px;
-$space-8: 40px;
-$space-9: 45px;
-$space-10: 50px;
+$space-1: 0.3125rem;
+$space-2: 0.625rem;
+$space-3: 0.9375rem;
+$space-4: 1.25rem;
+$space-5: 1.5625rem;
+$space-6: 1.875rem;
+$space-7: 2.1875rem;
+$space-8: 2.5rem;
+$space-9: 2.8125rem;
+$space-10: 3.125rem;
 /**** FONT SIZES ****/
-$font-size-1: 14px;
-$font-size-2: 16px;
-$font-size-3: 18px;
-$font-size-4: 23px;
-$font-size-5: 36px;
-$font-size-6: 45px;
+$font-size-1: 0.875rem;
+$font-size-2: 1rem;
+$font-size-3: 1.125rem;
+$font-size-4: 1.4375rem;
+$font-size-5: 2.25rem;
+$font-size-6: 2.8125rem;
 /**** FONT WEIGHTS ****/
 $font-weight-2: 400;
 $font-weight-3: 600;
 $font-weight-4: 700;
-/**** BREAKPOINTS ****/
-$breakpoint-1: 48em;
-$breakpoint-2: 64em;
-$breakpoint-3: 90em;
-$breakpoint-4: 114em;

--- a/packages/theming/styles.css
+++ b/packages/theming/styles.css
@@ -37,31 +37,30 @@
 /**** SPACE ****/
 /**** FONT SIZES ****/
 /**** FONT WEIGHTS ****/
-/**** BREAKPOINTS ****/
 .richTextEditor_editorFontStack__3RH-q {
 	font-family: 'Open Sans', sans-serif;
-	font-size: 16px;
+	font-size: 1rem;
 }
 .richTextEditor_editorFontStack__3RH-q h1 {
-	font-size: 45px;
+	font-size: 2.8125rem;
 }
 .richTextEditor_editorFontStack__3RH-q h2 {
-	font-size: 36px;
+	font-size: 2.25rem;
 }
 .richTextEditor_editorFontStack__3RH-q h3 {
-	font-size: 23px;
+	font-size: 1.4375rem;
 }
 .richTextEditor_editorFontStack__3RH-q h4 {
-	font-size: 18px;
+	font-size: 1.125rem;
 }
 .richTextEditor_editorFontStack__3RH-q h5 {
-	font-size: 16px;
+	font-size: 1rem;
 }
 .richTextEditor_editorFontStack__3RH-q h6 {
-	font-size: 14px;
+	font-size: 0.875rem;
 }
 .richTextEditor_editorFontStack__3RH-q p {
-	font-size: 16px;
+	font-size: 1rem;
 }
 .richTextEditor_editorFontStack__3RH-q b {
 	font-weight: 600;
@@ -70,7 +69,7 @@
 	font-weight: 600;
 }
 .richTextEditor_editorFontStack__3RH-q span {
-	font-size: 16px;
+	font-size: 1rem;
 }
 .richTextEditor_editorFontStack__3RH-q i {
 	font-style: italic;


### PR DESCRIPTION
Browsers default to a base font size of 16px, but users (particularly vision impaired users) can change this. Our app was not respecting this setting at all, and stayed at the same fixed size. Update the base unit for fonts and spacing from `px` to `rem` to fix this. rem values are all calculated as "existing pixel value / 16", so that everything looks the same at the default base font size, but the entire application now scales proportionately if the base font size is changed. Fixes the react-components part of [AB#109587](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/109587).

Along the way, also:
- delete the obsolete spinner which was rejected for accessibility
- make the footer responsive [AB#110263](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/110263)