### PR TITLE
Checkboxes and radio buttons must have height and width 

### DIFF
--- a/packages/forms/src/elements/checkbox/checkbox.module.scss
+++ b/packages/forms/src/elements/checkbox/checkbox.module.scss
@@ -1,6 +1,8 @@
 @import '@tpr/core/lib/components/typography/typography.module.scss';
 // typography.module.scss includes '@tpr/theming/lib/variables.scss'
 
+$wcag-minimum-clickable-size: 2.75rem;
+
 .wrapper {
 	cursor: pointer;
 	user-select: none;
@@ -13,13 +15,23 @@
 		overflow: visible;
 	}
 
+	input[type='checkbox'] {
+		width: $wcag-minimum-clickable-size;
+		height: $wcag-minimum-clickable-size;
+		margin-left: -$wcag-minimum-clickable-size;
+	}
+
+	input[type='checkbox']:focus {
+		outline: none;
+	}
+
 	input[type='checkbox']:focus + .checkbox {
 		box-shadow: 0 0 0 0.25rem #ffd300;
 	}
 
 	.checkbox {
-		min-width: 2.5rem;
-		min-height: 2.5rem;
+		min-width: $wcag-minimum-clickable-size;
+		min-height: $wcag-minimum-clickable-size;
 	}
 }
 

--- a/packages/forms/src/elements/checkbox/checkbox.tsx
+++ b/packages/forms/src/elements/checkbox/checkbox.tsx
@@ -51,19 +51,21 @@ export const Checkbox: React.FC<Partial<CheckboxIconProps>> = ({
 					</ErrorMessage>
 				)}
 				<div className={styles.innerWrapper}>
-					<HiddenInput
-						id={id}
-						type="checkbox"
-						checked={checked}
-						disabled={disabled}
-						required={required}
-						onChange={onChange}
-					/>
-					{checked ? (
-						<CheckboxChecked className={styles.checkbox} />
-					) : (
-						<CheckboxBlank className={styles.checkbox} />
-					)}
+					<div>
+						<HiddenInput
+							id={id}
+							type="checkbox"
+							checked={checked}
+							disabled={disabled}
+							required={required}
+							onChange={onChange}
+						/>
+						{checked ? (
+							<CheckboxChecked className={styles.checkbox} />
+						) : (
+							<CheckboxBlank className={styles.checkbox} />
+						)}
+					</div>
 					<P cfg={{ fontWeight: 3 }} className={styles.label}>
 						{label}
 					</P>

--- a/packages/forms/src/elements/radio/radio.module.scss
+++ b/packages/forms/src/elements/radio/radio.module.scss
@@ -1,5 +1,8 @@
 @import '@tpr/core/lib/components/typography/typography.module.scss';
 // typography.module.scss includes '@tpr/theming/lib/variables.scss'
+
+$wcag-minimum-clickable-size: 2.75rem;
+
 .wrapper {
 	cursor: pointer;
 	user-select: none;
@@ -10,14 +13,24 @@
 		align-items: center;
 	}
 
+	input[type='radio'] {
+		width: $wcag-minimum-clickable-size;
+		height: $wcag-minimum-clickable-size;
+		margin-left: -$wcag-minimum-clickable-size;
+	}
+
+	input[type='radio']:focus {
+		outline: none;
+	}
+
 	input[type='radio']:focus + .radio {
 		box-shadow: 0 0 0 0.25rem #ffd300;
 	}
 
 	.radio {
 		border-radius: 50%;
-		min-width: 2.5rem;
-		min-height: 2.5rem;
+		min-width: $wcag-minimum-clickable-size;
+		min-height: $wcag-minimum-clickable-size;
 	}
 }
 

--- a/packages/forms/src/elements/radio/radio.tsx
+++ b/packages/forms/src/elements/radio/radio.tsx
@@ -50,22 +50,24 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
 				htmlFor={id}
 			>
 				<div className={styles.innerWrapper}>
-					<HiddenInput
-						type="radio"
-						id={id}
-						name={name}
-						checked={checked}
-						value={value}
-						disabled={disabled}
-						required={required}
-						onChange={onChange}
-						data-testid={testId}
-					/>
-					{checked ? (
-						<RadioButtonChecked className={styles.radio} />
-					) : (
-						<RadioButtonUnchecked className={styles.radio} />
-					)}
+					<div>
+						<HiddenInput
+							type="radio"
+							id={id}
+							name={name}
+							checked={checked}
+							value={value}
+							disabled={disabled}
+							required={required}
+							onChange={onChange}
+							data-testid={testId}
+						/>
+						{checked ? (
+							<RadioButtonChecked className={styles.radio} />
+						) : (
+							<RadioButtonUnchecked className={styles.radio} />
+						)}
+					</div>
 					<P cfg={{ fontWeight: 3 }} className={styles.label}>
 						{label}
 					</P>


### PR DESCRIPTION
Checkboxes and radio buttons must have height and width to be focused in Safari. 

Even once focused, the "hidden" checkbox/radio that receives focus needs to be the same size as the SVG for the box-shadow on the SVG to be displayed correctly.

Wrap the hidden checkbox and the SVG in a div so that they act as one flex-child of the parent element rather than two.

Fixes [AB#109275](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/109275) ... if it works in IE11, which we can't test with docz.

