### PR TITLE
AB#112542 add styles for better mobile layout of cards

### DIFF
--- a/packages/layout/src/components/cards/cards.module.scss
+++ b/packages/layout/src/components/cards/cards.module.scss
@@ -112,31 +112,45 @@
 	}
 }
 
+@media (max-width: 75rem) {
+	//tablet
+}
+
 @media (max-width: 48rem) {
 	//mobile
 	.card {
-		.cardToolbar {			
+		.cardToolbar {
 			flex-direction: column;
 			flex-wrap: wrap;
 			.section {
 				order: 1;
 				width: 100%;
-				padding-right: 0!important;
+				padding-right: 0 !important;
 
 				&.removeSection {
 					order: 0;
 					justify-content: flex-start;
-					padding-left: 0!important;
+					padding-left: 0 !important;
 					padding-bottom: 2rem;
-				
+
 					> div {
 						width: 50%;
+
 						&.divider {
-							width: .06rem;
+							width: 0.06rem;
 							height: 2rem;
 							margin: 0 0.75rem;
 						}
 					}
+
+					.removeBtnWrapper {
+						align-items: 'flex-start';
+					}
+				}
+
+				svg {
+					min-width: 1.5rem;
+					min-height: 1.5rem;
 				}
 			}
 		}
@@ -146,11 +160,32 @@
 			}
 			.section {
 				width: 100%;
-				padding: 2rem 0 0 0!important;
+				padding: 2rem 0 0 0 !important;
 			}
 		}
 	}
 }
-@media (max-width: 75rem) {
-	//tablet
+
+@media (max-width: 26rem) {
+	.card {
+		.section {
+			&.removeSection {
+				flex-wrap: wrap;
+				justify-items: 100% !important;
+
+				> div {
+					&.divider {
+						width: 100% !important;
+						height: 0.06rem !important;
+						margin: 0.3rem 0 !important;
+					}
+				}
+
+				.removeBtnWrapper {
+					display: block;
+					width: 100% !important;
+				}
+			}
+		}
+	}
 }

--- a/packages/layout/src/components/cards/common/views/remove/confirm/confirm.module.scss
+++ b/packages/layout/src/components/cards/common/views/remove/confirm/confirm.module.scss
@@ -11,4 +11,23 @@
 	.paragraph2 {
 		margin-top: $space-3;
 	}
+
+	.actionButtons {
+		.cancelButton {
+			margin: $space-3;
+		}
+	}
+}
+
+@media (max-width: 30rem) {
+	.confirm {
+		.actionButtons {
+			flex-wrap: wrap;
+
+			.cancelButton {
+				margin-top: 0 !important;
+				margin-left: 0 !important;
+			}
+		}
+	}
 }

