### PR TITLE
AB#109719 fucus issue fix

### DIFF
--- a/packages/forms/src/elements/address/addressLookup.tsx
+++ b/packages/forms/src/elements/address/addressLookup.tsx
@@ -59,6 +59,7 @@ export const AddressLookup: React.FC<AddressProps> = ({
 	const [addresses, setAddresses] = useState<Address[]>([]);
 	const [address, setAddress] = useState<Address | null>(null);
 	const [postcode, setPostcode] = useState<string>(null);
+  const [focusOnAddressLine1,setFocusOnAddressLine1] = useState(false)
 
 	useEffect(() => {
 		if (setSubmitButton) {
@@ -112,6 +113,7 @@ export const AddressLookup: React.FC<AddressProps> = ({
 					onAddressSelected={(selectedAddress) => {
 						setAddress(selectedAddress);
 						setAddressView(AddressView.EditAddress);
+						setFocusOnAddressLine1(true)
 					}}
 					postcodeLookupLabel={postcodeLookupLabel}
 					changePostcodeButton={changePostcodeButton}
@@ -154,6 +156,7 @@ export const AddressLookup: React.FC<AddressProps> = ({
 						countryLabel={countryLabel}
 						changeAddressButton={changeAddressButton}
 						headingLevel={headingLevel}
+						focusOnAdressLine1={focusOnAddressLine1}
 					/>
 				)}
 			</div>

--- a/packages/forms/src/elements/address/editAddress.tsx
+++ b/packages/forms/src/elements/address/editAddress.tsx
@@ -25,6 +25,7 @@ export const EditAddress: React.FC<EditAddressProps> = React.memo(
 		countryLabel,
 		changeAddressButton,
 		headingLevel = 2,
+		focusOnAdressLine1,
 	}) => {
 		const form = useForm();
 
@@ -32,7 +33,6 @@ export const EditAddress: React.FC<EditAddressProps> = React.memo(
 			const selectedAddress = form.getFieldState('selectedAddress');
 			return selectedAddress && selectedAddress.dirty;
 		};
-
 		const renderNonEditableFieldWithUpdates = (
 			fieldName: string,
 			label?: string,
@@ -85,7 +85,9 @@ export const EditAddress: React.FC<EditAddressProps> = React.memo(
 		const address2ref = useRef(null);
 
 		useEffect(() => {
+	  if(focusOnAdressLine1){
 			address1ref.current && address1ref.current.focus();
+			}
 		}, [address1ref]);
 
 		useEffect(() => {

--- a/packages/forms/src/elements/address/types/EditAddressProps.ts
+++ b/packages/forms/src/elements/address/types/EditAddressProps.ts
@@ -16,4 +16,5 @@ export interface EditAddressProps {
 	countryLabel: string;
 	changeAddressButton: string;
 	headingLevel?: number;
+	focusOnAdressLine1?:boolean;
 }


### PR DESCRIPTION
#### Fixes AB#0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable Azure Pipelines for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Address line 1 on Scheme Address page should only be focused after Select Address has been clicked. On initial entry to the page Address line 1 should not be focused.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
