### PR TITLE
Task/110648 Update Independent Trustee card

### DIFF
--- a/packages/layout/src/components/__tests__/independentTrustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/independentTrustee.spec.tsx
@@ -23,6 +23,7 @@ const independentTrustee: IndependentTrustee = {
 	organisationName: 'Pensions Are Us Limited',
 	appointedByRegulator: true,
 	address: sampleAddress,
+	companiesHouseNumber: '1234567890',
 };
 
 describe('Professional / Independent Trustee Card', () => {

--- a/packages/layout/src/components/__tests__/independentTrustee.spec.tsx
+++ b/packages/layout/src/components/__tests__/independentTrustee.spec.tsx
@@ -73,13 +73,13 @@ describe('Professional / Independent Trustee Card', () => {
 			assertMainHeadingExists(
 				findByText,
 				findByTestId,
-				'Corporate Trustee',
+				independentTrustee.organisationName,
 				false,
 			);
 
 			assertRemoveButtonExists(findByText, findByTestId);
 
-			const h4Headings = ['Address'];
+			const h4Headings = ['Address', 'Companies House Number'];
 			assertHeadingsExist(findAllByTestId, h4Headings);
 
 			const h4Buttons: string[] = ['Appointed by the regulator'];

--- a/packages/layout/src/components/cards/common/views/preview/components/companiesHouseNumber/companiesHouseNumber.tsx
+++ b/packages/layout/src/components/cards/common/views/preview/components/companiesHouseNumber/companiesHouseNumber.tsx
@@ -12,7 +12,7 @@ export const CompaniesHouseNumber: React.FC<ICompaniesHouseNumberProps> = React.
 		return (
 			<Flex cfg={{ flexDirection: 'column', mt: 5 }}>
 				<UnderlinedButton>{heading}</UnderlinedButton>
-				<P>{houseNumber}</P>
+				<P cfg={{ mt: 2 }}>{houseNumber}</P>
 			</Flex>
 		);
 	},

--- a/packages/layout/src/components/cards/corporateGroup/corporateGroupMachine.ts
+++ b/packages/layout/src/components/cards/corporateGroup/corporateGroupMachine.ts
@@ -69,11 +69,11 @@ const corporateGroupMachine = Machine<
 				},
 				EDIT_NAME: {
 					target: 'edit.name',
-					actions: updateClickedButton(4),
+					actions: updateClickedButton(5),
 				},
 				EDIT_PROFESSIONAL: {
 					target: 'edit.professional',
-					actions: updateClickedButton(5),
+					actions: updateClickedButton(6),
 				},
 				COMPLETE: {
 					actions: assign((_, event) => ({

--- a/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
@@ -55,7 +55,7 @@ export const Preview: React.FC<any> = React.memo(() => {
 						isOpen={current.matches({ edit: 'contacts' })}
 						isEditButton={true}
 						buttonRef={chairBtn}
-						giveFocus={current.context.lastBtnClicked === 4}
+						giveFocus={current.context.lastBtnClicked === 5}
 					>
 						{i18n.preview.buttons.five}
 					</UnderlinedButton>
@@ -76,7 +76,7 @@ export const Preview: React.FC<any> = React.memo(() => {
 							isOpen={current.matches({ edit: 'professional' })}
 							isEditButton={true}
 							buttonRef={directorBtn}
-							giveFocus={current.context.lastBtnClicked === 5}
+							giveFocus={current.context.lastBtnClicked === 6}
 						>
 							{i18n.preview.buttons.six}
 						</UnderlinedButton>

--- a/packages/layout/src/components/cards/independentTrustee/i18n.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/i18n.tsx
@@ -7,6 +7,7 @@ export type IndependentTrusteeI18nProps = {
 			two: string;
 			three: string;
 			four: string;
+			five: string;
 		};
 		statusText: {
 			confirmed: string;
@@ -54,7 +55,8 @@ export const i18n: IndependentTrusteeI18nProps = {
 			one: 'Corporate Trustee',
 			two: 'Remove',
 			three: 'Address',
-			four: 'Appointed by the regulator',
+			four: 'Companies House Number',
+			five: 'Appointed by the regulator',
 		},
 		statusText: {
 			confirmed: 'Confirmed',

--- a/packages/layout/src/components/cards/independentTrustee/independentTrustee.mdx
+++ b/packages/layout/src/components/cards/independentTrustee/independentTrustee.mdx
@@ -45,6 +45,7 @@ import { IndependentTrusteeCard } from '@tpr/layout';
 				postcode: 'BN1 4DW',
 				country: '',
 			},
+			companiesHouseNumber: '001234567',
 		};
 		return (
 			<IndependentTrusteeCard

--- a/packages/layout/src/components/cards/independentTrustee/independentTrustee.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/independentTrustee.tsx
@@ -73,15 +73,14 @@ export const IndependentTrusteeCard: React.FC<IndependentTrusteeProviderProps> =
 						>
 							<Toolbar
 								buttonLeft={() => (
-									<CardMainHeadingTitle title={i18n.preview.buttons.one} />
+									<CardMainHeadingTitle
+										title={current.context.independentTrustee.organisationName}
+									/>
 								)}
 								buttonRight={RemoveButton}
 								complete={isComplete(current.context)}
 								subtitle={() => (
-									<Subtitle
-										main={current.context.independentTrustee.organisationName}
-										secondary={i18n.preview.trusteeType}
-									/>
+									<Subtitle secondary={i18n.preview.trusteeType} />
 								)}
 								statusText={
 									isComplete(current.context)

--- a/packages/layout/src/components/cards/independentTrustee/independentTrusteeMachine.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/independentTrusteeMachine.tsx
@@ -65,7 +65,7 @@ const independentTrusteeMachine = Machine<
 				},
 				EDIT_REGULATOR: {
 					target: 'edit.regulator',
-					actions: updateClickedButton(4),
+					actions: updateClickedButton(5),
 				},
 				COMPLETE: {
 					actions: assign((_, event) => ({

--- a/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
@@ -3,7 +3,10 @@ import { Checkbox } from '@tpr/forms';
 import { Flex, Hr, classNames, P } from '@tpr/core';
 import { UnderlinedButton } from '../../../components/button';
 import { useIndependentTrusteeContext } from '../../context';
-import { AddressPreview } from '../../../common/views/preview/components';
+import {
+	AddressPreview,
+	CompaniesHouseNumber,
+} from '../../../common/views/preview/components';
 import styles from '../../../cards.module.scss';
 
 export const Preview: React.FC<any> = React.memo(() => {
@@ -35,6 +38,12 @@ export const Preview: React.FC<any> = React.memo(() => {
 							country: independentTrustee.address.country,
 						}}
 					/>
+
+					{/* Companies House Number: display only	 */}
+					<CompaniesHouseNumber
+						heading={i18n.preview.buttons.four}
+						houseNumber={independentTrustee.companiesHouseNumber}
+					/>
 				</Flex>
 
 				{/* Appointed By Regulator section: open for editing	 */}
@@ -44,9 +53,9 @@ export const Preview: React.FC<any> = React.memo(() => {
 						isOpen={current.matches({ edit: 'regulator' })}
 						isEditButton={true}
 						buttonRef={regulatorBtn}
-						giveFocus={current.context.lastBtnClicked === 4}
+						giveFocus={current.context.lastBtnClicked === 5}
 					>
-						{i18n.preview.buttons.four}
+						{i18n.preview.buttons.five}
 					</UnderlinedButton>
 					<P className={styles.appointedByRegulator}>
 						{independentTrustee.appointedByRegulator

--- a/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
@@ -42,7 +42,7 @@ export const Preview: React.FC<any> = React.memo(() => {
 					{/* Companies House Number: display only	 */}
 					<CompaniesHouseNumber
 						heading={i18n.preview.buttons.four}
-						houseNumber={independentTrustee.companiesHouseNumber}
+						companiesHouseNumber={independentTrustee.companiesHouseNumber}
 					/>
 				</Flex>
 


### PR DESCRIPTION
#### Fixes [AB#110648](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/110648)

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable Azure Pipelines for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Company name becomes main heading
- "Companies House Number" section added

- update button clicked for IndependentTrustee & CorporateGroup card