### PR TITLE
Bugfix/108739 poscon spacing

### DIFF
--- a/packages/layout/src/components/__tests__/poscon.spec.tsx
+++ b/packages/layout/src/components/__tests__/poscon.spec.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import { Poscon } from '../poscon/poscon';
+import { axe } from 'jest-axe';
+import { act } from 'react-dom/test-utils';
+import userEvent from '@testing-library/user-event';
+
+const hello: string = 'Hello!';
+const close: string = 'I can be closed';
+
+describe('Poscon component', () => {
+	beforeEach(() => {
+		cleanup();
+	});
+
+	describe('default Poscon', () => {
+		test('is accessible', async () => {
+			const { container } = render(<Poscon>{hello}</Poscon>);
+
+			const results = await axe(container);
+			expect(results).toHaveNoViolations();
+		});
+
+		test('component renders correctly', () => {
+			const { getByText } = render(
+				<Poscon>
+					<p>{hello}</p>
+				</Poscon>,
+			);
+
+			expect(getByText(hello)).toBeDefined();
+		});
+	});
+
+	describe('closable Poscon', () => {
+		afterEach(() => {
+			cleanup();
+		});
+
+		test('is accessible', async () => {
+			const { container } = render(<Poscon enableClose={true}>{hello}</Poscon>);
+
+			const results = await axe(container);
+			expect(results).toHaveNoViolations();
+		});
+
+		test('component renders correctly', () => {
+			const { getByText } = render(
+				<Poscon enableClose={true}>
+					<p>{close}</p>
+				</Poscon>,
+			);
+
+			expect(getByText(close)).toBeDefined();
+		});
+
+		test('callback function executes', () => {
+			const cb = jest.fn();
+
+			const { getByTestId } = render(
+				<Poscon enableClose={true} callback={cb}>
+					<p>{close}</p>
+				</Poscon>,
+			);
+
+			const closeButton = getByTestId('cross');
+
+			act(() => {
+				userEvent.click(closeButton);
+			});
+
+			expect(cb).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/layout/src/components/poscon/components/closablePoscon.tsx
+++ b/packages/layout/src/components/poscon/components/closablePoscon.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { CrossButton } from '../../buttons/buttons';
+import { ClosablePosconProps } from './types';
+import { PersistentPoscon } from './persistentPoscon';
+import Styles from '../poscon.module.scss';
+
+export const ClosablePoscon: React.FC<ClosablePosconProps> = React.memo(
+	({ cfg, callback, closeButtonColor, children }) => {
+		const [closed, setClosed] = useState<boolean>(false);
+
+		const CloseButton: React.FC = () => (
+			<div className={Styles.closeButton}>
+				<CrossButton
+					colour={closeButtonColor}
+					onClick={() => {
+						setClosed(!closed);
+						callback && callback();
+					}}
+				/>
+			</div>
+		);
+
+		return (
+			<>
+				{!closed && (
+					<div className={Styles.wrapper}>
+						<CloseButton />
+						<PersistentPoscon cfg={cfg}>{children}</PersistentPoscon>
+					</div>
+				)}
+			</>
+		);
+	},
+);

--- a/packages/layout/src/components/poscon/components/persistentPoscon.tsx
+++ b/packages/layout/src/components/poscon/components/persistentPoscon.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Flex } from '@tpr/core';
+import { PersistentPosconProps } from './/types';
+
+export const PersistentPoscon: React.FC<PersistentPosconProps> = React.memo(
+	({ cfg, children }) => {
+		return (
+			<Flex cfg={cfg} role="alert">
+				{children}
+			</Flex>
+		);
+	},
+);

--- a/packages/layout/src/components/poscon/components/types.ts
+++ b/packages/layout/src/components/poscon/components/types.ts
@@ -1,0 +1,35 @@
+import {
+	BackgroundProps,
+	ColorProps,
+	ColorsFullRange,
+	CursorProps,
+	FlexProps,
+	SpaceProps,
+	TypographyProps,
+} from '@tpr/core';
+
+export type PosconCfgType = FlexProps &
+	SpaceProps &
+	BackgroundProps &
+	ColorProps &
+	CursorProps &
+	TypographyProps;
+
+export interface PersistentPosconProps {
+	cfg?: PosconCfgType;
+}
+
+export type CloseButtonColor = 'white' | 'black';
+
+export interface ClosablePosconProps extends PersistentPosconProps {
+	callback?: Function;
+	closeButtonColor?: CloseButtonColor;
+}
+
+export interface PosconProps {
+	callback?: Function;
+	cfg?: PosconCfgType;
+	closeButtonColor?: CloseButtonColor;
+	color?: ColorsFullRange;
+	enableClose?: boolean;
+}

--- a/packages/layout/src/components/poscon/poscon.mdx
+++ b/packages/layout/src/components/poscon/poscon.mdx
@@ -7,7 +7,7 @@ route: /layout/poscon
 import { Playground } from '@playground';
 import { Props } from 'docz';
 import { Poscon } from './poscon';
-import { H3, P } from '@tpr/core';
+import { H1, H3, P } from '@tpr/core';
 
 # Poscon Banner
 
@@ -23,8 +23,8 @@ import { Poscon } from '@tpr/layout';
 
 <Playground>
 	<Poscon>
-		<p>Section Complete</p>
-		<p>Information about section</p>
+		<p style={{ color: 'white' }}>Section Complete</p>
+		<p style={{ color: 'white' }}>Information about section</p>
 	</Poscon>
 </Playground>
 
@@ -48,9 +48,38 @@ import { Poscon } from '@tpr/layout';
 
 <Playground>
 	<Poscon enableClose={true}>
-		<H3>Poscon section</H3>
-		<P>Section complete</P>
+		<H3 cfg={{ color: 'white', my: 4 }}>Poscon section</H3>
+		<P cfg={{ color: 'white' }}>
+			You successfully submitted your scheme return for 10000168, The Pilot's
+			National Pension Fund on 2/9/2021 at 09:42 to The Pensions Regulator. You
+			can go home and relax now.
+		</P>
 	</Poscon>
+</Playground>
+
+### the "cfg" prop allows to override the default props for the Flex container.
+
+<Playground>
+	{() => {
+		const posconStyles = {
+			flexDirection: 'row',
+			bg: 'neutral.3',
+			px: 4,
+			pb: 2,
+		};
+		return (
+			<Poscon cfg={posconStyles} enableClose={true} closeButtonColor="black">
+				<H1 cfg={{ pr: 4 }}>Section Complete</H1>
+				<P cfg={{ textAlign: 'right' }}>
+					You successfully submitted your scheme return for 10000168, The
+					Pilot's National Pension Fund on 2/9/2021 at 09:42 to The Pensions
+					Regulator.
+					<br />
+					You can go home and relax now.
+				</P>
+			</Poscon>
+		);
+	}}
 </Playground>
 
 ## API

--- a/packages/layout/src/components/poscon/poscon.module.scss
+++ b/packages/layout/src/components/poscon/poscon.module.scss
@@ -1,5 +1,11 @@
-.enableClose {
-	margin-right: 0.9375rem;
-	margin-left: auto;
-	align-self: flex-start;
+@import '@tpr/theming/lib/variables.scss';
+
+.wrapper {
+	position: relative;
+
+	.closeButton {
+		position: absolute;
+		top: $space-4;
+		right: $space-3;
+	}
 }

--- a/packages/layout/src/components/poscon/poscon.tsx
+++ b/packages/layout/src/components/poscon/poscon.tsx
@@ -1,82 +1,42 @@
-import React, { useState } from 'react';
-import { ColorsFullRange, Flex, ValuesFullRange } from '@tpr/core';
-import { CrossButton } from '../buttons/buttons';
-import Styles from './poscon.module.scss';
-
-export type PosconProps = {
-	color?: ColorsFullRange;
-	enableClose?: boolean;
-	callback?: Function;
-};
+import React from 'react';
+import { ClosablePoscon } from './components/closablePoscon';
+import { PersistentPoscon } from './components/persistentPoscon';
+import { PosconCfgType, PosconProps } from './components/types';
 
 export const Poscon: React.FC<PosconProps> = ({
+	callback,
+	cfg,
+	closeButtonColor = 'white',
 	color = 'success.1',
 	enableClose = false,
-	callback,
 	children,
 }) => {
+	const defaultstyles: PosconCfgType = {
+		flexDirection: 'column',
+		alignItems: 'center',
+		justifyContent: 'center',
+		bg: color,
+		pl: 10,
+		pr: 10,
+		pt: enableClose ? 10 : 6,
+		pb: enableClose ? 10 : 6,
+		textAlign: 'center',
+	};
+
+	const posconCfg: PosconCfgType = {
+		...defaultstyles,
+		...cfg,
+	};
+
 	return enableClose ? (
-		<ClosablePoscon color={color} callback={callback}>
+		<ClosablePoscon
+			cfg={posconCfg}
+			callback={callback}
+			closeButtonColor={closeButtonColor}
+		>
 			{children}
 		</ClosablePoscon>
 	) : (
-		<PersistentPoscon color={color}>{children}</PersistentPoscon>
-	);
-};
-
-export type ClosablePosconProps = {
-	color?: ColorsFullRange;
-	callback?: Function;
-};
-
-const ClosablePoscon: React.FC<ClosablePosconProps> = ({
-	color,
-	callback,
-	children,
-}) => {
-	const [closed, setClosed] = useState<boolean>(false);
-	return !closed ? (
-		<PersistentPoscon color={color} pt={4}>
-			<div className={Styles.enableClose}>
-				<CrossButton
-					colour={'white'}
-					onClick={() => {
-						setClosed(!closed);
-						callback && callback();
-					}}
-				/>
-			</div>
-			{children}
-		</PersistentPoscon>
-	) : (
-		<></>
-	);
-};
-
-export type PersistentPosconProps = {
-	color?: ColorsFullRange;
-	pt?: ValuesFullRange;
-};
-
-const PersistentPoscon: React.FC<PersistentPosconProps> = ({
-	color,
-	pt = 8,
-	children,
-}) => {
-	return (
-		<Flex
-			cfg={{
-				alignItems: 'center',
-				justifyContent: 'center',
-				bg: color,
-				pb: 6,
-				pt: pt,
-				flexDirection: 'column',
-				textAlign: 'center',
-			}}
-			role="alert"
-		>
-			{children}
-		</Flex>
+		<PersistentPoscon cfg={posconCfg}>{children}</PersistentPoscon>
 	);
 };


### PR DESCRIPTION
#### Fixes [AB#108739](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/108739)

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable Azure Pipelines for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Refactor `Poscon` component
- add unit tests
- add `cfg` prop to allow modifying more styles of the container
- add `closebuttonColor` prop to allow choose the color for the closing button ("white" | "black")