### PR TITLE
Cards -  i18n refactor and update

### DIFF
--- a/packages/layout/src/components/__tests__/actuary.spec.tsx
+++ b/packages/layout/src/components/__tests__/actuary.spec.tsx
@@ -130,7 +130,7 @@ describe('Actuary Card', () => {
 		test('renders with a section containing an aria label', () => {
 			assertThatASectionExistsWithAnAriaLabel(
 				findByRole,
-				`${actuary.title} ${actuary.firstName} ${actuary.lastName} Actuary`,
+				`${actuary.title} ${actuary.firstName} ${actuary.lastName} Scheme Actuary`,
 			);
 		});
 

--- a/packages/layout/src/components/cards/actuary/actuary.tsx
+++ b/packages/layout/src/components/cards/actuary/actuary.tsx
@@ -59,7 +59,7 @@ const ToolbarButton: React.FC<IToolbarButtonProps> = React.memo(
 							edit: 'name',
 						})}
 					>
-						{i18n.preview.buttons.two}
+						{i18n.preview.buttonsAndHeadings.remove}
 					</CardRemoveButton>
 				) : (
 					<CardMainHeadingButton
@@ -100,7 +100,7 @@ export const ActuaryCard: React.FC<ActuaryProviderProps> = React.memo(
 								current.context.actuary.title,
 								current.context.actuary.firstName,
 								current.context.actuary.lastName,
-								i18n.preview.buttons.one,
+								i18n.preview.mainHeadingSubtitle.main,
 							])}
 						>
 							<Toolbar
