### PR TITLE
Remove use of flexbox for radios and checkboxes

### DIFF
--- a/packages/forms/src/elements/checkbox/checkbox.module.scss
+++ b/packages/forms/src/elements/checkbox/checkbox.module.scss
@@ -3,26 +3,17 @@
 
 $wcag-minimum-clickable-size: 2.75rem;
 
+.outerWrapper {
+	min-height: $wcag-minimum-clickable-size + $space-2;
+}
+
 .wrapper {
 	cursor: pointer;
 	user-select: none;
 
 	.innerWrapper {
-		display: flex;
-		flex: 0 0 auto;
-		align-items: center;
-		line-height: 1.4;
-		overflow: visible;
-	}
-
-	input[type='checkbox'] {
-		width: $wcag-minimum-clickable-size;
-		height: $wcag-minimum-clickable-size;
-		margin-left: -$wcag-minimum-clickable-size;
-	}
-
-	input[type='checkbox']:focus {
-		outline: none;
+		position: relative;
+		padding-top: 0.6rem;
 	}
 
 	input[type='checkbox']:focus + .checkbox {
@@ -30,8 +21,16 @@ $wcag-minimum-clickable-size: 2.75rem;
 	}
 
 	.checkbox {
+		position: absolute;
+		top: 0;
+		left: 0;
 		min-width: $wcag-minimum-clickable-size;
 		min-height: $wcag-minimum-clickable-size;
+	}
+
+	.label {
+		padding-left: $wcag-minimum-clickable-size + $space-3;
+		@include removeMarginBottom;
 	}
 }
 
@@ -45,13 +44,8 @@ $wcag-minimum-clickable-size: 2.75rem;
 	font-size: $font-size-2;
 	font-weight: $font-weight-2;
 	margin-top: $space-2;
-	margin-left: 3.4375rem;
+	padding-left: $wcag-minimum-clickable-size + $space-3;
 	margin-bottom: 0;
-}
-
-.label {
-	margin-left: $space-3;
-	@include removeMarginBottom;
 }
 
 .inline {

--- a/packages/forms/src/elements/checkbox/checkbox.tsx
+++ b/packages/forms/src/elements/checkbox/checkbox.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Field, FieldRenderProps } from 'react-final-form';
-import { P } from '@tpr/core';
+import { classNames, P } from '@tpr/core';
 import { FieldProps, FieldExtraProps } from '../../renderFields';
 import { CheckboxChecked, CheckboxBlank } from './icons';
 import { ErrorMessage, StyledInputLabel } from '../elements';