--- a/packages/layout/src/components/cards/common/views/remove/confirm/confirm.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/confirm/confirm.tsx
@@ -39,13 +39,13 @@ const Confirm: React.FC<ConfirmProps> = ({
 		<Content type={cardType} typeName={cardTypeName} breadcrumbs={breadcrumbs}>
 			<H3 cfg={{ mt: 3, fontWeight: 2 }}>{removeTitle}</H3>
 			<Hr cfg={{ my: 4 }} />
-			<WarningBox warningLabel={warningLabel}>
+			<WarningBox warningLabel={warningLabel} wrapInMobile={true}>
 				<Flex className={styles.confirm}>
 					<P className={styles.paragraph1}>{removeMessage1}</P>
 					{removeMessage2 && (
 						<P className={styles.paragraph2}>{removeMessage2}</P>
 					)}
-					<Flex cfg={{ mt: 3 }}>
+					<Flex cfg={{ mt: 3 }} className={styles.actionButtons}>
 						<ArrowButton
 							intent="warning"
 							pointsTo="right"
@@ -54,7 +54,11 @@ const Confirm: React.FC<ConfirmProps> = ({
 							onClick={handleRemove}
 							disabled={loading}
 						/>
-						<Link cfg={{ m: 3 }} underline onClick={handleCancel}>
+						<Link
+							underline
+							onClick={handleCancel}
+							className={styles.cancelButton}
+						>
 							{cancelBtnTitle}
 						</Link>
 					</Flex>

--- a/packages/layout/src/components/cards/common/views/remove/date/date.module.scss
+++ b/packages/layout/src/components/cards/common/views/remove/date/date.module.scss
@@ -10,3 +10,13 @@
 	margin-top: $space-5;
 	@include removeMarginBottom;
 }
+
+.actionButtons {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+
+	.cancelButton {
+		margin-bottom: $space-3;
+	}
+}

--- a/packages/layout/src/components/cards/common/views/remove/date/date.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/date/date.tsx
@@ -62,16 +62,23 @@ const DateForm: React.FC<DateFormProps> = ({
 							</div>
 						</div>
 						<Footer>
-							<ArrowButton
-								appearance="secondary"
-								pointsTo="right"
-								iconSide="right"
-								title="Continue"
-								type="submit"
-							/>
-							<Link cfg={{ m: 3 }} underline onClick={() => send('CANCEL')}>
-								Cancel
-							</Link>
+							<div className={styles.actionButtons}>
+								<ArrowButton
+									appearance="secondary"
+									pointsTo="right"
+									iconSide="right"
+									title="Continue"
+									type="submit"
+									cfg={{ mr: 3 }}
+								/>
+								<Link
+									underline
+									onClick={() => send('CANCEL')}
+									className={styles.cancelButton}
+								>
+									Cancel
+								</Link>
+							</div>
 						</Footer>
 					</form>
 				)}

--- a/packages/layout/src/components/cards/common/views/remove/reason/reason.module.scss
+++ b/packages/layout/src/components/cards/common/views/remove/reason/reason.module.scss
@@ -9,3 +9,13 @@
 	margin-left: 3.4375rem;
 	margin-bottom: 1.25rem;
 }
+
+.actionButtons {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+
+	.cancelButton {
+		margin-bottom: $space-3;
+	}
+}

--- a/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
+++ b/packages/layout/src/components/cards/common/views/remove/reason/reason.tsx
@@ -87,16 +87,23 @@ export const Reason: React.FC<ReasonProps> = ({
 								</fieldset>
 							</div>
 							<Footer>
-								<ArrowButton
-									appearance="secondary"
-									pointsTo="right"
-									iconSide="right"
-									type="submit"
-									title="Continue"
-								/>
-								<Link cfg={{ m: 3 }} underline onClick={() => send('CANCEL')}>
-									Cancel
-								</Link>
+								<div className={styles.actionButtons}>
+									<ArrowButton
+										appearance="secondary"
+										pointsTo="right"
+										iconSide="right"
+										type="submit"
+										title="Continue"
+										cfg={{ mr: 3 }}
+									/>
+									<Link
+										underline
+										onClick={() => send('CANCEL')}
+										className={styles.cancelButton}
+									>
+										Cancel
+									</Link>
+								</div>
 							</Footer>
 						</form>
 					);

--- a/packages/layout/src/components/cards/components/breadcrumbs.module.scss
+++ b/packages/layout/src/components/cards/components/breadcrumbs.module.scss
@@ -1,0 +1,8 @@
+.breadcrumbsWrapper {
+	align-items: center;
+
+	svg {
+		min-width: 1.5rem;
+		min-height: 1.5rem;
+	}
+}

--- a/packages/layout/src/components/cards/components/breadcrumbs.tsx
+++ b/packages/layout/src/components/cards/components/breadcrumbs.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import { Flex, Link } from '@tpr/core';
 import { ArrowRight } from '@tpr/icons';
+import styles from './breadcrumbs.module.scss';
 
 export type BreadcrumbLink = {
 	to?: 'BACK';
@@ -14,7 +15,7 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ links, send }) => {
 	const totalLinks = links.length - 1;
 	if (links.length < 1) return null;
 	return (
-		<Flex cfg={{ alignItems: 'center' }}>
+		<Flex className={styles.breadcrumbsWrapper}>
 			{links.map((link, index) => {
 				return (
 					<Fragment key={index}>

--- a/packages/layout/src/components/cards/components/cardContentSectionHeader.module.scss
+++ b/packages/layout/src/components/cards/components/cardContentSectionHeader.module.scss
@@ -4,3 +4,9 @@
 	width: 50%;
 	padding-right: $space-4;
 }
+
+@media (max-width: 48rem) {
+	.contentHeader {
+		width: 100%;
+	}
+}

--- a/packages/layout/src/components/cards/components/cardContentSectionHeader.module.scss
+++ b/packages/layout/src/components/cards/components/cardContentSectionHeader.module.scss
@@ -8,5 +8,6 @@
 @media (max-width: 48rem) {
 	.contentHeader {
 		width: 100%;
+		padding-right: 0;
 	}
 }

--- a/packages/layout/src/components/cards/components/toolbar.tsx
+++ b/packages/layout/src/components/cards/components/toolbar.tsx
@@ -57,7 +57,7 @@ export const Toolbar: React.FC<ToolbarProps> = React.memo(
 						text={statusText}
 					/>
 					<div className={styles.divider} />
-					<Flex cfg={{ alignItems: 'flex-start' }}>{buttonRight()}</Flex>
+					<Flex className={styles.removeBtnWrapper}>{buttonRight()}</Flex>
 				</Flex>
 			</div>
 		);

--- a/packages/layout/src/components/warning/warning.module.scss
+++ b/packages/layout/src/components/warning/warning.module.scss
@@ -10,3 +10,11 @@
 		margin-top: 0.125rem;
 	}
 }
+
+@media (max-width: 25rem) {
+	.warning {
+		.innerWrapper {
+			flex-wrap: wrap;
+		}
+	}
+}

--- a/packages/layout/src/components/warning/warning.tsx
+++ b/packages/layout/src/components/warning/warning.tsx
@@ -6,11 +6,13 @@ import styles from './warning.module.scss';
 export type WarningBoxProps = {
 	cfg?: SpaceProps & FlexProps;
 	warningLabel?: string;
+	wrapInMobile?: boolean;
 };
 export const WarningBox: React.FC<WarningBoxProps> = ({
 	children,
 	cfg,
 	warningLabel = 'Warning',
+	wrapInMobile = false,
 }) => {
 	return (
 		<Flex
@@ -18,7 +20,10 @@ export const WarningBox: React.FC<WarningBoxProps> = ({
 			className={styles.warning}
 			role="alert"
 		>
-			<Flex cfg={{ flexDirection: 'row' }}>
+			<Flex
+				cfg={{ flexDirection: 'row' }}
+				className={wrapInMobile ? styles.innerWrapper : ''}
+			>
 				<WarningCircle cfg={{ mr: 4 }} alternativeText={warningLabel} />
 				{children}
 			</Flex>


### PR DESCRIPTION
#### Fixes [AB#112542](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/112542)

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable Azure Pipelines for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

With new styles

- The confirmed/unconfirmed icon does not shrink and disappears, and the 2 elements do not overlap.
![image](https://user-images.githubusercontent.com/69628308/140390756-055f7242-03c4-4513-a14b-2a1c6e772eae.png)

- The svg icon for the breadcrumbs resizes accordingly
![image](https://user-images.githubusercontent.com/69628308/140391080-d1432c02-c590-4521-81fc-39103bfe3029.png)

- The content for the warningBox can now wrap when needed.
![image](https://user-images.githubusercontent.com/69628308/140391007-98896772-14b2-4e60-8a74-22e8b6e32204.png)