@@ -111,7 +111,7 @@ export const ActuaryCard: React.FC<ActuaryProviderProps> = React.memo(
 								complete={isComplete(current.context)}
 								subtitle={() => (
 									<Subtitle
-										main={i18n.preview.buttons.one}
+										main={i18n.preview.mainHeadingSubtitle.main}
 										secondary={current.context.actuary.organisationName}
 									/>
 								)}

--- a/packages/layout/src/components/cards/actuary/i18n.ts
+++ b/packages/layout/src/components/cards/actuary/i18n.ts
@@ -1,105 +1,38 @@
 import {
-	InputErrorMessages,
 	defaultEmailErrorMessages,
 	defaultPhoneErrorMessages,
+	I18nNameView,
+	I18nRemoveViewDateAndConfirm,
+	I18nPreviewViewCommonProps,
+	I18nContactsView,
 } from '../common/interfaces';
-type PropertyFunction<T> = () => T;
+
+interface I18nActuaryPreviewView extends I18nPreviewViewCommonProps {
+	buttonsAndHeadings: {
+		remove: string;
+		address: string;
+		companiesHouseNumber: string;
+		contacts: string;
+	}
+}
 
 export type ActuaryI18nProps = {
-	preview: {
-		buttons: {
-			one: string;
-			two: string;
-			three: string;
-			four: string;
-			five: string;
-		};
-		statusText: {
-			confirmed: string;
-			unconfirmed: string;
-		};
-		checkboxLabel: string;
-	};
-	name: {
-		title: string;
-		sectionTitle?: string;
-		fields: {
-			title: {
-				label: string;
-				error: string | PropertyFunction<string | undefined>;
-				maxlength: number;
-			};
-			firstName: {
-				label: string;
-				error: string | PropertyFunction<string | undefined>;
-				maxlength: number;
-			};
-			lastName: {
-				label: string;
-				error: string | PropertyFunction<string | undefined>;
-				maxlength: number;
-			};
-		};
-	};
-	contacts: {
-		title: string;
-		subtitle: string;
-		sectionTitle?: string;
-		fields: {
-			telephone: {
-				label: string;
-				error: InputErrorMessages;
-			};
-			email: {
-				label: string;
-				error: InputErrorMessages;
-			};
-		};
-	};
-	remove: {
-		confirm: {
-			breadcrumbs: {
-				link1: string;
-				link2: string;
-			};
-			title: string;
-			dialog: {
-				message1: string;
-			};
-			buttons: {
-				remove: string;
-				cancel: string;
-			};
-		};
-		date: {
-			title: string;
-			fields: {
-				confirm: {
-					label: string;
-				};
-				date: {
-					label: string;
-					hint: string;
-					error: string;
-				};
-			};
-			errors: {
-				formIncomplete: string;
-				dateAddedBeforeEffectiveDate: string;
-				dateAddedInTheFuture: string;
-			};
-		};
-	};
+	preview: I18nActuaryPreviewView;
+	name: I18nNameView;
+	contacts: I18nContactsView;
+	remove: I18nRemoveViewDateAndConfirm;
 };
 
 export const i18n: ActuaryI18nProps = {
 	preview: {
-		buttons: {
-			one: 'Actuary',
-			two: 'Remove',
-			three: 'Address',
-			four: 'Companies House Number',
-			five: 'Contact details',
+		buttonsAndHeadings: {
+			remove: 'Remove',
+			address: 'Address',
+			companiesHouseNumber: 'Companies House Number',
+			contacts: 'Contact details',
+		},
+		mainHeadingSubtitle: {
+			main: 'Scheme Actuary',
 		},
 		statusText: {
 			confirmed: 'Confirmed',

--- a/packages/layout/src/components/cards/actuary/i18n.ts
+++ b/packages/layout/src/components/cards/actuary/i18n.ts
@@ -13,7 +13,7 @@ interface I18nActuaryPreviewView extends I18nPreviewViewCommonProps {
 		address: string;
 		companiesHouseNumber: string;
 		contacts: string;
-	}
+	};
 }
 
 export type ActuaryI18nProps = {

--- a/packages/layout/src/components/cards/actuary/views/contacts/index.tsx
+++ b/packages/layout/src/components/cards/actuary/views/contacts/index.tsx
@@ -72,7 +72,7 @@ export const Contacts: React.FC = () => {
 			}}
 			fields={fields}
 			send={send}
-			subSectionHeaderText={i18n.preview.buttons.four}
+			subSectionHeaderText={i18n.preview.buttonsAndHeadings.contacts}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
-import { Checkbox } from '@tpr/forms';
-import { Flex, Hr, classNames } from '@tpr/core';
+import { Flex, classNames } from '@tpr/core';
 import { UnderlinedButton } from '../../../components/button';
+import { CardFooter } from '../../../components/footer';
 import { useActuaryContext } from '../../context';
 import {
 	AddressPreview,
@@ -69,25 +69,21 @@ export const Preview: React.FC<any> = React.memo(() => {
 			</Flex>
 
 			{/*  All details correct - Checkbox	 */}
-			<Flex cfg={{ flexDirection: 'column' }}>
-				<Hr cfg={{ my: 4 }} />
-				<Checkbox
-					value={complete}
-					checked={complete}
-					onChange={() => {
-						send('COMPLETE', { value: !complete });
-						onCorrect(!complete);
-					}}
-					label={i18n.preview.checkboxLabel.replace(
-						'__NAME__',
-						concatenateStrings([
-							actuary.title,
-							actuary.firstName,
-							actuary.lastName,
-						]),
-					)}
-				/>
-			</Flex>
+			<CardFooter
+				complete={complete}
+				onChange={() => {
+					send('COMPLETE', { value: !complete });
+					onCorrect(!complete);
+				}}
+				label={i18n.preview.checkboxLabel.replace(
+					'__NAME__',
+					concatenateStrings([
+						actuary.title,
+						actuary.firstName,
+						actuary.lastName,
+					]),
+				)}
+			/>
 		</div>
 	);
 });

--- a/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/actuary/views/preview/preview.tsx
@@ -28,7 +28,9 @@ export const Preview: React.FC<any> = React.memo(() => {
 			<Flex>
 				{/* Address section: display only	 */}
 				<Flex cfg={{ pr: 4 }} className={styles.section}>
-					<UnderlinedButton>{i18n.preview.buttons.three}</UnderlinedButton>
+					<UnderlinedButton>
+						{i18n.preview.buttonsAndHeadings.address}
+					</UnderlinedButton>
 					<AddressPreview
 						address={{
 							addressLine1: actuary.address.addressLine1,
@@ -43,7 +45,7 @@ export const Preview: React.FC<any> = React.memo(() => {
 
 					{/* Companies House Number: display only	 */}
 					<CompaniesHouseNumber
-						heading={i18n.preview.buttons.four}
+						heading={i18n.preview.buttonsAndHeadings.companiesHouseNumber}
 						companiesHouseNumber={actuary.companiesHouseNumber}
 					/>
 				</Flex>
@@ -57,7 +59,7 @@ export const Preview: React.FC<any> = React.memo(() => {
 						buttonRef={contactsBtn}
 						giveFocus={current.context.lastBtnClicked === 4}
 					>
-						{i18n.preview.buttons.five}
+						{i18n.preview.buttonsAndHeadings.contacts}
 					</UnderlinedButton>
 					<ContactDetailsPreview
 						phone={{ value: actuary.telephoneNumber }}

--- a/packages/layout/src/components/cards/common/interfaces.ts
+++ b/packages/layout/src/components/cards/common/interfaces.ts
@@ -99,9 +99,97 @@ export interface CommonCardMachineContext {
 	lastBtnClicked?: number | null;
 }
 
+type PropertyFunction<T> = () => T;
+
 /*	--------------------------------
 					i18n common props
 		--------------------------------	*/
+export interface I18nPreviewViewCommonProps {
+	mainHeadingSubtitle: {
+		main: string;
+		secondary?: string;
+	};
+	statusText: {
+		confirmed: string;
+		unconfirmed: string;
+	};
+	checkboxLabel: string;
+}
+
+export interface I18nNameView {
+	title: string;
+	sectionTitle?: string;
+	fields: {
+		title: {
+			label: string;
+			error: string | PropertyFunction<string | undefined>;
+			maxlength: number;
+		};
+		firstName: {
+			label: string;
+			error: string | PropertyFunction<string | undefined>;
+			maxlength: number;
+		};
+		lastName: {
+			label: string;
+			error: string | PropertyFunction<string | undefined>;
+			maxlength: number;
+		};
+	};
+}
+
+export interface I18nContactsView {
+	title: string;
+	subtitle?: string;
+	sectionTitle?: string;
+	fields: {
+		telephone: {
+			label: string;
+			error: InputErrorMessages;
+		};
+		email: {
+			label: string;
+			error: InputErrorMessages;
+		};
+	};
+}
+
+export interface I18nRemoveViewDateAndConfirm {
+	date: {
+		title: string;
+		fields: {
+			confirm: {
+				label: string;
+			};
+			date: {
+				label: string;
+				hint: string;
+				error: string;
+			};
+		};
+		errors: {
+			formIncomplete: string;
+			dateAddedBeforeEffectiveDate: string;
+			dateAddedInTheFuture: string;
+		};
+	};
+	confirm: {
+		breadcrumbs: {
+			link1: string;
+			link2: string;
+		};
+		title: string;
+		dialog: {
+			message1: string;
+			message2?: string;
+		};
+		buttons: {
+			remove: string;
+			cancel: string;
+		};
+	};
+}
+
 export interface I18nRemoveReason {
 	title?: string;
 	subtitle?: string;
@@ -123,6 +211,27 @@ export interface I18nRemoveReason {
 		dateAddedInTheFuture?: string;
 	};
 }
+
+export interface I18nRemoveViewReasonAndConfirm {
+	reason: I18nRemoveReason;
+	confirm: {
+		title: string;
+		subtitle: string;
+		breadcrumbs: {
+			link1: string;
+			link2: string;
+		};
+		dialog?: {
+			message1: string;
+		};
+		buttons: {
+			remove: string;
+			cancel: string;
+		};
+	};
+}
+
+// -----------------------------------------
 
 export interface InputErrorMessages {
 	empty: string;

--- a/packages/layout/src/components/cards/common/interfaces.ts
+++ b/packages/layout/src/components/cards/common/interfaces.ts
@@ -248,9 +248,14 @@ export const defaultPhoneErrorMessages: InputErrorMessages = {
 	invalid: 'Enter a telephone number, like 0163 960 598 or +44 7700 900 359',
 };
 
-export interface CardContentProps {
-	enableContactDetails?: boolean;
+// -----------------------------------------
+
+export interface IAddressViewProps {
 	onChangeAddress?: (...args: any[]) => Promise<any>;
+}
+
+export interface CardContentProps extends IAddressViewProps {
+	enableContactDetails?: boolean;
 }
 
 /*	--------------------------------

--- a/packages/layout/src/components/cards/common/views/preview/components/subtitle/Subtitle.tsx
+++ b/packages/layout/src/components/cards/common/views/preview/components/subtitle/Subtitle.tsx
@@ -9,7 +9,7 @@ interface SubtitleProps {
 }
 
 export const Subtitle: React.FC<SubtitleProps> = React.memo(
-	({ main, secondary, mainBold = true }) => {
+	({ main, secondary, mainBold = false }) => {
 		return (
 			<>
 				{main && (

--- a/packages/layout/src/components/cards/components/footer.tsx
+++ b/packages/layout/src/components/cards/components/footer.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Flex, Hr } from '@tpr/core';
+import { Checkbox } from '@tpr/forms';
+
+interface ICardFooterProps {
+	complete: boolean;
+	onChange: any;
+	label: string;
+}
+
+export const CardFooter: React.FC<ICardFooterProps> = React.memo(
+	({ complete, onChange, label }) => {
+		return (
+			<Flex cfg={{ flexDirection: 'column' }}>
+				<Hr cfg={{ my: 4 }} />
+				<Checkbox
+					value={complete}
+					checked={complete}
+					onChange={onChange}
+					label={label}
+				/>
+			</Flex>
+		);
+	},
+);

--- a/packages/layout/src/components/cards/corporateGroup/corporateGroup.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/corporateGroup.tsx
@@ -63,7 +63,7 @@ export const CorporateGroupCard: React.FC<CorporateGroupProviderProps> = React.m
 							send={send}
 							current={current}
 						>
-							{i18n.preview.buttons.two}
+							{i18n.preview.buttonsAndHeadings.remove}
 						</CardRemoveButton>
 					);
 
@@ -74,7 +74,7 @@ export const CorporateGroupCard: React.FC<CorporateGroupProviderProps> = React.m
 							className={styles.card}
 							ariaLabel={concatenateStrings([
 								current.context.corporateGroup.organisationName,
-								i18n.preview.trusteeType,
+								i18n.preview.mainHeadingSubtitle.main,
 							])}
 						>
 							<Toolbar
@@ -86,7 +86,7 @@ export const CorporateGroupCard: React.FC<CorporateGroupProviderProps> = React.m
 								buttonRight={RemoveButton}
 								complete={isComplete(current.context)}
 								subtitle={() => (
-									<Subtitle secondary={i18n.preview.trusteeType} />
+									<Subtitle secondary={i18n.preview.mainHeadingSubtitle.main} />
 								)}
 								statusText={
 									isComplete(current.context)

--- a/packages/layout/src/components/cards/corporateGroup/i18n.ts
+++ b/packages/layout/src/components/cards/corporateGroup/i18n.ts
@@ -1,62 +1,26 @@
 import {
-	I18nRemoveReason,
-	InputErrorMessages,
+	I18nNameView,
+	I18nContactsView,
+	I18nRemoveViewReasonAndConfirm,
 	defaultEmailErrorMessages,
 	defaultPhoneErrorMessages,
+	I18nPreviewViewCommonProps,
 } from '../common/interfaces';
-type PropertyFunction<T> = () => T;
+
+interface I18nCorporateGroupPreviewView extends I18nPreviewViewCommonProps {
+	buttonsAndHeadings: {
+		remove: string;
+		address: string;
+		companiesHouseNumber: string;
+		chairOfBoard: string;
+		directorProfessional: string;
+	};
+}
 
 export type CorporateGroupI18nProps = {
-	preview: {
-		buttons: {
-			one: string;
-			two: string;
-			three: string;
-			four: string;
-			five: string;
-			six: string;
-		};
-		statusText: {
-			confirmed: string;
-			unconfirmed: string;
-		};
-		checkboxLabel: string;
-		trusteeType: string;
-	};
-	name: {
-		title: string;
-		sectionTitle?: string;
-		fields: {
-			title: {
-				label: string;
-				error: string | PropertyFunction<string | undefined>;
-				maxlength: number;
-			};
-			firstName: {
-				label: string;
-				error: string | PropertyFunction<string | undefined>;
-				maxlength: number;
-			};
-			lastName: {
-				label: string;
-				error: string | PropertyFunction<string | undefined>;
-				maxlength: number;
-			};
-		};
-	};
-	contacts: {
-		title: string;
-		fields: {
-			telephone: {
-				label: string;
-				error: InputErrorMessages;
-			};
-			email: {
-				label: string;
-				error: InputErrorMessages;
-			};
-		};
-	};
+	preview: I18nCorporateGroupPreviewView;
+	name: I18nNameView;
+	contacts: I18nContactsView;
 	professional: {
 		title: string;
 		subtitle: string;
@@ -70,42 +34,26 @@ export type CorporateGroupI18nProps = {
 			};
 		};
 	};
-	remove: {
-		confirm: {
-			title: string;
-			subtitle: string;
-			breadcrumbs: {
-				link1: string;
-				link2: string;
-			};
-			dialog: {
-				message1: string;
-			};
-			buttons: {
-				remove: string;
-				cancel: string;
-			};
-		};
-		reason: I18nRemoveReason;
-	};
+	remove: I18nRemoveViewReasonAndConfirm;
 };
 
 export const i18n: CorporateGroupI18nProps = {
 	preview: {
-		buttons: {
-			one: 'Corporate Trustee',
-			two: 'Remove',
-			three: 'Address',
-			four: 'Companies House Number',
-			five: 'Chair of board',
-			six: 'Director(s) are Professional Trustees',
+		buttonsAndHeadings: {
+			remove: 'Remove',
+			address: 'Address',
+			companiesHouseNumber: 'Companies House Number',
+			chairOfBoard: 'Chair of board',
+			directorProfessional: 'Director(s) are Professional Trustees',
+		},
+		mainHeadingSubtitle: {
+			main: 'Corporate Group trustee',
 		},
 		statusText: {
 			confirmed: 'Confirmed',
 			unconfirmed: 'Unconfirmed',
 		},
 		checkboxLabel: "Confirm '__NAME__' is correct.",
-		trusteeType: 'Corporate Group trustee',
 	},
 	name: {
 		title: 'Name of the chair of the board',

--- a/packages/layout/src/components/cards/corporateGroup/views/contacts/contacts.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/contacts/contacts.tsx
@@ -62,7 +62,7 @@ export const Contacts: React.FC = () => {
 			}}
 			fields={fields}
 			send={send}
-			subSectionHeaderText={i18n.preview.buttons.five}
+			subSectionHeaderText={i18n.preview.buttonsAndHeadings.chairOfBoard}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/corporateGroup/views/name/name.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/name/name.tsx
@@ -86,7 +86,7 @@ export const NameScreen: React.FC = () => {
 			loading={loading}
 			nextStep={true}
 			send={send}
-			subSectionHeaderText={i18n.preview.buttons.five}
+			subSectionHeaderText={i18n.preview.buttonsAndHeadings.chairOfBoard}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
@@ -28,7 +28,9 @@ export const Preview: React.FC<any> = React.memo(() => {
 			<Flex>
 				{/* Address section: display only	 */}
 				<Flex cfg={{ pr: 4 }} className={styles.section}>
-					<UnderlinedButton>{i18n.preview.buttons.three}</UnderlinedButton>
+					<UnderlinedButton>
+						{i18n.preview.buttonsAndHeadings.address}
+					</UnderlinedButton>
 					<AddressPreview
 						address={{
 							addressLine1: corporateGroup.address.addressLine1,
@@ -43,7 +45,7 @@ export const Preview: React.FC<any> = React.memo(() => {
 
 					{/* Companies House Number: display only	 */}
 					<CompaniesHouseNumber
-						heading={i18n.preview.buttons.four}
+						heading={i18n.preview.buttonsAndHeadings.companiesHouseNumber}
 						companiesHouseNumber={corporateGroup.companiesHouseNumber}
 					/>
 				</Flex>
@@ -57,7 +59,7 @@ export const Preview: React.FC<any> = React.memo(() => {
 						buttonRef={chairBtn}
 						giveFocus={current.context.lastBtnClicked === 5}
 					>
-						{i18n.preview.buttons.five}
+						{i18n.preview.buttonsAndHeadings.chairOfBoard}
 					</UnderlinedButton>
 					<ContactDetailsPreview
 						name={
@@ -78,7 +80,7 @@ export const Preview: React.FC<any> = React.memo(() => {
 							buttonRef={directorBtn}
 							giveFocus={current.context.lastBtnClicked === 6}
 						>
-							{i18n.preview.buttons.six}
+							{i18n.preview.buttonsAndHeadings.directorProfessional}
 						</UnderlinedButton>
 						<P className={styles.isProfessional}>
 							{corporateGroup.directorIsProfessional

--- a/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/preview/preview.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
-import { Checkbox } from '@tpr/forms';
-import { Flex, P, Hr, classNames } from '@tpr/core';
+import { Flex, P, classNames } from '@tpr/core';
 import { UnderlinedButton } from '../../../components/button';
+import { CardFooter } from '../../../components/footer';
 import { useCorporateGroupContext } from '../../context';
 import {
 	ContactDetailsPreview,
@@ -94,21 +94,17 @@ export const Preview: React.FC<any> = React.memo(() => {
 			</Flex>
 
 			{/*  All details correct - Checkbox	 */}
-			<Flex cfg={{ flexDirection: 'column' }}>
-				<Hr cfg={{ my: 4 }} />
-				<Checkbox
-					value={complete}
-					checked={complete}
-					onChange={() => {
-						send('COMPLETE', { value: !complete });
-						onCorrect(!complete);
-					}}
-					label={i18n.preview.checkboxLabel.replace(
-						'__NAME__',
-						corporateGroup.organisationName,
-					)}
-				/>
-			</Flex>
+			<CardFooter
+				complete={complete}
+				onChange={() => {
+					send('COMPLETE', { value: !complete });
+					onCorrect(!complete);
+				}}
+				label={i18n.preview.checkboxLabel.replace(
+					'__NAME__',
+					corporateGroup.organisationName,
+				)}
+			/>
 		</div>
 	);
 });

--- a/packages/layout/src/components/cards/corporateGroup/views/professional/professional.tsx
+++ b/packages/layout/src/components/cards/corporateGroup/views/professional/professional.tsx
@@ -57,7 +57,9 @@ export const Professional: React.FC = () => {
 			type={cardType.trustee}
 			title={i18n.professional.title}
 			sectionTitle={i18n.professional.sectionTitle}
-			subSectionHeaderText={i18n.preview.buttons.six}
+			subSectionHeaderText={
+				i18n.preview.buttonsAndHeadings.directorProfessional
+			}
 			send={send}
 		>
 			<Form

--- a/packages/layout/src/components/cards/employer/employer.tsx
+++ b/packages/layout/src/components/cards/employer/employer.tsx
@@ -58,7 +58,7 @@ export const ToolbarButton: React.FC<IToolbarButtonProps> = React.memo(
 						current={current}
 						tabIndex={removeFromTabFlowIfMatches(current, 'employerType')}
 					>
-						{i18n.preview.buttons.two}
+						{i18n.preview.buttonsAndHeadings.remove}
 					</CardRemoveButton>
 				) : (
 					<CardMainHeadingButton
@@ -66,7 +66,7 @@ export const ToolbarButton: React.FC<IToolbarButtonProps> = React.memo(
 						current={current}
 						onClick={() => send('CHANGE_TYPE')}
 					>
-						{i18n.preview.buttons.one}
+						{current.context.employer.organisationName}
 					</CardMainHeadingButton>
 				)}
 			</>

--- a/packages/layout/src/components/cards/employer/employerMachine.ts
+++ b/packages/layout/src/components/cards/employer/employerMachine.ts
@@ -59,7 +59,7 @@ const employerMachine = Machine<
 			on: {
 				CHANGE_TYPE: {
 					target: '#employerType',
-					actions: updateClickedButton(1),
+					actions: updateClickedButton(5),
 				},
 				REMOVE: {
 					target: '#remove',
@@ -105,7 +105,6 @@ const employerMachine = Machine<
 								};
 							}),
 						},
-						CHANGE_TYPE: returnToPreview(1),
 						REMOVE: '#preview',
 					},
 				},
@@ -114,7 +113,6 @@ const employerMachine = Machine<
 						CANCEL: '#preview',
 						BACK: '#remove',
 						DELETE: 'deleted',
-						CHANGE_TYPE: returnToPreview(1),
 						REMOVE: '#preview',
 					},
 				},

--- a/packages/layout/src/components/cards/employer/i18n.ts
+++ b/packages/layout/src/components/cards/employer/i18n.ts
@@ -1,22 +1,24 @@
-export type EmployerI18nProps = {
-	preview: {
-		buttons: {
-			one: string;
-			two: string;
-			three: string;
-			four: string;
-		};
-		identifiers: {
-			companiesHouseNo: string;
-			registeredCharityNo: string;
-			epsrNumber: string;
-		};
-		statusText: {
-			confirmed: string;
-			unconfirmed: string;
-		};
-		checkboxLabel: string;
+import {
+	I18nPreviewViewCommonProps,
+	I18nRemoveViewDateAndConfirm,
+} from '../common/interfaces';
+
+interface I18nEmployerPreviewView extends I18nPreviewViewCommonProps {
+	buttonsAndHeadings: {
+		remove: string;
+		address: string;
+		employerType: string;
+		employerIdentifiers: string;
 	};
+	identifiers: {
+		companiesHouseNo: string;
+		registeredCharityNo: string;
+		epsrNumber: string;
+	};
+}
+
+export type EmployerI18nProps = {
+	preview: I18nEmployerPreviewView;
 	type: {
 		title: string;
 		subtitle: string;
@@ -53,50 +55,19 @@ export type EmployerI18nProps = {
 			};
 		};
 	};
-	remove: {
-		confirm: {
-			breadcrumbs: {
-				link1: string;
-				link2: string;
-			};
-			title: string;
-			dialog: {
-				message1: string;
-				message2: string;
-			};
-			buttons: {
-				remove: string;
-				cancel: string;
-			};
-		};
-		date: {
-			title: string;
-			fields: {
-				confirm: {
-					label: string;
-				};
-				date: {
-					label: string;
-					hint: string;
-					error: string;
-				};
-			};
-			errors: {
-				formIncomplete: string;
-				dateAddedBeforeEffectiveDate: string;
-				dateAddedInTheFuture: string;
-			};
-		};
-	};
+	remove: I18nRemoveViewDateAndConfirm;
 };
 
 export const i18n: EmployerI18nProps = {
 	preview: {
-		buttons: {
-			one: 'Employer type',
-			two: 'Remove',
-			three: 'Registered office address',
-			four: 'Employer Identifiers',
+		buttonsAndHeadings: {
+			employerType: 'Employer type',
+			remove: 'Remove',
+			address: 'Registered office address',
+			employerIdentifiers: 'Employer Identifiers',
+		},
+		mainHeadingSubtitle: {
+			main: 'Employer',
 		},
 		identifiers: {
 			companiesHouseNo: 'Companies House number',

--- a/packages/layout/src/components/cards/employer/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/employer/views/preview/preview.tsx
@@ -1,12 +1,12 @@
 import React, { useRef, useState } from 'react';
 import { Flex, P, Hr, classNames } from '@tpr/core';
-import { UnderlinedButton } from '../../../components/button';
 import { Checkbox } from '@tpr/forms';
+import { UnderlinedButton } from '../../../components/button';
 import { useEmployerContext } from '../../context';
 import { AddressPreview } from '../../../common/views/preview/components';
-import styles from '../../../cards.module.scss';
 import { PreviewButton } from './previewButton';
 import { EmployerTypePreview } from './employerTypePreview';
+import styles from '../../../cards.module.scss';
 
 type IdentifiersItemProps = { title: string; number: string | number };
 const IdentifiersItem: React.FC<IdentifiersItemProps> = ({ title, number }) => {
@@ -49,7 +49,9 @@ export const Preview: React.FC<any> = React.memo(() => {
 		>
 			<Flex>
 				<Flex cfg={{ pr: 4 }} className={styles.section}>
-					<UnderlinedButton>{i18n.preview.buttons.three}</UnderlinedButton>
+					<UnderlinedButton>
+						{i18n.preview.buttonsAndHeadings.address}
+					</UnderlinedButton>
 					<AddressPreview
 						address={{
 							addressLine1: employer.address.addressLine1,
@@ -61,7 +63,9 @@ export const Preview: React.FC<any> = React.memo(() => {
 						}}
 					/>
 					<Flex cfg={{ mt: 3 }} className={styles.identifierItem}>
-						<UnderlinedButton>{i18n.preview.buttons.four}</UnderlinedButton>
+						<UnderlinedButton>
+							{i18n.preview.buttonsAndHeadings.employerIdentifiers}
+						</UnderlinedButton>
 						{items.map((item, key) => (
 							<IdentifiersItem key={key} {...item} />
 						))}
@@ -69,7 +73,7 @@ export const Preview: React.FC<any> = React.memo(() => {
 				</Flex>
 				<Flex cfg={{ pl: 4 }} className={styles.section}>
 					<PreviewButton button={employerButtonRef}>
-						{i18n.preview.buttons.one}
+						{i18n.preview.buttonsAndHeadings.employerType}
 					</PreviewButton>
 					<EmployerTypePreview {...current.context} />
 				</Flex>

--- a/packages/layout/src/components/cards/employer/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/employer/views/preview/preview.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react';
-import { Flex, P, Hr, classNames } from '@tpr/core';
-import { Checkbox } from '@tpr/forms';
+import { Flex, P, classNames } from '@tpr/core';
 import { UnderlinedButton } from '../../../components/button';
+import { CardFooter } from '../../../components/footer';
 import { useEmployerContext } from '../../context';
 import { AddressPreview } from '../../../common/views/preview/components';
 import { PreviewButton } from './previewButton';
@@ -49,6 +49,7 @@ export const Preview: React.FC<any> = React.memo(() => {
 		>
 			<Flex>
 				<Flex cfg={{ pr: 4 }} className={styles.section}>
+					{/* Office Address: display only	 */}
 					<UnderlinedButton>
 						{i18n.preview.buttonsAndHeadings.address}
 					</UnderlinedButton>
@@ -62,6 +63,8 @@ export const Preview: React.FC<any> = React.memo(() => {
 							postcode: employer.address.postcode,
 						}}
 					/>
+
+					{/* Employer Identifiers: display only	 */}
 					<Flex cfg={{ mt: 3 }} className={styles.identifierItem}>
 						<UnderlinedButton>
 							{i18n.preview.buttonsAndHeadings.employerIdentifiers}
@@ -71,6 +74,8 @@ export const Preview: React.FC<any> = React.memo(() => {
 						))}
 					</Flex>
 				</Flex>
+
+				{/* Employer type: open for editing	 */}
 				<Flex cfg={{ pl: 4 }} className={styles.section}>
 					<PreviewButton button={employerButtonRef}>
 						{i18n.preview.buttonsAndHeadings.employerType}
@@ -78,21 +83,19 @@ export const Preview: React.FC<any> = React.memo(() => {
 					<EmployerTypePreview {...current.context} />
 				</Flex>
 			</Flex>
-			<Flex cfg={{ flexDirection: 'column' }}>
-				<Hr cfg={{ my: 4 }} />
-				<Checkbox
-					value={complete}
-					checked={complete}
-					onChange={() => {
-						send('COMPLETE', { value: !complete });
-						onCorrect(!complete);
-					}}
-					label={i18n.preview.checkboxLabel.replace(
-						'__NAME__',
-						employer.organisationName,
-					)}
-				/>
-			</Flex>
+
+			{/*  All details correct - Checkbox	 */}
+			<CardFooter
+				complete={complete}
+				onChange={() => {
+					send('COMPLETE', { value: !complete });
+					onCorrect(!complete);
+				}}
+				label={i18n.preview.checkboxLabel.replace(
+					'__NAME__',
+					employer.organisationName,
+				)}
+			/>
 		</div>
 	);
 });

--- a/packages/layout/src/components/cards/employer/views/preview/previewButton.tsx
+++ b/packages/layout/src/components/cards/employer/views/preview/previewButton.tsx
@@ -13,7 +13,7 @@ export const PreviewButton: React.FC<IPreviewButtonProps> = ({
 	return (
 		<UnderlinedButton
 			buttonRef={button}
-			giveFocus={current.context.lastBtnClicked === 1}
+			giveFocus={current.context.lastBtnClicked === 5}
 			isEditButton={true}
 			isMainHeading={false}
 			isOpen={isEditing}

--- a/packages/layout/src/components/cards/employer/views/type/type.tsx
+++ b/packages/layout/src/components/cards/employer/views/type/type.tsx
@@ -93,6 +93,8 @@ export const EmployerType: React.FC = () => {
 			title={i18n.type.title}
 			subtitle={i18n.type.subtitle}
 			sectionTitle={i18n.type.sectionTitle}
+			subSectionHeaderText={i18n.preview.buttonsAndHeadings.employerType}
+			send={send}
 		>
 			<Form
 				onSubmit={onSubmit}

--- a/packages/layout/src/components/cards/inHouse/i18n.ts
+++ b/packages/layout/src/components/cards/inHouse/i18n.ts
@@ -1,97 +1,27 @@
 import { I18nAddressLookup, i18n as AddressI18n } from '@tpr/forms';
 import {
-	InputErrorMessages,
 	defaultEmailErrorMessages,
 	defaultPhoneErrorMessages,
+	I18nNameView,
+	I18nContactsView,
+	I18nRemoveViewDateAndConfirm,
+	I18nPreviewViewCommonProps
 } from '../common/interfaces';
-type PropertyFunction<T> = () => T;
+
+interface I18nInHouseAdminPreviewView extends I18nPreviewViewCommonProps {
+	buttonsAndHeadings: {
+		remove: string;
+		address: string;
+		contacts: string;
+	}
+}
 
 export type InHouseAdminI18nProps = {
 	address: I18nAddressLookup;
-	preview: {
-		buttons: {
-			one: string;
-			two: string;
-			three: string;
-			four: string;
-		};
-		statusText: {
-			confirmed: string;
-			unconfirmed: string;
-		};
-		checkboxLabel: string;
-	};
-	name: {
-		title: string;
-		sectionTitle?: string;
-		fields: {
-			title: {
-				label: string;
-				error: string | PropertyFunction<string | undefined>;
-				maxlength: number;
-			};
-			firstName: {
-				label: string;
-				error: string | PropertyFunction<string | undefined>;
-				maxlength: number;
-			};
-			lastName: {
-				label: string;
-				error: string | PropertyFunction<string | undefined>;
-				maxlength: number;
-			};
-		};
-	};
-	contacts: {
-		title: string;
-		subtitle: string;
-		sectionTitle?: string;
-		fields: {
-			telephone: {
-				label: string;
-				error: InputErrorMessages;
-			};
-			email: {
-				label: string;
-				error: InputErrorMessages;
-			};
-		};
-	};
-	remove: {
-		confirm: {
-			breadcrumbs: {
-				link1: string;
-				link2: string;
-			};
-			title: string;
-			dialog: {
-				message1: string;
-				message2: string;
-			};
-			buttons: {
-				remove: string;
-				cancel: string;
-			};
-		};
-		date: {
-			title: string;
-			fields: {
-				confirm: {
-					label: string;
-				};
-				date: {
-					label: string;
-					hint: string;
-					error: string;
-				};
-			};
-			errors: {
-				formIncomplete: string;
-				dateAddedBeforeEffectiveDate: string;
-				dateAddedInTheFuture: string;
-			};
-		};
-	};
+	preview: I18nInHouseAdminPreviewView;
+	name: I18nNameView;
+	contacts: I18nContactsView;
+	remove: I18nRemoveViewDateAndConfirm;
 };
 
 export const i18n: InHouseAdminI18nProps = {
@@ -101,11 +31,13 @@ export const i18n: InHouseAdminI18nProps = {
 		...AddressI18n,
 	},
 	preview: {
-		buttons: {
-			one: 'In House Administrator',
-			two: 'Remove',
-			three: 'Address',
-			four: 'Contact details',
+		buttonsAndHeadings: {
+			remove: 'Remove',
+			address: 'Address',
+			contacts: 'Contact details',
+		},
+		mainHeadingSubtitle: {
+			main: 'In House Administrator',
 		},
 		statusText: {
 			confirmed: 'Confirmed',
@@ -181,8 +113,7 @@ export const i18n: InHouseAdminI18nProps = {
 			},
 			errors: {
 				formIncomplete: 'Please confirm and fill in the date fields.',
-				dateAddedBeforeEffectiveDate:
-					'Date must be after the Employer was added.',
+				dateAddedBeforeEffectiveDate: 'Date must be after the Employer was added.',
 				dateAddedInTheFuture: 'Date cannot be in the future.',
 			},
 		},

--- a/packages/layout/src/components/cards/inHouse/i18n.ts
+++ b/packages/layout/src/components/cards/inHouse/i18n.ts
@@ -5,7 +5,7 @@ import {
 	I18nNameView,
 	I18nContactsView,
 	I18nRemoveViewDateAndConfirm,
-	I18nPreviewViewCommonProps
+	I18nPreviewViewCommonProps,
 } from '../common/interfaces';
 
 interface I18nInHouseAdminPreviewView extends I18nPreviewViewCommonProps {
@@ -13,7 +13,7 @@ interface I18nInHouseAdminPreviewView extends I18nPreviewViewCommonProps {
 		remove: string;
 		address: string;
 		contacts: string;
-	}
+	};
 }
 
 export type InHouseAdminI18nProps = {
@@ -113,7 +113,8 @@ export const i18n: InHouseAdminI18nProps = {
 			},
 			errors: {
 				formIncomplete: 'Please confirm and fill in the date fields.',
-				dateAddedBeforeEffectiveDate: 'Date must be after the Employer was added.',
+				dateAddedBeforeEffectiveDate:
+					'Date must be after the Employer was added.',
 				dateAddedInTheFuture: 'Date cannot be in the future.',
 			},
 		},

--- a/packages/layout/src/components/cards/inHouse/inHouse.tsx
+++ b/packages/layout/src/components/cards/inHouse/inHouse.tsx
@@ -10,15 +10,10 @@ import { Preview } from './views/preview/preview';
 import { Contacts } from './views/contacts';
 import { RemoveDateForm } from './views/remove/date/date';
 import { ConfirmRemove } from './views/remove/confirm/confirm';
-import Address from '../common/views/address/addressPage';
 import { NameScreen } from './views/name';
+import AddressView from './views/address';
 import RemovedBox from '../components/removedBox';
-import {
-	cardType,
-	cardTypeName,
-	IToolbarButtonProps,
-} from '../common/interfaces';
-import { AddressComparer } from '@tpr/forms';
+import { cardTypeName, IToolbarButtonProps } from '../common/interfaces';
 import { InHouseAdminContext } from './inHouseMachine';
 import {
 	CardMainHeadingButton,
@@ -32,55 +27,16 @@ export interface ICardContentSwitchProps {
 	onChangeAddress?: (...args: any[]) => Promise<any>;
 }
 
-const CardContentSwitch: React.FC<ICardContentSwitchProps> = (
-	props: ICardContentSwitchProps,
-) => {
-	const {
-		current,
-		i18n,
-		send,
-		addressAPI,
-		onSaveAddress,
-	} = useInHouseAdminContext();
-	const { inHouseAdmin } = current.context;
+const CardContentSwitch: React.FC<ICardContentSwitchProps> = ({
+	onChangeAddress,
+}) => {
+	const { current } = useInHouseAdminContext();
 
 	switch (true) {
 		case current.matches('preview'):
 			return <Preview />;
 		case current.matches({ edit: 'address' }):
-			return (
-				<Address
-					onSubmit={async (values) => {
-						try {
-							const {
-								address,
-								...inHouseAdminValues
-							} = current.context.inHouseAdmin;
-
-							if (AddressComparer.areEqual(values.initialValue, values)) {
-								send('CANCEL');
-							} else {
-								await onSaveAddress(
-									values,
-									Object.assign(inHouseAdminValues, address),
-								);
-								send('SAVE', { values });
-							}
-						} catch (error) {
-							console.log(error);
-						}
-					}}
-					initialValue={inHouseAdmin.address}
-					addressAPI={addressAPI}
-					cardType={cardType.inHouseAdmin}
-					cardTypeName={cardTypeName.inHouseAdmin}
-					sectionTitle={i18n.address.sectionTitle}
-					i18n={i18n.address}
-					onCancelChanges={() => send('CANCEL')}
-					subSectionHeaderText={i18n.preview.buttons.three}
-					onChangeAddress={props.onChangeAddress}
-				/>
-			);
+			return <AddressView onChangeAddress={onChangeAddress} />;
 		case current.matches({ edit: 'contacts' }):
 			return <Contacts />;
 		case current.matches({ edit: 'name' }):
@@ -112,7 +68,7 @@ const ToolbarButton: React.FC<IToolbarButtonProps> = React.memo(
 							edit: 'name',
 						})}
 					>
-						{i18n.preview.buttons.two}
+						{i18n.preview.buttonsAndHeadings.remove}
 					</CardRemoveButton>
 				) : (
 					<CardMainHeadingButton
@@ -153,7 +109,7 @@ export const InHouseCard: React.FC<InHouseAdminProviderProps> = React.memo(
 								current.context.inHouseAdmin.title,
 								current.context.inHouseAdmin.firstName,
 								current.context.inHouseAdmin.lastName,
-								i18n.preview.buttons.one,
+								i18n.preview.mainHeadingSubtitle.main,
 							])}
 						>
 							<Toolbar
@@ -162,7 +118,9 @@ export const InHouseCard: React.FC<InHouseAdminProviderProps> = React.memo(
 									<ToolbarButton button={removeButtonRef} remove={true} />
 								)}
 								complete={isComplete(current.context)}
-								subtitle={() => <Subtitle main={i18n.preview.buttons.one} />}
+								subtitle={() => (
+									<Subtitle main={i18n.preview.mainHeadingSubtitle.main} />
+								)}
 								statusText={
 									isComplete(current.context)
 										? i18n.preview.statusText.confirmed

--- a/packages/layout/src/components/cards/inHouse/views/address/index.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/address/index.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { AddressComparer } from '@tpr/forms';
 import { useInHouseAdminContext } from '../../context';
-import { cardType, cardTypeName } from '../../../common/interfaces';
+import {
+	cardType,
+	cardTypeName,
+	IAddressViewProps,
+} from '../../../common/interfaces';
 import Address from '../../../common/views/address/addressPage';
-
-interface IAddressViewProps {
-	onChangeAddress?: (...args: any[]) => Promise<any>;
-}
 
 const AddressView: React.FC<IAddressViewProps> = ({ onChangeAddress }) => {
 	const {

--- a/packages/layout/src/components/cards/inHouse/views/address/index.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/address/index.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { AddressComparer } from '@tpr/forms';
+import { useInHouseAdminContext } from '../../context';
+import { cardType, cardTypeName } from '../../../common/interfaces';
+import Address from '../../../common/views/address/addressPage';
+
+interface IAddressViewProps {
+	onChangeAddress?: (...args: any[]) => Promise<any>;
+}
+
+const AddressView: React.FC<IAddressViewProps> = ({ onChangeAddress }) => {
+	const {
+		current,
+		i18n,
+		send,
+		addressAPI,
+		onSaveAddress,
+	} = useInHouseAdminContext();
+
+	return (
+		<Address
+			onSubmit={async (values) => {
+				try {
+					const {
+						address,
+						...inHouseAdminValues
+					} = current.context.inHouseAdmin;
+
+					if (AddressComparer.areEqual(values.initialValue, values)) {
+						send('CANCEL');
+					} else {
+						await onSaveAddress(
+							values,
+							Object.assign(inHouseAdminValues, address),
+						);
+						send('SAVE', { values });
+					}
+				} catch (error) {
+					console.log(error);
+				}
+			}}
+			initialValue={current.context.inHouseAdmin.address}
+			addressAPI={addressAPI}
+			cardType={cardType.inHouseAdmin}
+			cardTypeName={cardTypeName.inHouseAdmin}
+			sectionTitle={i18n.address.sectionTitle}
+			i18n={i18n.address}
+			onCancelChanges={() => send('CANCEL')}
+			subSectionHeaderText={i18n.preview.buttonsAndHeadings.address}
+			onChangeAddress={onChangeAddress}
+		/>
+	);
+};
+
+export default React.memo(AddressView);

--- a/packages/layout/src/components/cards/inHouse/views/contacts/index.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/contacts/index.tsx
@@ -64,7 +64,7 @@ export const Contacts: React.FC = () => {
 			}}
 			fields={fields}
 			send={send}
-			subSectionHeaderText={i18n.preview.buttons.four}
+			subSectionHeaderText={i18n.preview.buttonsAndHeadings.contacts}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/inHouse/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/preview/preview.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
-import { Checkbox } from '@tpr/forms';
-import { Flex, Hr, classNames } from '@tpr/core';
+import { Flex, classNames } from '@tpr/core';
 import { UnderlinedButton } from '../../../components/button';
+import { CardFooter } from '../../../components/footer';
 import { useInHouseAdminContext } from '../../context';
 import {
 	ContactDetailsPreview,
@@ -69,25 +69,21 @@ export const Preview: React.FC<any> = React.memo(() => {
 			</Flex>
 
 			{/*  All details correct - Checkbox	 */}
-			<Flex cfg={{ flexDirection: 'column' }}>
-				<Hr cfg={{ my: 4 }} />
-				<Checkbox
-					value={complete}
-					checked={complete}
-					onChange={() => {
-						send('COMPLETE', { value: !complete });
-						onCorrect(!complete);
-					}}
-					label={i18n.preview.checkboxLabel.replace(
-						'__NAME__',
-						concatenateStrings([
-							inHouseAdmin.title,
-							inHouseAdmin.firstName,
-							inHouseAdmin.lastName,
-						]),
-					)}
-				/>
-			</Flex>
+			<CardFooter
+				complete={complete}
+				onChange={() => {
+					send('COMPLETE', { value: !complete });
+					onCorrect(!complete);
+				}}
+				label={i18n.preview.checkboxLabel.replace(
+					'__NAME__',
+					concatenateStrings([
+						inHouseAdmin.title,
+						inHouseAdmin.firstName,
+						inHouseAdmin.lastName,
+					]),
+				)}
+			/>
 		</div>
 	);
 });

--- a/packages/layout/src/components/cards/inHouse/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/preview/preview.tsx
@@ -35,7 +35,7 @@ export const Preview: React.FC<any> = React.memo(() => {
 						buttonRef={addressBtn}
 						giveFocus={current.context.lastBtnClicked === 3}
 					>
-						{i18n.preview.buttons.three}
+						{i18n.preview.buttonsAndHeadings.address}
 					</UnderlinedButton>
 					<AddressPreview
 						address={{
@@ -59,7 +59,7 @@ export const Preview: React.FC<any> = React.memo(() => {
 						buttonRef={contactsBtn}
 						giveFocus={current.context.lastBtnClicked === 4}
 					>
-						{i18n.preview.buttons.four}
+						{i18n.preview.buttonsAndHeadings.contacts}
 					</UnderlinedButton>
 					<ContactDetailsPreview
 						phone={{ value: inHouseAdmin.telephoneNumber }}

--- a/packages/layout/src/components/cards/independentTrustee/i18n.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/i18n.tsx
@@ -1,21 +1,19 @@
-import { I18nRemoveReason } from '../common/interfaces';
+import {
+	I18nPreviewViewCommonProps,
+	I18nRemoveViewReasonAndConfirm,
+} from '../common/interfaces';
+
+interface I18nIndependentTrusteePreviewView extends I18nPreviewViewCommonProps {
+	buttonsAndHeadings: {
+		remove: string;
+		address: string;
+		companiesHouseNumber: string;
+		appointedByRegulator: string;
+	};
+}
 
 export type IndependentTrusteeI18nProps = {
-	preview: {
-		buttons: {
-			one: string;
-			two: string;
-			three: string;
-			four: string;
-			five: string;
-		};
-		statusText: {
-			confirmed: string;
-			unconfirmed: string;
-		};
-		checkboxLabel: string;
-		trusteeType: string;
-	};
+	preview: I18nIndependentTrusteePreviewView;
 	regulator: {
 		title: string;
 		subtitle: string;
@@ -29,41 +27,25 @@ export type IndependentTrusteeI18nProps = {
 			};
 		};
 	};
-	remove: {
-		confirm: {
-			title: string;
-			subtitle: string;
-			breadcrumbs: {
-				link1: string;
-				link2: string;
-			};
-			dialog: {
-				message1: string;
-			};
-			buttons: {
-				remove: string;
-				cancel: string;
-			};
-		};
-		reason: I18nRemoveReason;
-	};
+	remove: I18nRemoveViewReasonAndConfirm;
 };
 
 export const i18n: IndependentTrusteeI18nProps = {
 	preview: {
-		buttons: {
-			one: 'Corporate Trustee',
-			two: 'Remove',
-			three: 'Address',
-			four: 'Companies House Number',
-			five: 'Appointed by the regulator',
+		buttonsAndHeadings: {
+			remove: 'Remove',
+			address: 'Address',
+			companiesHouseNumber: 'Companies House Number',
+			appointedByRegulator: 'Appointed by the regulator',
+		},
+		mainHeadingSubtitle: {
+			main: 'Professional / Independent Trustee',
 		},
 		statusText: {
 			confirmed: 'Confirmed',
 			unconfirmed: 'Unconfirmed',
 		},
 		checkboxLabel: "Confirm '__NAME__' is correct.",
-		trusteeType: 'Professional / Independent Trustee',
 	},
 	regulator: {
 		title: 'Was this trustee appointed to this scheme by the regulator?',

--- a/packages/layout/src/components/cards/independentTrustee/independentTrustee.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/independentTrustee.tsx
@@ -57,7 +57,7 @@ export const IndependentTrusteeCard: React.FC<IndependentTrusteeProviderProps> =
 							send={send}
 							current={current}
 						>
-							{i18n.preview.buttons.two}
+							{i18n.preview.buttonsAndHeadings.remove}
 						</CardRemoveButton>
 					);
 
@@ -68,7 +68,7 @@ export const IndependentTrusteeCard: React.FC<IndependentTrusteeProviderProps> =
 							className={styles.card}
 							ariaLabel={concatenateStrings([
 								current.context.independentTrustee.organisationName,
-								i18n.preview.trusteeType,
+								i18n.preview.mainHeadingSubtitle.main,
 							])}
 						>
 							<Toolbar
@@ -80,7 +80,7 @@ export const IndependentTrusteeCard: React.FC<IndependentTrusteeProviderProps> =
 								buttonRight={RemoveButton}
 								complete={isComplete(current.context)}
 								subtitle={() => (
-									<Subtitle secondary={i18n.preview.trusteeType} />
+									<Subtitle secondary={i18n.preview.mainHeadingSubtitle.main} />
 								)}
 								statusText={
 									isComplete(current.context)

--- a/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
@@ -26,7 +26,9 @@ export const Preview: React.FC<any> = React.memo(() => {
 			<Flex>
 				{/* Address section: display only	 */}
 				<Flex cfg={{ pr: 4 }} className={styles.section}>
-					<UnderlinedButton>{i18n.preview.buttons.three}</UnderlinedButton>
+					<UnderlinedButton>
+						{i18n.preview.buttonsAndHeadings.address}
+					</UnderlinedButton>
 					<AddressPreview
 						address={{
 							addressLine1: independentTrustee.address.addressLine1,
@@ -41,7 +43,7 @@ export const Preview: React.FC<any> = React.memo(() => {
 
 					{/* Companies House Number: display only	 */}
 					<CompaniesHouseNumber
-						heading={i18n.preview.buttons.four}
+						heading={i18n.preview.buttonsAndHeadings.companiesHouseNumber}
 						companiesHouseNumber={independentTrustee.companiesHouseNumber}
 					/>
 				</Flex>
@@ -55,7 +57,7 @@ export const Preview: React.FC<any> = React.memo(() => {
 						buttonRef={regulatorBtn}
 						giveFocus={current.context.lastBtnClicked === 5}
 					>
-						{i18n.preview.buttons.five}
+						{i18n.preview.buttonsAndHeadings.appointedByRegulator}
 					</UnderlinedButton>
 					<P className={styles.appointedByRegulator}>
 						{independentTrustee.appointedByRegulator

--- a/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/views/preview/preview.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
-import { Checkbox } from '@tpr/forms';
-import { Flex, Hr, classNames, P } from '@tpr/core';
+import { Flex, classNames, P } from '@tpr/core';
 import { UnderlinedButton } from '../../../components/button';
+import { CardFooter } from '../../../components/footer';
 import { useIndependentTrusteeContext } from '../../context';
 import {
 	AddressPreview,
@@ -70,21 +70,17 @@ export const Preview: React.FC<any> = React.memo(() => {
 			</Flex>
 
 			{/*  All details correct - Checkbox	 */}
-			<Flex cfg={{ flexDirection: 'column' }}>
-				<Hr cfg={{ my: 4 }} />
-				<Checkbox
-					value={complete}
-					checked={complete}
-					onChange={() => {
-						send('COMPLETE', { value: !complete });
-						onCorrect(!complete);
-					}}
-					label={i18n.preview.checkboxLabel.replace(
-						'__NAME__',
-						independentTrustee.organisationName,
-					)}
-				/>
-			</Flex>
+			<CardFooter
+				complete={complete}
+				onChange={() => {
+					send('COMPLETE', { value: !complete });
+					onCorrect(!complete);
+				}}
+				label={i18n.preview.checkboxLabel.replace(
+					'__NAME__',
+					independentTrustee.organisationName,
+				)}
+			/>
 		</div>
 	);
 });

--- a/packages/layout/src/components/cards/independentTrustee/views/regulator/regulator.tsx
+++ b/packages/layout/src/components/cards/independentTrustee/views/regulator/regulator.tsx
@@ -62,7 +62,9 @@ export const Regulator: React.FC = () => {
 			type={cardType.trustee}
 			title={i18n.regulator.title}
 			sectionTitle={i18n.regulator.sectionTitle}
-			subSectionHeaderText={i18n.preview.buttons.four}
+			subSectionHeaderText={
+				i18n.preview.buttonsAndHeadings.appointedByRegulator
+			}
 			send={send}
 		>
 			<Form

--- a/packages/layout/src/components/cards/insurer/i18n.ts
+++ b/packages/layout/src/components/cards/insurer/i18n.ts
@@ -1,4 +1,7 @@
-import { I18nPreviewViewCommonProps, I18nRemoveViewDateAndConfirm } from '../common/interfaces';
+import {
+	I18nPreviewViewCommonProps,
+	I18nRemoveViewDateAndConfirm,
+} from '../common/interfaces';
 
 interface I18nInsurerPreviewView extends I18nPreviewViewCommonProps {
 	buttonsAndHeadings: {
@@ -6,7 +9,7 @@ interface I18nInsurerPreviewView extends I18nPreviewViewCommonProps {
 		address: string;
 		companiesHouseNumber: string;
 		insurerReferenceNumber: string;
-	}
+	};
 }
 
 export type InsurerI18nProps = {

--- a/packages/layout/src/components/cards/insurer/i18n.ts
+++ b/packages/layout/src/components/cards/insurer/i18n.ts
@@ -1,18 +1,16 @@
+import { I18nPreviewViewCommonProps, I18nRemoveViewDateAndConfirm } from '../common/interfaces';
+
+interface I18nInsurerPreviewView extends I18nPreviewViewCommonProps {
+	buttonsAndHeadings: {
+		remove: string;
+		address: string;
+		companiesHouseNumber: string;
+		insurerReferenceNumber: string;
+	}
+}
+
 export type InsurerI18nProps = {
-	preview: {
-		buttons: {
-			one: string;
-			two: string;
-			three: string;
-			four: string;
-			five: string;
-		};
-		statusText: {
-			confirmed: string;
-			unconfirmed: string;
-		};
-		checkboxLabel: string;
-	};
+	preview: I18nInsurerPreviewView;
 	reference: {
 		title: string;
 		subtitle: string;
@@ -26,51 +24,19 @@ export type InsurerI18nProps = {
 			};
 		};
 	};
-	remove: {
-		confirm: {
-			breadcrumbs: {
-				link1: string;
-				link2: string;
-			};
-			title: string;
-			dialog: {
-				message1: string;
-				message2: string;
-			};
-			buttons: {
-				remove: string;
-				cancel: string;
-			};
-		};
-		date: {
-			title: string;
-			fields: {
-				confirm: {
-					label: string;
-				};
-				date: {
-					label: string;
-					hint: string;
-					error: string;
-				};
-			};
-			errors: {
-				formIncomplete: string;
-				dateAddedBeforeEffectiveDate: string;
-				dateAddedInTheFuture: string;
-			};
-		};
-	};
+	remove: I18nRemoveViewDateAndConfirm;
 };
 
 export const i18n: InsurerI18nProps = {
 	preview: {
-		buttons: {
-			one: 'Insurer administrator',
-			two: 'Remove',
-			three: 'Address',
-			four: 'Companies House Number',
-			five: 'Insurer reference number',
+		buttonsAndHeadings: {
+			remove: 'Remove',
+			address: 'Address',
+			companiesHouseNumber: 'Companies House Number',
+			insurerReferenceNumber: 'Insurer reference number',
+		},
+		mainHeadingSubtitle: {
+			main: 'Insurer administrator',
 		},
 		statusText: {
 			confirmed: 'Confirmed',

--- a/packages/layout/src/components/cards/insurer/insurer.tsx
+++ b/packages/layout/src/components/cards/insurer/insurer.tsx
@@ -57,7 +57,7 @@ export const InsurerCard: React.FC<InsurerProviderProps> = React.memo(
 							send={send}
 							current={current}
 						>
-							{i18n.preview.buttons.two}
+							{i18n.preview.buttonsAndHeadings.remove}
 						</CardRemoveButton>
 					);
 
@@ -68,7 +68,7 @@ export const InsurerCard: React.FC<InsurerProviderProps> = React.memo(
 							className={styles.card}
 							ariaLabel={concatenateStrings([
 								current.context.insurer.organisationName,
-								i18n.preview.buttons.one,
+								i18n.preview.mainHeadingSubtitle.main,
 							])}
 						>
 							<Toolbar
@@ -80,7 +80,7 @@ export const InsurerCard: React.FC<InsurerProviderProps> = React.memo(
 								buttonRight={RemoveButton}
 								complete={isComplete(current.context)}
 								subtitle={() => (
-									<Subtitle secondary={i18n.preview.buttons.one} />
+									<Subtitle secondary={i18n.preview.mainHeadingSubtitle.main} />
 								)}
 								statusText={
 									isComplete(current.context)

--- a/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
@@ -26,7 +26,9 @@ export const Preview: React.FC<any> = React.memo(() => {
 			<Flex>
 				{/* Address block: display only	 */}
 				<Flex cfg={{ pr: 4 }} className={styles.section}>
-					<UnderlinedButton>{i18n.preview.buttons.three}</UnderlinedButton>
+					<UnderlinedButton>
+						{i18n.preview.buttonsAndHeadings.address}
+					</UnderlinedButton>
 					<AddressPreview
 						address={{
 							addressLine1: insurer.address.addressLine1,
@@ -41,7 +43,7 @@ export const Preview: React.FC<any> = React.memo(() => {
 
 					{/* Companies House Number: display only	 */}
 					<CompaniesHouseNumber
-						heading={i18n.preview.buttons.four}
+						heading={i18n.preview.buttonsAndHeadings.companiesHouseNumber}
 						companiesHouseNumber={insurer.companiesHouseNumber}
 					/>
 				</Flex>
@@ -55,7 +57,7 @@ export const Preview: React.FC<any> = React.memo(() => {
 						buttonRef={insurerBtn}
 						giveFocus={current.context.lastBtnClicked === 5}
 					>
-						{i18n.preview.buttons.five}
+						{i18n.preview.buttonsAndHeadings.insurerReferenceNumber}
 					</UnderlinedButton>
 					<P className={styles.insurerCompanyRef}>
 						{insurer.insurerCompanyReference}

--- a/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/insurer/views/preview/preview.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
-import { Checkbox } from '@tpr/forms';
-import { Flex, Hr, P, classNames } from '@tpr/core';
+import { Flex, P, classNames } from '@tpr/core';
 import { UnderlinedButton } from '../../../components/button';
+import { CardFooter } from '../../../components/footer';
 import { useInsurerContext } from '../../context';
 import {
 	AddressPreview,
@@ -66,21 +66,17 @@ export const Preview: React.FC<any> = React.memo(() => {
 			</Flex>
 
 			{/*  All details correct - Checkbox	 */}
-			<Flex cfg={{ flexDirection: 'column' }}>
-				<Hr cfg={{ my: 4 }} />
-				<Checkbox
-					value={complete}
-					checked={complete}
-					onChange={() => {
-						send('COMPLETE', { value: !complete });
-						onCorrect(!complete);
-					}}
-					label={i18n.preview.checkboxLabel.replace(
-						'__NAME__',
-						insurer.organisationName,
-					)}
-				/>
-			</Flex>
+			<CardFooter
+				complete={complete}
+				onChange={() => {
+					send('COMPLETE', { value: !complete });
+					onCorrect(!complete);
+				}}
+				label={i18n.preview.checkboxLabel.replace(
+					'__NAME__',
+					insurer.organisationName,
+				)}
+			/>
 		</div>
 	);
 });

--- a/packages/layout/src/components/cards/insurer/views/reference/index.tsx
+++ b/packages/layout/src/components/cards/insurer/views/reference/index.tsx
@@ -58,7 +58,9 @@ export const Reference: React.FC = () => {
 			subtitle={i18n.reference.subtitle}
 			loading={false}
 			sectionTitle={i18n.reference.sectionTitle}
-			subSectionHeaderText={i18n.preview.buttons.four}
+			subSectionHeaderText={
+				i18n.preview.buttonsAndHeadings.insurerReferenceNumber
+			}
 			send={send}
 		>
 			<Form

--- a/packages/layout/src/components/cards/thirdParty/i18n.ts
+++ b/packages/layout/src/components/cards/thirdParty/i18n.ts
@@ -1,11 +1,14 @@
-import { I18nPreviewViewCommonProps, I18nRemoveViewDateAndConfirm } from '../common/interfaces';
+import {
+	I18nPreviewViewCommonProps,
+	I18nRemoveViewDateAndConfirm,
+} from '../common/interfaces';
 
 interface I18nThirdPartyPreviewView extends I18nPreviewViewCommonProps {
 	buttonsAndHeadings: {
 		remove: string;
 		address: string;
-		companiesHouseNumber: string;		
-	}
+		companiesHouseNumber: string;
+	};
 }
 
 export type ThirdPartyI18nProps = {

--- a/packages/layout/src/components/cards/thirdParty/i18n.ts
+++ b/packages/layout/src/components/cards/thirdParty/i18n.ts
@@ -1,17 +1,15 @@
+import { I18nPreviewViewCommonProps, I18nRemoveViewDateAndConfirm } from '../common/interfaces';
+
+interface I18nThirdPartyPreviewView extends I18nPreviewViewCommonProps {
+	buttonsAndHeadings: {
+		remove: string;
+		address: string;
+		companiesHouseNumber: string;		
+	}
+}
+
 export type ThirdPartyI18nProps = {
-	preview: {
-		buttons: {
-			one: string;
-			two: string;
-			three: string;
-			four: string;
-		};
-		statusText: {
-			confirmed: string;
-			unconfirmed: string;
-		};
-		checkboxLabel: string;
-	};
+	preview: I18nThirdPartyPreviewView;
 	reference: {
 		title: string;
 		subtitle: string;
@@ -24,50 +22,18 @@ export type ThirdPartyI18nProps = {
 			};
 		};
 	};
-	remove: {
-		confirm: {
-			breadcrumbs: {
-				link1: string;
-				link2: string;
-			};
-			title: string;
-			dialog: {
-				message1: string;
-				message2: string;
-			};
-			buttons: {
-				remove: string;
-				cancel: string;
-			};
-		};
-		date: {
-			title: string;
-			fields: {
-				confirm: {
-					label: string;
-				};
-				date: {
-					label: string;
-					hint: string;
-					error: string;
-				};
-			};
-			errors: {
-				formIncomplete: string;
-				dateAddedBeforeEffectiveDate: string;
-				dateAddedInTheFuture: string;
-			};
-		};
-	};
+	remove: I18nRemoveViewDateAndConfirm;
 };
 
 export const i18n: ThirdPartyI18nProps = {
 	preview: {
-		buttons: {
-			one: 'Third Party Administrator',
-			two: 'Remove',
-			three: 'Address',
-			four: 'Companies House Number',
+		buttonsAndHeadings: {
+			remove: 'Remove',
+			address: 'Address',
+			companiesHouseNumber: 'Companies House Number',
+		},
+		mainHeadingSubtitle: {
+			main: 'Third Party Administrator',
 		},
 		statusText: {
 			confirmed: 'Confirmed',

--- a/packages/layout/src/components/cards/thirdParty/thirdParty.tsx
+++ b/packages/layout/src/components/cards/thirdParty/thirdParty.tsx
@@ -54,7 +54,7 @@ export const ThirdPartyCard: React.FC<ThirdPartyProviderProps> = React.memo(
 							send={send}
 							current={current}
 						>
-							{i18n.preview.buttons.two}
+							{i18n.preview.buttonsAndHeadings.remove}
 						</CardRemoveButton>
 					);
 
@@ -65,7 +65,7 @@ export const ThirdPartyCard: React.FC<ThirdPartyProviderProps> = React.memo(
 							className={styles.card}
 							ariaLabel={concatenateStrings([
 								current.context.thirdParty.organisationName,
-								i18n.preview.buttons.one,
+								i18n.preview.mainHeadingSubtitle.main,
 							])}
 						>
 							<Toolbar
@@ -76,7 +76,9 @@ export const ThirdPartyCard: React.FC<ThirdPartyProviderProps> = React.memo(
 								)}
 								buttonRight={RemoveButton}
 								complete={isComplete(current.context)}
-								subtitle={() => <Subtitle main={i18n.preview.buttons.one} />}
+								subtitle={() => (
+									<Subtitle main={i18n.preview.mainHeadingSubtitle.main} />
+								)}
 								statusText={
 									isComplete(current.context)
 										? i18n.preview.statusText.confirmed

--- a/packages/layout/src/components/cards/thirdParty/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/thirdParty/views/preview/preview.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Checkbox } from '@tpr/forms';
-import { Flex, Hr, classNames } from '@tpr/core';
+import { Flex, classNames } from '@tpr/core';
 import { UnderlinedButton } from '../../../components/button';
+import { CardFooter } from '../../../components/footer';
 import { useThirdPartyContext } from '../../context';
 import {
 	AddressPreview,
@@ -43,21 +43,17 @@ export const Preview: React.FC<any> = React.memo(() => {
 					/>
 				</Flex>
 			</Flex>
-			<Flex cfg={{ flexDirection: 'column' }}>
-				<Hr cfg={{ my: 4 }} />
-				<Checkbox
-					value={complete}
-					checked={complete}
-					onChange={() => {
-						send('COMPLETE', { value: !complete });
-						onCorrect(!complete);
-					}}
-					label={i18n.preview.checkboxLabel.replace(
-						'__NAME__',
-						thirdParty.organisationName,
-					)}
-				/>
-			</Flex>
+			<CardFooter
+				complete={complete}
+				onChange={() => {
+					send('COMPLETE', { value: !complete });
+					onCorrect(!complete);
+				}}
+				label={i18n.preview.checkboxLabel.replace(
+					'__NAME__',
+					thirdParty.organisationName,
+				)}
+			/>
 		</div>
 	);
 });

--- a/packages/layout/src/components/cards/thirdParty/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/thirdParty/views/preview/preview.tsx
@@ -23,7 +23,9 @@ export const Preview: React.FC<any> = React.memo(() => {
 		>
 			<Flex>
 				<Flex cfg={{ pr: 4 }} className={styles.section}>
-					<UnderlinedButton>{i18n.preview.buttons.three}</UnderlinedButton>
+					<UnderlinedButton>
+						{i18n.preview.buttonsAndHeadings.address}
+					</UnderlinedButton>
 					<AddressPreview
 						address={{
 							addressLine1: thirdParty.address.addressLine1,
@@ -36,7 +38,7 @@ export const Preview: React.FC<any> = React.memo(() => {
 						}}
 					/>
 					<CompaniesHouseNumber
-						heading={i18n.preview.buttons.four}
+						heading={i18n.preview.buttonsAndHeadings.companiesHouseNumber}
 						companiesHouseNumber={thirdParty.companiesHouseNumber}
 					/>
 				</Flex>

--- a/packages/layout/src/components/cards/trustee/i18n.ts
+++ b/packages/layout/src/components/cards/trustee/i18n.ts
@@ -1,78 +1,27 @@
 import { I18nAddressLookup, i18n as AddressI18n } from '@tpr/forms';
 import {
-	I18nRemoveReason,
-	InputErrorMessages,
+	I18nContactsView,
+	I18nNameView,
+	I18nRemoveViewReasonAndConfirm,
 	defaultEmailErrorMessages,
 	defaultPhoneErrorMessages,
+	I18nPreviewViewCommonProps,
 } from '../common/interfaces';
-type PropertyFunction<T> = () => T;
+
+interface I18nTrusteePreviewView extends I18nPreviewViewCommonProps {
+	buttonsAndHeadings: {
+		remove: string;
+		correspondenceAddress: string;
+		contacts: string;
+	};
+}
 
 export type TrusteeI18nProps = {
 	address: I18nAddressLookup;
-	contacts: {
-		title: string;
-		subtitle: string;
-		sectionTitle?: string;
-		fields: {
-			telephone: {
-				label: string;
-				error: InputErrorMessages;
-			};
-			email: {
-				label: string;
-				error: InputErrorMessages;
-			};
-		};
-	};
-	name: {
-		title: string;
-		sectionTitle?: string;
-		fields: {
-			title: {
-				label: string;
-				error: string | PropertyFunction<string | undefined>;
-				maxlength: number;
-			};
-			firstName: {
-				label: string;
-				error: string | PropertyFunction<string | undefined>;
-				maxlength: number;
-			};
-			lastName: {
-				label: string;
-				error: string | PropertyFunction<string | undefined>;
-				maxlength: number;
-			};
-		};
-	};
-	preview: {
-		buttons: {
-			one: string;
-			two: string;
-			three: string;
-			four: string;
-		};
-		statusText: {
-			confirmed: string;
-			unconfirmed: string;
-		};
-		checkboxLabel: string;
-	};
-	remove: {
-		confirm: {
-			title: string;
-			subtitle: string;
-			breadcrumbs: {
-				link1: string;
-				link2: string;
-			};
-			buttons: {
-				remove: string;
-				cancel: string;
-			};
-		};
-		reason: I18nRemoveReason;
-	};
+	contacts: I18nContactsView;
+	name: I18nNameView;
+	preview: I18nTrusteePreviewView;
+	remove: I18nRemoveViewReasonAndConfirm;
 	type: {
 		title: string;
 		subtitle: string;
@@ -144,11 +93,13 @@ export const i18n: TrusteeI18nProps = {
 		},
 	},
 	preview: {
-		buttons: {
-			one: 'Trustee',
-			two: 'Remove',
-			three: 'Correspondence address',
-			four: 'Contact details',
+		buttonsAndHeadings: {
+			remove: 'Remove',
+			correspondenceAddress: 'Correspondence address',
+			contacts: 'Contact details',
+		},
+		mainHeadingSubtitle: {
+			main: 'Trustee',
 		},
 		statusText: {
 			confirmed: 'Confirmed',

--- a/packages/layout/src/components/cards/trustee/trustee.tsx
+++ b/packages/layout/src/components/cards/trustee/trustee.tsx
@@ -9,18 +9,16 @@ import { Preview } from './views/preview';
 import { Toolbar } from '../components/toolbar';
 import Name from './views/name';
 import Type from './views/type/type';
-import Address from '../common/views/address/addressPage';
 import { Contacts } from './views/contacts';
 import RemoveReason from './views/remove/reason/reason';
 import { ConfirmRemove } from './views/remove/confirm';
+import AddressView from './views/address/address';
 import RemovedBox from '../components/removedBox';
 import {
 	CardContentProps,
-	cardType,
 	cardTypeName,
 	IToolbarButtonProps,
 } from '../common/interfaces';
-import { AddressComparer } from '@tpr/forms';
 import { TrusteeContext } from './trusteeMachine';
 import {
 	CardMainHeadingButton,
@@ -38,8 +36,7 @@ const CardContent: React.FC<CardContentProps> = ({
 	enableContactDetails = true,
 	onChangeAddress,
 }) => {
-	const { current, i18n, send, addressAPI } = useTrusteeContext();
-	const { trustee } = current.context;
+	const { current } = useTrusteeContext();
 
 	if (current.matches('preview')) {
 		return <Preview enableContactDetails={enableContactDetails} />;
@@ -54,26 +51,7 @@ const CardContent: React.FC<CardContentProps> = ({
 		current.matches({ edit: { company: 'address' } }) ||
 		current.matches({ edit: { company: 'save' } })
 	) {
-		return (
-			<Address
-				onSubmit={(values) => {
-					if (AddressComparer.areEqual(values.initialValue, values)) {
-						send('CANCEL');
-					} else {
-						send('SAVE', { address: values || {} });
-					}
-				}}
-				initialValue={trustee.address}
-				addressAPI={addressAPI}
-				cardType={cardType.trustee}
-				cardTypeName={cardTypeName.trustee}
-				sectionTitle={i18n.address.sectionTitle}
-				i18n={i18n.address}
-				onCancelChanges={() => send('CANCEL')}
-				subSectionHeaderText={i18n.preview.buttons.three}
-				onChangeAddress={onChangeAddress}
-			/>
-		);
+		return <AddressView onChangeAddress={onChangeAddress} />;
 	} else if (
 		current.matches({ edit: { contact: 'details' } }) ||
 		current.matches({ edit: { contact: 'save' } })
@@ -106,7 +84,7 @@ const ToolbarButton: React.FC<IToolbarButtonProps> = React.memo(
 							edit: { trustee: 'name' },
 						})}
 					>
-						{i18n.preview.buttons.two}
+						{i18n.preview.buttonsAndHeadings.remove}
 					</CardRemoveButton>
 				) : (
 					<CardMainHeadingButton
@@ -114,7 +92,7 @@ const ToolbarButton: React.FC<IToolbarButtonProps> = React.memo(
 						current={current}
 						onClick={() => send('EDIT_TRUSTEE')}
 					>
-						{text ? text : i18n.preview.buttons.one}
+						{text}
 					</CardMainHeadingButton>
 				)}
 			</>
@@ -149,7 +127,7 @@ export const TrusteeCard: React.FC<
 						ariaLabel={concatenateStrings([
 							trusteeName,
 							current.context.trustee.trusteeType,
-							i18n.preview.buttons.one,
+							i18n.preview.mainHeadingSubtitle.main,
 						])}
 					>
 						<Toolbar

--- a/packages/layout/src/components/cards/trustee/views/address/address.tsx
+++ b/packages/layout/src/components/cards/trustee/views/address/address.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { AddressComparer } from '@tpr/forms';
+import Address from '../../../common/views/address/addressPage';
+import {
+	cardType,
+	cardTypeName,
+	IAddressViewProps,
+} from '../../../common/interfaces';
+import { useTrusteeContext } from '../../context';
+
+const AddressView: React.FC<IAddressViewProps> = ({ onChangeAddress }) => {
+	const { current, i18n, send, addressAPI } = useTrusteeContext();
+
+	return (
+		<Address
+			onSubmit={(values) => {
+				if (AddressComparer.areEqual(values.initialValue, values)) {
+					send('CANCEL');
+				} else {
+					send('SAVE', { address: values || {} });
+				}
+			}}
+			initialValue={current.context.trustee.address}
+			addressAPI={addressAPI}
+			cardType={cardType.trustee}
+			cardTypeName={cardTypeName.trustee}
+			sectionTitle={i18n.address.sectionTitle}
+			i18n={i18n.address}
+			onCancelChanges={() => send('CANCEL')}
+			subSectionHeaderText={
+				i18n.preview.buttonsAndHeadings.correspondenceAddress
+			}
+			onChangeAddress={onChangeAddress}
+		/>
+	);
+};
+
+export default React.memo(AddressView);

--- a/packages/layout/src/components/cards/trustee/views/contacts/index.tsx
+++ b/packages/layout/src/components/cards/trustee/views/contacts/index.tsx
@@ -55,7 +55,7 @@ export const Contacts: React.FC = () => {
 			}}
 			fields={fields}
 			send={send}
-			subSectionHeaderText={i18n.preview.buttons.four}
+			subSectionHeaderText={i18n.preview.buttonsAndHeadings.contacts}
 		/>
 	);
 };

--- a/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
@@ -37,7 +37,7 @@ export const Preview: React.FC<CardContentProps> = React.memo(
 							buttonRef={correspondenceBtn}
 							giveFocus={current.context.lastBtnClicked === 3}
 						>
-							{i18n.preview.buttons.three}
+							{i18n.preview.buttonsAndHeadings.correspondenceAddress}
 						</UnderlinedButton>
 						<AddressPreview
 							name={trustee.address.addressLine1}
@@ -62,7 +62,7 @@ export const Preview: React.FC<CardContentProps> = React.memo(
 								buttonRef={contactsBtn}
 								giveFocus={current.context.lastBtnClicked === 4}
 							>
-								{i18n.preview.buttons.four}
+								{i18n.preview.buttonsAndHeadings.contacts}
 							</UnderlinedButton>
 							<ContactDetailsPreview
 								phone={{ value: trustee.telephoneNumber }}

--- a/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
+++ b/packages/layout/src/components/cards/trustee/views/preview/preview.tsx
@@ -1,8 +1,8 @@
 import React, { useRef } from 'react';
-import { Flex, Hr, classNames } from '@tpr/core';
+import { Flex, classNames } from '@tpr/core';
 import { useTrusteeContext } from '../../context';
 import { UnderlinedButton } from '../../../components/button';
-import { Checkbox } from '@tpr/forms';
+import { CardFooter } from '../../../components/footer';
 import {
 	ContactDetailsPreview,
 	AddressPreview,
@@ -73,25 +73,21 @@ export const Preview: React.FC<CardContentProps> = React.memo(
 				</Flex>
 
 				{/*  All details correct - Checkbox	 */}
-				<Flex cfg={{ flexDirection: 'column' }}>
-					<Hr cfg={{ my: 4 }} />
-					<Checkbox
-						value={complete}
-						checked={complete}
-						onChange={() => {
-							send('COMPLETE', { value: !complete });
-							onCorrect(!complete);
-						}}
-						label={i18n.preview.checkboxLabel.replace(
-							'__NAME__',
-							concatenateStrings([
-								trustee.title,
-								trustee.firstName,
-								trustee.lastName,
-							]),
-						)}
-					/>
-				</Flex>
+				<CardFooter
+					complete={complete}
+					onChange={() => {
+						send('COMPLETE', { value: !complete });
+						onCorrect(!complete);
+					}}
+					label={i18n.preview.checkboxLabel.replace(
+						'__NAME__',
+						concatenateStrings([
+							trustee.title,
+							trustee.firstName,
+							trustee.lastName,
+						]),
+					)}
+				/>
 			</div>
 		);
 	},


### PR DESCRIPTION
#### Fixes [AB#110654](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/110654) 

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable Azure Pipelines for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- refactoring `i18n` common props 
- renaming `buttons` prop of i18n to `buttonsAndHeadings` which contains the dictionary entries for the buttons and headings of the cards, apart from the main heading which now displays the organisation/person name, provided through the data and not via dictionary.
- moving `Address` view declaration to a separate component apart from `CardContentSwitch` for (inHouse and Trustee cards)
- section with checkbox "Confirm details are correct" moved to a separate component `CardFooter`
- add missing button for `Employer type` section.