@@ -29,7 +29,7 @@ export const Checkbox: React.FC<Partial<CheckboxIconProps>> = ({
 	return (
 		<StyledInputLabel
 			element="div"
-			className={className}
+			className={classNames([className, styles.outerWrapper])}
 			cfg={Object.assign(
 				{
 					mt: 1,
@@ -51,21 +51,19 @@ export const Checkbox: React.FC<Partial<CheckboxIconProps>> = ({
 					</ErrorMessage>
 				)}
 				<div className={styles.innerWrapper}>
-					<div>
-						<HiddenInput
-							id={id}
-							type="checkbox"
-							checked={checked}
-							disabled={disabled}
-							required={required}
-							onChange={onChange}
-						/>
-						{checked ? (
-							<CheckboxChecked className={styles.checkbox} />
-						) : (
-							<CheckboxBlank className={styles.checkbox} />
-						)}
-					</div>
+					<HiddenInput
+						id={id}
+						type="checkbox"
+						checked={checked}
+						disabled={disabled}
+						required={required}
+						onChange={onChange}
+					/>
+					{checked ? (
+						<CheckboxChecked className={styles.checkbox} />
+					) : (
+						<CheckboxBlank className={styles.checkbox} />
+					)}
 					<P cfg={{ fontWeight: 3 }} className={styles.label}>
 						{label}
 					</P>

--- a/packages/forms/src/elements/hidden/hidden.module.scss
+++ b/packages/forms/src/elements/hidden/hidden.module.scss
@@ -1,4 +1,0 @@
-.hiddenInput {
-	width: 0;
-	height: 0;
-}

--- a/packages/forms/src/elements/hidden/hidden.tsx
+++ b/packages/forms/src/elements/hidden/hidden.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { FieldInputTypes } from '../../renderFields';
-import styles from './hidden.module.scss';
+import accessibilityStyles from '@tpr/theming/lib/accessibility.module.scss';
 
 export type HiddenInputProps = {
 	type: FieldInputTypes;
@@ -28,7 +28,7 @@ export const HiddenInput: React.FC<HiddenInputProps> = ({
 			type={type}
 			disabled={disabled}
 			required={required}
-			className={styles.hiddenInput}
+			className={accessibilityStyles.visuallyHidden}
 			{...rest}
 		/>
 	);

--- a/packages/forms/src/elements/radio/radio.module.scss
+++ b/packages/forms/src/elements/radio/radio.module.scss
@@ -3,24 +3,17 @@
 
 $wcag-minimum-clickable-size: 2.75rem;
 
+.outerWrapper {
+	min-height: $wcag-minimum-clickable-size + $space-2;
+}
+
 .wrapper {
 	cursor: pointer;
 	user-select: none;
 
 	.innerWrapper {
-		display: flex;
-		flex: 0 0 auto;
-		align-items: center;
-	}
-
-	input[type='radio'] {
-		width: $wcag-minimum-clickable-size;
-		height: $wcag-minimum-clickable-size;
-		margin-left: -$wcag-minimum-clickable-size;
-	}
-
-	input[type='radio']:focus {
-		outline: none;
+		position: relative;
+		padding-top: 0.6rem;
 	}
 
 	input[type='radio']:focus + .radio {
@@ -28,20 +21,22 @@ $wcag-minimum-clickable-size: 2.75rem;
 	}
 
 	.radio {
+		position: absolute;
+		top: 0;
+		left: 0;
 		border-radius: 50%;
 		min-width: $wcag-minimum-clickable-size;
 		min-height: $wcag-minimum-clickable-size;
 	}
-}
 
-.label {
-	color: $colors-neutral-8;
-	font-weight: $font-weight-3;
-	line-height: $line-height-3;
-	padding-left: $space-1;
-	cursor: pointer;
-	margin-left: $space-2;
-	@include removeMarginBottom;
+	.label {
+		color: $colors-neutral-8;
+		font-weight: $font-weight-3;
+		line-height: $line-height-3;
+		padding-left: $wcag-minimum-clickable-size + $space-3;
+		cursor: pointer;
+		@include removeMarginBottom;
+	}
 }
 
 .disabled {
@@ -65,7 +60,7 @@ $wcag-minimum-clickable-size: 2.75rem;
 	font-size: $font-size-2;
 	font-weight: $font-weight-2;
 	margin-top: $space-2;
-	padding-left: 3.4375rem;
+	padding-left: $wcag-minimum-clickable-size + $space-3;
 	max-width: 100%;
 	@include removeMarginBottom;
 }

--- a/packages/forms/src/elements/radio/radio.tsx
+++ b/packages/forms/src/elements/radio/radio.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Field, FieldRenderProps } from 'react-final-form';
-import { P } from '@tpr/core';
+import { classNames, P } from '@tpr/core';
 import { FieldProps, FieldExtraProps } from '../../renderFields';
 import { RadioButtonChecked, RadioButtonUnchecked } from './icons';
 import { StyledInputLabel } from '../elements';
@@ -33,7 +33,7 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
 	return (
 		<StyledInputLabel
 			element="div"
-			className={className}
+			className={classNames([className, styles.outerWrapper])}
 			cfg={Object.assign(
 				{
 					mt: 1,
@@ -50,28 +50,26 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
 				htmlFor={id}
 			>
 				<div className={styles.innerWrapper}>
-					<div>
-						<HiddenInput
-							type="radio"
-							id={id}
-							name={name}
-							checked={checked}
-							value={value}
-							disabled={disabled}
-							required={required}
-							onChange={onChange}
-							data-testid={testId}
-						/>
-						{checked ? (
-							<RadioButtonChecked className={styles.radio} />
-						) : (
-							<RadioButtonUnchecked className={styles.radio} />
-						)}
-					</div>
-					<P cfg={{ fontWeight: 3 }} className={styles.label}>
-						{label}
-					</P>
+					<HiddenInput
+						type="radio"
+						id={id}
+						name={name}
+						checked={checked}
+						value={value}
+						disabled={disabled}
+						required={required}
+						onChange={onChange}
+						data-testid={testId}
+					/>
+					{checked ? (
+						<RadioButtonChecked className={styles.radio} />
+					) : (
+						<RadioButtonUnchecked className={styles.radio} />
+					)}
 				</div>
+				<P cfg={{ fontWeight: 3 }} className={styles.label}>
+					{label}
+				</P>
 				{hint && (
 					<P id={helper && helper.hintId} className={styles.hint}>
 						{hint}


### PR DESCRIPTION
Safari has weird and inconsistent rendering errors of this focus highlight around radios and checkboxes, which is clearly triggered by flexbox. Use an alternative technique to get the layout we want. 

However, this needs to be deployed to test environments before it can be tested in IE or Safari so there are likely to be follow-up PRs with further fixes.
