### PR TITLE
Bugfix/111182 confirm remove error message

### DIFF
--- a/packages/forms/src/elements/checkbox/checkbox.mdx
+++ b/packages/forms/src/elements/checkbox/checkbox.mdx
@@ -185,6 +185,32 @@ Horizontal layout will only be used where there are two checkboxes buttons with 
 
 </Playground>
 
+### Field level validation
+
+<Playground>
+	{() => {
+		return (
+			<Form onSubmit={(values) => console.log(values)}>
+				{({ handleSubmit }) => (
+					<form noValidate onSubmit={handleSubmit}>
+						<FFCheckbox
+							id="checkbox-z"
+							name="checkbox-z"
+							label="Confirm these details are correct"
+							validate={(value) => {
+								if (!value) {
+									return 'Confirm details are correct to continue';
+								}
+							}}
+						></FFCheckbox>
+						<button type="submit">Submit</button>
+					</form>
+				)}
+			</Form>
+		);
+	}}
+</Playground>
+
 ## API
 
 ```

--- a/packages/forms/src/elements/checkbox/checkbox.tsx
+++ b/packages/forms/src/elements/checkbox/checkbox.tsx
@@ -3,7 +3,7 @@ import { Field, FieldRenderProps } from 'react-final-form';
 import { P } from '@tpr/core';
 import { FieldProps, FieldExtraProps } from '../../renderFields';
 import { CheckboxChecked, CheckboxBlank } from './icons';
-import { StyledInputLabel } from '../elements';
+import { ErrorMessage, StyledInputLabel } from '../elements';
 import { HiddenInput } from '../hidden/hidden';
 import styles from './checkbox.module.scss';
 import AccessibilityHelper from '../accessibilityHelper';
@@ -19,6 +19,7 @@ export const Checkbox: React.FC<Partial<CheckboxIconProps>> = ({
 	onChange,
 	label,
 	hint,
+	meta,
 	className,
 	children,
 }) => {
@@ -36,6 +37,7 @@ export const Checkbox: React.FC<Partial<CheckboxIconProps>> = ({
 				},
 				cfg,
 			)}
+			isError={meta && meta.error && meta.touched}
 		>
 			<label
 				id={helper && helper.labelId}
@@ -43,6 +45,11 @@ export const Checkbox: React.FC<Partial<CheckboxIconProps>> = ({
 				className={styles.wrapper}
 				htmlFor={id}
 			>
+				{meta && meta.touched && meta.touched && (
+					<ErrorMessage id={helper.errorId} role="alert">
+						{meta.error}
+					</ErrorMessage>
+				)}
 				<div className={styles.innerWrapper}>
 					<HiddenInput
 						id={id}

--- a/packages/forms/src/elements/number/number.mdx
+++ b/packages/forms/src/elements/number/number.mdx
@@ -9,7 +9,6 @@ import { Form } from 'react-final-form';
 import { FFInputNumber } from './number';
 import { validate } from '../../validation';
 import { renderFields } from '../../renderFields';
-import { StyledInputLabelWithSubscription } from '../elements';
 import { FFCheckbox } from '@tpr/forms';
 import styles from './input.module.scss';
 

--- a/packages/layout/src/components/__tests__/employer.spec.tsx
+++ b/packages/layout/src/components/__tests__/employer.spec.tsx
@@ -198,7 +198,7 @@ describe('Employer Remove', () => {
 		userEvent.click(getByText('Continue'));
 
 		expect(
-			getByText('Please confirm and fill in the date fields.'),
+			getByText('Confirm this employer is no longer associated'),
 		).toBeInTheDocument();
 	});
 

--- a/packages/layout/src/components/__tests__/inHouse.spec.tsx
+++ b/packages/layout/src/components/__tests__/inHouse.spec.tsx
@@ -364,7 +364,7 @@ describe('InHouse Remove', () => {
 		userEvent.click(getByText('Continue'));
 
 		expect(
-			getByText('Please confirm and fill in the date fields.'),
+			getByText('Confirm this employer is no longer associated'),
 		).toBeInTheDocument();
 	});
 

--- a/packages/layout/src/components/__tests__/insurer.spec.tsx
+++ b/packages/layout/src/components/__tests__/insurer.spec.tsx
@@ -183,7 +183,7 @@ describe('Insurer Remove', () => {
 		});
 
 		expect(
-			getByText('Please confirm and fill in the date fields.'),
+			getByText('Confirm this employer is no longer associated'),
 		).toBeInTheDocument();
 	});
 

--- a/packages/layout/src/components/__tests__/thirdParty.spec.tsx
+++ b/packages/layout/src/components/__tests__/thirdParty.spec.tsx
@@ -177,7 +177,7 @@ describe('ThirdParty Remove', () => {
 		});
 
 		expect(
-			getByText('Please confirm and fill in the date fields.'),
+			getByText('Confirm this employer is no longer associated'),
 		).toBeInTheDocument();
 	});
 

--- a/packages/layout/src/components/cards/actuary/i18n.ts
+++ b/packages/layout/src/components/cards/actuary/i18n.ts
@@ -105,6 +105,7 @@ export const i18n: ActuaryI18nProps = {
 				},
 			},
 			errors: {
+				confirmMissing: 'Confirm this employer is no longer associated',
 				formIncomplete: 'Please confirm and fill in the date fields.',
 				dateAddedBeforeEffectiveDate:
 					'Date must be after the Employer was added.',

--- a/packages/layout/src/components/cards/actuary/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/actuary/views/remove/date/date.tsx
@@ -36,13 +36,7 @@ export const RemoveDateForm = () => {
 	];
 
 	const onSubmit = (values) => {
-		if (!values.confirm) {
-			return {
-				[FORM_ERROR]: i18n.remove.date.errors.formIncomplete,
-			};
-		} else {
-			send('NEXT', { values });
-		}
+		send('NEXT', { values });
 	};
 
 	return (
@@ -51,6 +45,7 @@ export const RemoveDateForm = () => {
 			onSubmit={onSubmit}
 			remove={remove}
 			label={i18n.remove.date.fields.confirm.label}
+			checkboxErrorMessage={i18n.remove.date.errors.confirmMissing}
 			dateField={DateField}
 			type={cardType.actuary}
 			typeName={cardTypeName.actuary}

--- a/packages/layout/src/components/cards/actuary/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/actuary/views/remove/date/date.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FORM_ERROR } from 'final-form';
 import { FieldProps } from '@tpr/forms';
 import { useActuaryContext } from '../../../context';
 import { isAfter, toDate, isBefore } from 'date-fns';

--- a/packages/layout/src/components/cards/common/interfaces.ts
+++ b/packages/layout/src/components/cards/common/interfaces.ts
@@ -168,6 +168,7 @@ export interface I18nRemoveViewDateAndConfirm {
 			};
 		};
 		errors: {
+			confirmMissing: string;
 			formIncomplete: string;
 			dateAddedBeforeEffectiveDate: string;
 			dateAddedInTheFuture: string;

--- a/packages/layout/src/components/cards/common/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/date/date.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, P } from '@tpr/core';
+import { Link } from '@tpr/core';
 import { Form, FFCheckbox, renderFields, FieldProps } from '@tpr/forms';
 import { Content } from '../../../../components/content';
 import { Footer } from '../../../../components/card';

--- a/packages/layout/src/components/cards/common/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/date/date.tsx
@@ -12,6 +12,7 @@ interface DateFormProps {
 	onSubmit: (any) => void;
 	remove: any;
 	label: string;
+	checkboxErrorMessage: string;
 	dateField: FieldProps[];
 	type: cardType;
 	typeName: cardTypeName;
@@ -23,6 +24,7 @@ const DateForm: React.FC<DateFormProps> = ({
 	onSubmit,
 	remove,
 	label,
+	checkboxErrorMessage,
 	dateField,
 	type,
 	typeName,
@@ -40,24 +42,25 @@ const DateForm: React.FC<DateFormProps> = ({
 					date: remove && remove.date && new Date(remove.date),
 				}}
 			>
-				{({ handleSubmit, submitError }) => (
+				{({ handleSubmit }) => (
 					<form onSubmit={handleSubmit} data-testid={testId} noValidate>
 						<div aria-describedby={errorMsg}>
 							<FFCheckbox
+								id="confirm"
 								name="confirm"
 								type="checkbox"
 								label={label}
+								validate={(value) => {
+									if (!value) {
+										return checkboxErrorMessage;
+									}
+								}}
 								cfg={{ mb: 3 }}
 							/>
 							<div className={styles.dateWrapper}>
 								{renderFields(dateField)}
 							</div>
 						</div>
-						{submitError && (
-							<P id={errorMsg} className={styles.errorMsg}>
-								{submitError}
-							</P>
-						)}
 						<Footer>
 							<ArrowButton
 								appearance="secondary"

--- a/packages/layout/src/components/cards/employer/i18n.ts
+++ b/packages/layout/src/components/cards/employer/i18n.ts
@@ -150,6 +150,7 @@ export const i18n: EmployerI18nProps = {
 				},
 			},
 			errors: {
+				confirmMissing: 'Confirm this employer is no longer associated',
 				formIncomplete: 'Please confirm and fill in the date fields.',
 				dateAddedBeforeEffectiveDate:
 					'Date must be after the Employer was added.',

--- a/packages/layout/src/components/cards/employer/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/employer/views/remove/date/date.tsx
@@ -36,13 +36,7 @@ export const RemoveDateForm: React.FC = () => {
 	];
 
 	const onSubmit = (values) => {
-		if (!values.confirm) {
-			return {
-				[FORM_ERROR]: i18n.remove.date.errors.formIncomplete,
-			};
-		} else {
-			send('NEXT', { values });
-		}
+		send('NEXT', { values });
 	};
 
 	return (
@@ -51,6 +45,7 @@ export const RemoveDateForm: React.FC = () => {
 			onSubmit={onSubmit}
 			remove={remove}
 			label={i18n.remove.date.fields.confirm.label}
+			checkboxErrorMessage={i18n.remove.date.errors.confirmMissing}
 			dateField={DateField}
 			type={cardType.employer}
 			typeName={cardTypeName.employer}

--- a/packages/layout/src/components/cards/employer/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/employer/views/remove/date/date.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FORM_ERROR } from 'final-form';
 import { FieldProps } from '@tpr/forms';
 import { useEmployerContext } from '../../../context';
 import { isAfter, toDate, isBefore } from 'date-fns';

--- a/packages/layout/src/components/cards/inHouse/i18n.ts
+++ b/packages/layout/src/components/cards/inHouse/i18n.ts
@@ -112,6 +112,7 @@ export const i18n: InHouseAdminI18nProps = {
 				},
 			},
 			errors: {
+				confirmMissing: 'Confirm this employer is no longer associated',
 				formIncomplete: 'Please confirm and fill in the date fields.',
 				dateAddedBeforeEffectiveDate:
 					'Date must be after the Employer was added.',

--- a/packages/layout/src/components/cards/inHouse/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/inHouse/views/remove/date/date.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FORM_ERROR } from 'final-form';
 import { FieldProps } from '@tpr/forms';
 import { useInHouseAdminContext } from '../../../context';
 import { isAfter, toDate, isBefore } from 'date-fns';
@@ -36,13 +35,7 @@ export const RemoveDateForm: React.FC = () => {
 	];
 
 	const onSubmit = (values) => {
-		if (!values.confirm) {
-			return {
-				[FORM_ERROR]: i18n.remove.date.errors.formIncomplete,
-			};
-		} else {
-			send('NEXT', { values });
-		}
+		send('NEXT', { values });
 	};
 
 	return (
@@ -51,6 +44,7 @@ export const RemoveDateForm: React.FC = () => {
 			onSubmit={onSubmit}
 			remove={remove}
 			label={i18n.remove.date.fields.confirm.label}
+			checkboxErrorMessage={i18n.remove.date.errors.confirmMissing}
 			dateField={DateField}
 			type={cardType.inHouseAdmin}
 			typeName={cardTypeName.inHouseAdmin}

--- a/packages/layout/src/components/cards/insurer/i18n.ts
+++ b/packages/layout/src/components/cards/insurer/i18n.ts
@@ -91,6 +91,7 @@ export const i18n: InsurerI18nProps = {
 				},
 			},
 			errors: {
+				confirmMissing: 'Confirm this employer is no longer associated',
 				formIncomplete: 'Please confirm and fill in the date fields.',
 				dateAddedBeforeEffectiveDate:
 					'Date must be after the Insurer was added.',

--- a/packages/layout/src/components/cards/insurer/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/insurer/views/remove/date/date.tsx
@@ -35,13 +35,7 @@ export const RemoveDateForm: React.FC = () => {
 		},
 	];
 	const onSubmit = (values) => {
-		if (!values.confirm) {
-			return {
-				[FORM_ERROR]: i18n.remove.date.errors.formIncomplete,
-			};
-		} else {
-			send('NEXT', { values });
-		}
+		send('NEXT', { values });
 	};
 
 	return (
@@ -50,6 +44,7 @@ export const RemoveDateForm: React.FC = () => {
 			onSubmit={onSubmit}
 			remove={remove}
 			label={i18n.remove.date.fields.confirm.label}
+			checkboxErrorMessage={i18n.remove.date.errors.confirmMissing}
 			dateField={DateField}
 			type={cardType.insurer}
 			typeName={cardTypeName.insurer}

--- a/packages/layout/src/components/cards/insurer/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/insurer/views/remove/date/date.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FORM_ERROR } from 'final-form';
 import { FieldProps } from '@tpr/forms';
 import { useInsurerContext } from '../../../context';
 import { isAfter, toDate, isBefore } from 'date-fns';

--- a/packages/layout/src/components/cards/thirdParty/i18n.ts
+++ b/packages/layout/src/components/cards/thirdParty/i18n.ts
@@ -88,6 +88,7 @@ export const i18n: ThirdPartyI18nProps = {
 				},
 			},
 			errors: {
+				confirmMissing: 'Confirm this employer is no longer associated',
 				formIncomplete: 'Please confirm and fill in the date fields.',
 				dateAddedBeforeEffectiveDate:
 					'Date must be after the third party admin was added.',

--- a/packages/layout/src/components/cards/thirdParty/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/thirdParty/views/remove/date/date.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FORM_ERROR } from 'final-form';
 import { FieldProps } from '@tpr/forms';
 import { useThirdPartyContext } from '../../../context';
 import { isAfter, toDate, isBefore } from 'date-fns';

--- a/packages/layout/src/components/cards/thirdParty/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/thirdParty/views/remove/date/date.tsx
@@ -36,13 +36,7 @@ export const RemoveDateForm: React.FC = () => {
 	];
 
 	const onSubmit = (values) => {
-		if (!values.confirm) {
-			return {
-				[FORM_ERROR]: i18n.remove.date.errors.formIncomplete,
-			};
-		} else {
-			send('NEXT', { values });
-		}
+		send('NEXT', { values });
 	};
 
 	return (
@@ -51,6 +45,7 @@ export const RemoveDateForm: React.FC = () => {
 			onSubmit={onSubmit}
 			remove={remove}
 			label={i18n.remove.date.fields.confirm.label}
+			checkboxErrorMessage={i18n.remove.date.errors.confirmMissing}
 			dateField={DateField}
 			type={cardType.thirdParty}
 			typeName={cardTypeName.thirdParty}


### PR DESCRIPTION
#### Fixes [AB#111182](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/111182)

#### Checklist

- [ ] Includes tests
- [X] Update documentation

<!-- DO NOT enable Azure Pipelines for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Added error messages to checkboxes
- Used field validation instead of validation on submit in the common -> remove -> date component
- Added a new error message in i18n

#### Reviewers should focus on:

- Changes to checkboxes
- The remove view of:
  -  employer
  - insurer admin
  - inhouse admin
  - third-party admin
  - scheme acturary

#### Screenshot
Checkbox with a validation error
![image](https://user-images.githubusercontent.com/25232112/136992379-b95e7e16-f35a-4d48-a005-f1ae1cf28d91.png)

