### PR TITLE
Bugfix/112661 radio button children

### DIFF
--- a/packages/forms/src/__tests__/radio.spec.tsx
+++ b/packages/forms/src/__tests__/radio.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { formSetup } from '../__mocks__/setup';
 import { FFRadioButton } from '../elements/radio/radio';
-import { renderFields } from '../index';
+import { FFInputText, renderFields } from '../index';
 import { fireEvent, getByTestId } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { FieldProps } from '../../lib/renderFields';
@@ -214,5 +214,19 @@ describe('Radio input', () => {
 		const label = container.querySelector(`[id=${id}-label]`);
 		expect(label).not.toBeNull();
 		expect(label).toHaveAttribute('for', id);
+	});
+	test('renders child components', () => {
+		// Arrange
+		const childId = 'childId';
+		// Act
+		const { getByTestId } = formSetup({
+			render: (
+				<FFRadioButton value="a" label="a" name="a" id="radio_a">
+					<FFInputText id={childId} name="phoneNumber" testId={childId} />
+				</FFRadioButton>
+			),
+		});
+		// Assert
+		expect(getByTestId(childId)).toBeInTheDocument();
 	});
 });

--- a/packages/forms/src/elements/address/addressLookup.tsx
+++ b/packages/forms/src/elements/address/addressLookup.tsx
@@ -59,7 +59,7 @@ export const AddressLookup: React.FC<AddressProps> = ({
 	const [addresses, setAddresses] = useState<Address[]>([]);
 	const [address, setAddress] = useState<Address | null>(null);
 	const [postcode, setPostcode] = useState<string>(null);
-  const [focusOnAddressLine1,setFocusOnAddressLine1] = useState(false)
+	const [focusOnAddressLine1, setFocusOnAddressLine1] = useState(false);
 
 	useEffect(() => {
 		if (setSubmitButton) {
@@ -113,7 +113,7 @@ export const AddressLookup: React.FC<AddressProps> = ({
 					onAddressSelected={(selectedAddress) => {
 						setAddress(selectedAddress);
 						setAddressView(AddressView.EditAddress);
-						setFocusOnAddressLine1(true)
+						setFocusOnAddressLine1(true);
 					}}
 					postcodeLookupLabel={postcodeLookupLabel}
 					changePostcodeButton={changePostcodeButton}

--- a/packages/forms/src/elements/address/editAddress.tsx
+++ b/packages/forms/src/elements/address/editAddress.tsx
@@ -85,8 +85,8 @@ export const EditAddress: React.FC<EditAddressProps> = React.memo(
 		const address2ref = useRef(null);
 
 		useEffect(() => {
-	  if(focusOnAdressLine1){
-			address1ref.current && address1ref.current.focus();
+			if (focusOnAdressLine1) {
+				address1ref.current && address1ref.current.focus();
 			}
 		}, [address1ref]);
 

--- a/packages/forms/src/elements/address/types/EditAddressProps.ts
+++ b/packages/forms/src/elements/address/types/EditAddressProps.ts
@@ -16,5 +16,5 @@ export interface EditAddressProps {
 	countryLabel: string;
 	changeAddressButton: string;
 	headingLevel?: number;
-	focusOnAdressLine1?:boolean;
+	focusOnAdressLine1?: boolean;
 }

--- a/packages/forms/src/elements/radio/radio.mdx
+++ b/packages/forms/src/elements/radio/radio.mdx
@@ -7,6 +7,7 @@ route: /forms/radio
 import { Playground } from '@playground';
 import { Form } from 'react-final-form';
 import { FFRadioButton } from './radio';
+import { FFInputText } from '@tpr/forms';
 import { renderFields } from '../../renderFields';
 import radioStyles from './radio.module.scss';
 import styles from '../elements.module.scss';
@@ -297,6 +298,44 @@ required = true;
 			</Form>
 		);
 	}}
+</Playground>
+
+### With Children
+
+```js
+required = true;
+```
+
+<Playground>
+	{() => {
+		const FIELD_NAME = 'required_rb';
+		return (
+			<Form
+				onSubmit={(value, form) => {
+					console.log(value);
+					setTimeout(() => {
+						form.reset();
+					}, 500);
+				}}
+			>
+				{({ handleSubmit, errors }) => (
+					<form onSubmit={handleSubmit}>
+						<FFRadioButton name={FIELD_NAME} label="Email" id="email" value="email"/>
+						<FFRadioButton name={FIELD_NAME} label="Phone" id="phone" value="phone">
+							<FFInputText name="phoneNumber" id="phoneNumber" label="Phone number"/>
+						</FFRadioButton>
+						<FFRadioButton name={FIELD_NAME} label="Text message" id="textMessage" value="textMessage"/>
+    					<button type="submit" style={{ display: 'none' }}>
+    						Submit
+    					</button>
+    					<br />
+    					<p>(Press ENTER to reset)</p>
+    				</form>
+    			)}
+    		</Form>
+    	);
+    }}
+
 </Playground>
 
 ## API

--- a/packages/forms/src/elements/radio/radio.module.scss
+++ b/packages/forms/src/elements/radio/radio.module.scss
@@ -67,6 +67,8 @@
 }
 
 .children {
-	border-left: 4px solid $colors-neutral-9;
-	padding-left: 20px;
+	border-left: 0.3rem solid $colors-neutral-9;
+	margin-left: 1.125rem;
+	margin-top: 0.625rem;
+	padding-left: 2.055rem;
 }

--- a/packages/forms/src/elements/radio/radio.module.scss
+++ b/packages/forms/src/elements/radio/radio.module.scss
@@ -1,6 +1,5 @@
 @import '@tpr/core/lib/components/typography/typography.module.scss';
 // typography.module.scss includes '@tpr/theming/lib/variables.scss'
-
 .wrapper {
 	cursor: pointer;
 	user-select: none;
@@ -65,4 +64,9 @@
 	& > div {
 		margin-right: $space-8;
 	}
+}
+
+.children {
+	border-left: 4px solid $colors-neutral-9;
+	padding-left: 20px;
 }

--- a/packages/forms/src/elements/radio/radio.tsx
+++ b/packages/forms/src/elements/radio/radio.tsx
@@ -21,6 +21,7 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
 	value,
 	hint,
 	className,
+	children,
 	required = false,
 }) => {
 	const msg = testId ? `${testId}-${checked ? 'checked' : 'unchecked'}` : null;
@@ -74,6 +75,7 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
 						{hint}
 					</P>
 				)}
+				{children && <div className={styles.children}>{children}</div>}
 			</label>
 		</StyledInputLabel>
 	);

--- a/packages/layout/src/components/cards/common/views/address/addressPage.tsx
+++ b/packages/layout/src/components/cards/common/views/address/addressPage.tsx
@@ -11,7 +11,7 @@ import {
 	Address,
 	I18nAddressLookup,
 } from '@tpr/forms';
-import { Link } from '@tpr/core/lib/components/links/links';
+import { Link } from '@tpr/core';
 export type AddressPageProps = {
 	onSubmit: (values: Address & { initialValue?: Address }) => void;
 	initialValue?: Address;

--- a/packages/theming/src/variables.scss
+++ b/packages/theming/src/variables.scss
@@ -22,6 +22,7 @@ $colors-neutral-7: #585858;
 $colors-neutral-8: #3d3d3d;
 $colors-neutral-a1: #557b97;
 $colors-neutral-a2: #54616c;
+$colors-neutral-9: #b1b4b6;
 /* colors accents */
 $colors-accents-1: #7469ba;
 $colors-accents-2: #483b8b;


### PR DESCRIPTION
#### Fixes [AB#112661](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/112661)

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable Azure Pipelines for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
 - Radio buttons can now have child components, styled according to [GDS Standards](https://design-system.service.gov.uk/components/radios/conditional-reveal/index.html)

#### Reviewers should focus on:

The styling of the child border and spacing of the radio buttons child component

#### Screenshot
![image](https://user-images.githubusercontent.com/25232112/139845073-d219c2ff-d8f4-487e-952d-8a2de9fd16d4.png)

