### PR TITLE
Task/110654 update common prop and styles for CompaniesHouseNumber & UnderlinedButton

### DIFF
--- a/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
+++ b/packages/layout/src/components/__tests__/corporateGroup.spec.tsx
@@ -28,6 +28,7 @@ const corporateGroup: CorporateGroup = {
 	telephoneNumber: '01273 000 111',
 	emailAddress: 'susan@corporate-group.com',
 	address: sampleAddress,
+	companiesHouseNumber: '0987654321',
 };
 
 describe('Corporate Group Trustee Card', () => {

--- a/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
@@ -42,12 +42,10 @@ export const Preview: React.FC<any> = React.memo(() => {
 					/>
 
 					{/* Companies House Number: display only	 */}
-					{actuary.companiesHouseNumber && (
-						<CompaniesHouseNumber
-							heading={i18n.preview.buttons.four}
-							houseNumber={actuary.companiesHouseNumber}
-						/>
-					)}
+					<CompaniesHouseNumber
+						heading={i18n.preview.buttons.four}
+						companiesHouseNumber={actuary.companiesHouseNumber}
+					/>
 				</Flex>
 
 				{/* Contact details section: open for editing	 */}

--- a/packages/layout/src/components/cards/cards.module.scss
+++ b/packages/layout/src/components/cards/cards.module.scss
@@ -72,7 +72,6 @@
 		}
 
 		.identifierItem {
-			margin-top: $space-2;
 			flex-direction: column;
 
 			.title {
@@ -89,7 +88,6 @@
 		.isProfessional,
 		.appointedByRegulator,
 		.insurerCompanyRef {
-			margin-top: $space-2;
 			@include removeMarginBottom;
 		}
 	}

--- a/packages/layout/src/components/cards/common/views/preview/components/addressPreview/addressPreview.tsx
+++ b/packages/layout/src/components/cards/common/views/preview/components/addressPreview/addressPreview.tsx
@@ -13,7 +13,7 @@ export const AddressPreview: React.FC<AddressPreviewProps> = ({
 	address,
 }) => {
 	return (
-		<Flex cfg={{ my: 2, flexDirection: 'column' }}>
+		<Flex cfg={{ flexDirection: 'column' }}>
 			{name && <P className={styles.name}>{name}</P>}
 
 			<P className={styles.address} data-testid="address-preview">

--- a/packages/layout/src/components/cards/common/views/preview/components/companiesHouseNumber/companiesHouseNumber.tsx
+++ b/packages/layout/src/components/cards/common/views/preview/components/companiesHouseNumber/companiesHouseNumber.tsx
@@ -4,16 +4,20 @@ import { UnderlinedButton } from '../../../../../components/button';
 
 interface ICompaniesHouseNumberProps {
 	heading: string;
-	houseNumber: number | string;
+	companiesHouseNumber: number | string;
 }
 
 export const CompaniesHouseNumber: React.FC<ICompaniesHouseNumberProps> = React.memo(
-	({ heading, houseNumber }) => {
+	({ heading, companiesHouseNumber }) => {
 		return (
-			<Flex cfg={{ flexDirection: 'column', mt: 5 }}>
-				<UnderlinedButton>{heading}</UnderlinedButton>
-				<P>{houseNumber}</P>
-			</Flex>
+			<>
+				{companiesHouseNumber && (
+					<Flex cfg={{ flexDirection: 'column', mt: 6 }}>
+						<UnderlinedButton>{heading}</UnderlinedButton>
+						<P>{companiesHouseNumber}</P>
+					</Flex>
+				)}
+			</>
 		);
 	},
 );

--- a/packages/layout/src/components/cards/common/views/preview/components/contactDetailsPreview/contactDetailsPreview.tsx
+++ b/packages/layout/src/components/cards/common/views/preview/components/contactDetailsPreview/contactDetailsPreview.tsx
@@ -16,7 +16,7 @@ interface ContactDetailsPreviewProps {
 export const ContactDetailsPreview: React.FC<ContactDetailsPreviewProps> = React.memo(
 	(props: ContactDetailsPreviewProps) => {
 		return (
-			<Flex cfg={{ my: 2, flexDirection: 'column' }}>
+			<Flex cfg={{ flexDirection: 'column' }}>
 				{props.name && <P cfg={{ mb: 2 }}>{props.name}</P>}
 				{props.phone && (
 					<>

--- a/packages/layout/src/components/cards/components/button.module.scss
+++ b/packages/layout/src/components/cards/components/button.module.scss
@@ -60,6 +60,7 @@
 	cursor: default;
 	color: $colors-neutral-7;
 	border-bottom-color: $colors-neutral-7;
+	margin-bottom: $space-2;
 
 	p {
 		@include removeMarginBottom;
@@ -80,12 +81,17 @@
 .heading3 {
 	font-size: $font-size-3;
 	font-weight: $font-weight-3;
+	margin-bottom: $space-1;
 }
 
 .heading4 {
 	font-size: $font-size-2;
 	font-weight: $font-weight-3;
 	width: 100%;
+
+	&.headingButton {
+		margin-bottom: $space-2;
+	}
 }
 
 :export {

--- a/packages/layout/src/components/cards/components/button.tsx
+++ b/packages/layout/src/components/cards/components/button.tsx
@@ -109,7 +109,10 @@ export const UnderlinedButton: React.FC<UnderlinedButtonProps> = React.memo(
 		);
 
 		const HeadingButton: React.FC = () => (
-			<H4 className={styles.heading4} data-testid="card-heading-button">
+			<H4
+				className={`${styles.heading4} ${isOpen ? '' : styles.headingButton}`}
+				data-testid="card-heading-button"
+			>
 				<ClickableButton />
 			</H4>
 		);

--- a/packages/layout/src/components/cards/components/toolbar.tsx
+++ b/packages/layout/src/components/cards/components/toolbar.tsx
@@ -42,7 +42,7 @@ export const Toolbar: React.FC<ToolbarProps> = React.memo(
 				>
 					{buttonLeft()}
 					{subtitle && (
-						<Flex cfg={{ mt: 1, flexDirection: 'column' }}>{subtitle()}</Flex>
+						<Flex cfg={{ flexDirection: 'column' }}>{subtitle()}</Flex>
 					)}
 				</Flex>
 				<Flex

--- a/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
@@ -44,7 +44,7 @@ export const Preview: React.FC<any> = React.memo(() => {
 					{/* Companies House Number: display only	 */}
 					<CompaniesHouseNumber
 						heading={i18n.preview.buttons.four}
-						houseNumber={corporateGroup.companiesHouseNumber}
+						companiesHouseNumber={corporateGroup.companiesHouseNumber}
 					/>
 				</Flex>
 


### PR DESCRIPTION
#### Fixes [AB#110654](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/110654)

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable Azure Pipelines for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- `UnderlinedButton` adds conditional `margin-bottom`, allowing to remove `margin-top` from other components.
- `houseNumber` prop renamed to `companiesHouseNumber` in `<CompaniesHouseNumber>` component.
- `<CompaniesHouseNumber>` will handle the render when `companiesHouseNumber` exists, allowing us to save writing a condition everywhere is used. 