### PR TITLE
Enter in a text field should submit the form, not open help text below

### DIFF
--- a/packages/layout/src/components/__tests__/helplink.spec.tsx
+++ b/packages/layout/src/components/__tests__/helplink.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { HelpLink } from '../helplink/helplink';
+import { axe } from 'jest-axe';
+import { formSetup } from '@tpr/forms';
 
 describe('HelpLink', () => {
 	test('displays title', () => {
@@ -16,5 +18,23 @@ describe('HelpLink', () => {
 		expect(renderOutput.container.textContent).toContain(
 			'This is some HelpLink content',
 		);
+	});
+	test('uses type=button', async () => {
+		const renderOutput = render(
+			<HelpLink title="HelpLink Title">This is some HelpLink content</HelpLink>,
+		);
+		const button = await renderOutput.findByText('HelpLink Title');
+		expect(button).toHaveAttribute('type', 'button');
+	});
+	test('passes accessibility checks', async () => {
+		const { container } = formSetup({
+			render: (
+				<HelpLink title="HelpLink Title">
+					This is some HelpLink content
+				</HelpLink>
+			),
+		});
+		const results = await axe(container);
+		expect(results).toHaveNoViolations();
 	});
 });

--- a/packages/layout/src/components/helplink/helplink.tsx
+++ b/packages/layout/src/components/helplink/helplink.tsx
@@ -15,7 +15,7 @@ export const HelpLink: React.FC<HelpLinkProps> = (props) => {
 	// Use a separate component for the trigger so that we can set aria-expanded, and place the inline SVG inside the button
 	const [expanded, setExpanded] = React.useState(false);
 	const Trigger = () => (
-		<button aria-expanded={expanded} data-gtm="helpLink">
+		<button aria-expanded={expanded} type="button" data-gtm="helpLink">
 			<ArrowDown />
 			{props.title}
 		</button>


### PR DESCRIPTION
Fixes [AB#114507](https://dev.azure.com/thepensionsregulator/0158f35d-cea5-4d9d-adc8-9fc3d3d98793/_workitems/edit/114507) 

- [x] Includes tests
