### PR TITLE
AB#110026 add URl as a field type with demo

### DIFF
--- a/packages/forms/src/__tests__/text.spec.tsx
+++ b/packages/forms/src/__tests__/text.spec.tsx
@@ -138,7 +138,15 @@ describe('Text input', () => {
 		const results = await axe(container);
 		expect(results).toHaveNoViolations();
 	});
+	test('has type URL', async () => {
+		const { getByTestId } = formSetup({
+			render: (
+				<FFInputText label="URL" testId="url-field" name="URL" type="url" />
+			),
+		});
 
+		expect(getByTestId('url-field')).toHaveAttribute('type', 'url');
+	});
 	test('shows error message on required field when left empty', () => {
 		const fields: FieldProps[] = [
 			{

--- a/packages/forms/src/elements/text/text.mdx
+++ b/packages/forms/src/elements/text/text.mdx
@@ -116,6 +116,26 @@ import { Form, validate, renderFields } from '@tpr/forms';
 	}}
 </Playground>
 
+### Example with URL as type
+
+<Playground>
+	<Form onSubmit={console.log}>
+		{({ handleSubmit }) => (
+			<form onSubmit={handleSubmit} noValidate>
+				<FFInputText
+					type="url"
+					name="event_url"
+					label="Event URl"
+					cfg={{ my: 5 }}
+					inputClassName={textStyles.textInput}
+					required
+				/>
+				<button type="submit" style={{ display: 'none' }} children="Submit" />
+			</form>
+		)}
+	</Form>
+</Playground>
+
 ## API
 
 ```

--- a/packages/forms/src/renderFields.tsx
+++ b/packages/forms/src/renderFields.tsx
@@ -21,7 +21,7 @@ export type FieldInputTypes =
 	| 'phone'
 	| 'email'
 	| 'hidden'
-	| 'ur;';
+	| 'url';
 
 export type FieldOptions = {
 	label: string;

--- a/packages/forms/src/renderFields.tsx
+++ b/packages/forms/src/renderFields.tsx
@@ -20,7 +20,8 @@ export type FieldInputTypes =
 	| 'select'
 	| 'phone'
 	| 'email'
-	| 'hidden';
+	| 'hidden'
+	| 'ur;';
 
 export type FieldOptions = {
 	label: string;


### PR DESCRIPTION
#### Fixes [AB#110026](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/110026)

#### Checklist

- [x] Includes tests
- [X] Update documentation

<!-- DO NOT enable Azure Pipelines for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Added `url` to the list of available `FieldTypes`

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
